### PR TITLE
Add MySQL load test container and ansible-based litmus executor framework 

### DIFF
--- a/executor/ansible/README.md
+++ b/executor/ansible/README.md
@@ -1,0 +1,91 @@
+# Ansible Based CI Framework For OpenEBS
+----------------------------------------
+
+## Purpose
+
+This project aims to provide an automated deployment & test framework for OpenEBS using the popular workflow
+orchestration tool Ansible,while using python & shell scripts for auxiliary purposes. While the primary 
+purpose of this project is to ensure quick validation of commits made into OpenEBS repos and keep it free of issues,
+it can also be used to automate the on-premise deployment of OpenEBS. 
+
+In its current form, this project performs an automated setup of:
+
+- Kubernetes cluster (K8s-master, K8s-minions)
+- OpenEBS cluster (openEBS-maya server,openEBS-storage hosts)
+
+The OpenEBS installation can be performed either in __dedicated mode__, with the openebs storage services
+running directly on linux machines (same as the ones hosting kubernetes cluster OR distinct boxes) OR
+in __hyperconverged mode__, where the maya-server and openebs storage hosts are run as pods on the kubernetes
+cluster
+
+The detailed steps to perform this on-premise installation can be found here : 
+
+https://github.com/ksatchit/openebs/blob/master/e2e/ansible/openebs-on-premise-deployment-guide.md
+
+You can also validate the setup be running some simple applications on OpenEBS storage, either as Kubernetes pods 
+(mysql, percona-mysql) or as containers running directly on the test-harness machine (fio, iometer).
+
+Going ahead, this project is expected to evolve to provide additional configuration options for OpenEBS deployment 
+and include a greater number of test scenarios.
+
+## Ansible
+
+At the outset, ansible was primarily preferred in view of its agent-less architecture, batch 
+deployment capabilities, idempotent nature of task execution & YAML usage
+
+To know more about Ansible, visit : http://docs.ansible.com/ansible/index.html
+
+## Directory Layout Of The CI-CD Project
+
+A broad listing of the folders in this project is provided below. 
+
+```
+ansible
+├── files
+├── inventory
+│   └── group_vars
+|   └── host_vars
+├── playbooks
+│   └── dedicated
+│   └── hyperconverged
+├── plugins
+│   └── callback
+└── roles
+    ├── cleanup
+    ├── common
+    ├── fio
+    ├── hosts
+    ├── inventory
+    ├── iometer
+    ├── k8s-hosts
+    ├── k8s-localhost
+    ├── k8s-master
+    ├── kubernetes
+    ├── localhost
+    ├── master
+    ├── prerequisites
+    ├── vagrant
+    └── volume
+  
+```
+## Limitations
+
+Currently, the ansible playbooks are written to work with Ubuntu hosts. Going ahead, they will be enhanced to work on 
+other linux flavours
+
+### Contributions
+
+If you'd like to contribute, please fork the repository and use a feature branch. Pull requests are warmly welcome.
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/executor/ansible/ansible.cfg
+++ b/executor/ansible/ansible.cfg
@@ -1,0 +1,364 @@
+# config file for ansible -- http://ansible.com/
+# ==============================================
+
+# nearly all parameters can be overridden in ansible-playbook
+# or with command line flags. ansible will read ANSIBLE_CONFIG,
+# ansible.cfg in the current working directory, .ansible.cfg in
+# the home directory or /etc/ansible/ansible.cfg, whichever it
+# finds first
+
+[defaults]
+
+# some basic default values...
+
+inventory      = ./inventory/hosts
+callback_plugins = ./plugins/callback
+stdout_callback = openebs 
+library = ./plugins/modules
+#remote_tmp     = ~/.ansible/tmp
+#local_tmp      = ~/.ansible/tmp
+#forks          = 5
+#poll_interval  = 15
+#sudo_user      = root
+#ask_sudo_pass = True
+#ask_pass      = True
+#transport      = smart
+#remote_port    = 22
+#module_lang    = C
+#module_set_locale = False
+
+# plays will gather facts by default, which contain information about
+# the remote system.
+#
+# smart - gather by default, but don't regather if already gathered
+# implicit - gather by default, turn off with gather_facts: False
+# explicit - do not gather by default, must say gather_facts: True
+#gathering = implicit
+
+# by default retrieve all facts subsets
+# all - gather all subsets
+# network - gather min and network facts
+# hardware - gather hardware facts (longest facts to retrieve)
+# virtual - gather min and virtual facts
+# facter - import facts from facter
+# ohai - import facts from ohai
+# You can combine them using comma (ex: network,virtual)
+# You can negate them using ! (ex: !hardware,!facter,!ohai)
+# A minimal set of facts is always gathered.
+#gather_subset = all
+
+# some hardware related facts are collected
+# with a maximum timeout of 10 seconds. This
+# option lets you increase or decrease that
+# timeout to something more suitable for the
+# environment. 
+# gather_timeout = 10
+
+# additional paths to search for roles in, colon separated
+roles_path    = ./roles/
+
+# uncomment this to disable SSH key host checking
+#host_key_checking = False
+
+# change the default callback
+#stdout_callback = skippy
+# enable additional callbacks
+#callback_whitelist = timer, mail
+
+# Determine whether includes in tasks and handlers are "static" by
+# default. As of 2.0, includes are dynamic by default. Setting these
+# values to True will make includes behave more like they did in the
+# 1.x versions.
+#task_includes_static = True
+#handler_includes_static = True
+
+# Controls if a missing handler for a notification event is an error or a warning
+#error_on_missing_handler = True
+
+# change this for alternative sudo implementations
+#sudo_exe = sudo
+
+# What flags to pass to sudo
+# WARNING: leaving out the defaults might create unexpected behaviours
+#sudo_flags = -H -S -n
+
+# SSH timeout
+#timeout = 10
+
+# default user to use for playbooks if user is not specified
+# (/usr/bin/ansible will use current user as default)
+#remote_user = root
+
+# logging is off by default unless this path is defined
+# if so defined, consider logrotate
+#log_path = /var/log/ansible.log
+
+# default module name for /usr/bin/ansible
+#module_name = command
+
+# use this shell for commands executed under sudo
+# you may need to change this to bin/bash in rare instances
+# if sudo is constrained
+#executable = /bin/sh
+
+# if inventory variables overlap, does the higher precedence one win
+# or are hash values merged together?  The default is 'replace' but
+# this can also be set to 'merge'.
+#hash_behaviour = replace
+
+# by default, variables from roles will be visible in the global variable
+# scope. To prevent this, the following option can be enabled, and only
+# tasks and handlers within the role will see the variables there
+#private_role_vars = yes
+
+# list any Jinja2 extensions to enable here:
+#jinja2_extensions = jinja2.ext.do,jinja2.ext.i18n
+
+# if set, always use this private key file for authentication, same as
+# if passing --private-key to ansible or ansible-playbook
+#private_key_file = /path/to/file
+
+# If set, configures the path to the Vault password file as an alternative to
+# specifying --vault-password-file on the command line.
+#vault_password_file = /path/to/vault_password_file
+
+# format of string {{ ansible_managed }} available within Jinja2
+# templates indicates to users editing templates files will be replaced.
+# replacing {file}, {host} and {uid} and strftime codes with proper values.
+#ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
+# {file}, {host}, {uid}, and the timestamp can all interfere with idempotence
+# in some situations so the default is a static string:
+#ansible_managed = Ansible managed
+
+# by default, ansible-playbook will display "Skipping [host]" if it determines a task
+# should not be run on a host.  Set this to "False" if you don't want to see these "Skipping"
+# messages. NOTE: the task header will still be shown regardless of whether or not the
+# task is skipped.
+#display_skipped_hosts = True
+
+# by default, if a task in a playbook does not include a name: field then
+# ansible-playbook will construct a header that includes the task's action but
+# not the task's args.  This is a security feature because ansible cannot know
+# if the *module* considers an argument to be no_log at the time that the
+# header is printed.  If your environment doesn't have a problem securing
+# stdout from ansible-playbook (or you have manually specified no_log in your
+# playbook on all of the tasks where you have secret information) then you can
+# safely set this to True to get more informative messages.
+#display_args_to_stdout = False
+
+# by default (as of 1.3), Ansible will raise errors when attempting to dereference
+# Jinja2 variables that are not set in templates or action lines. Uncomment this line
+# to revert the behavior to pre-1.3.
+#error_on_undefined_vars = False
+
+# by default (as of 1.6), Ansible may display warnings based on the configuration of the
+# system running ansible itself. This may include warnings about 3rd party packages or
+# other conditions that should be resolved if possible.
+# to disable these warnings, set the following value to False:
+#system_warnings = True
+
+# by default (as of 1.4), Ansible may display deprecation warnings for language
+# features that should no longer be used and will be removed in future versions.
+# to disable these warnings, set the following value to False:
+#deprecation_warnings = True
+
+# (as of 1.8), Ansible can optionally warn when usage of the shell and
+# command module appear to be simplified by using a default Ansible module
+# instead.  These warnings can be silenced by adjusting the following
+# setting or adding warn=yes or warn=no to the end of the command line
+# parameter string.  This will for example suggest using the git module
+# instead of shelling out to the git command.
+# command_warnings = False
+
+
+# set plugin path directories here, separate with colons
+action_plugins = ./plugins/actions
+#cache_plugins      = /usr/share/ansible/plugins/cache
+#callback_plugins   = /usr/share/ansible/plugins/callback
+#connection_plugins = /usr/share/ansible/plugins/connection
+#lookup_plugins     = /usr/share/ansible/plugins/lookup
+#inventory_plugins  = /usr/share/ansible/plugins/inventory
+#vars_plugins       = /usr/share/ansible/plugins/vars
+#filter_plugins     = /usr/share/ansible/plugins/filter
+#test_plugins       = /usr/share/ansible/plugins/test
+#strategy_plugins   = /usr/share/ansible/plugins/strategy
+
+# by default callbacks are not loaded for /bin/ansible, enable this if you
+# want, for example, a notification or logging callback to also apply to
+# /bin/ansible runs
+#bin_ansible_callbacks = False
+
+
+# don't like cows?  that's unfortunate.
+# set to 1 if you don't want cowsay support or export ANSIBLE_NOCOWS=1
+#nocows = 1
+
+# set which cowsay stencil you'd like to use by default. When set to 'random',
+# a random stencil will be selected for each task. The selection will be filtered
+# against the `cow_whitelist` option below.
+#cow_selection = default
+#cow_selection = random
+
+# when using the 'random' option for cowsay, stencils will be restricted to this list.
+# it should be formatted as a comma-separated list with no spaces between names.
+# NOTE: line continuations here are for formatting purposes only, as the INI parser
+#       in python does not support them.
+#cow_whitelist=bud-frogs,bunny,cheese,daemon,default,dragon,elephant-in-snake,elephant,eyes,\
+#              hellokitty,kitty,luke-koala,meow,milk,moofasa,moose,ren,sheep,small,stegosaurus,\
+#              stimpy,supermilker,three-eyes,turkey,turtle,tux,udder,vader-koala,vader,www
+
+# don't like colors either?
+# set to 1 if you don't want colors, or export ANSIBLE_NOCOLOR=1
+#nocolor = 1
+
+# if set to a persistent type (not 'memory', for example 'redis') fact values
+# from previous runs in Ansible will be stored.  This may be useful when
+# wanting to use, for example, IP information from one group of servers
+# without having to talk to them in the same playbook run to get their
+# current IP information.
+#fact_caching = memory
+
+
+# retry files
+# When a playbook fails by default a .retry file will be created in ~/
+# You can disable this feature by setting retry_files_enabled to False
+# and you can change the location of the files by setting retry_files_save_path
+
+retry_files_enabled = False
+notification_callback = ara
+#retry_files_save_path = ~/.ansible-retry
+
+# squash actions
+# Ansible can optimise actions that call modules with list parameters
+# when looping. Instead of calling the module once per with_ item, the
+# module is called once with all items at once. Currently this only works
+# under limited circumstances, and only with parameters named 'name'.
+#squash_actions = apk,apt,dnf,homebrew,package,pacman,pkgng,yum,zypper
+
+# prevents logging of task data, off by default
+#no_log = False
+
+# prevents logging of tasks, but only on the targets, data is still logged on the master/controller
+#no_target_syslog = False
+
+# controls whether Ansible will raise an error or warning if a task has no
+# choice but to create world readable temporary files to execute a module on
+# the remote machine.  This option is False by default for security.  Users may
+# turn this on to have behaviour more like Ansible prior to 2.1.x.  See
+# https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user
+# for more secure ways to fix this than enabling this option.
+#allow_world_readable_tmpfiles = False
+
+# controls the compression level of variables sent to
+# worker processes. At the default of 0, no compression
+# is used. This value must be an integer from 0 to 9.
+#var_compression_level = 9
+
+# controls what compression method is used for new-style ansible modules when
+# they are sent to the remote system.  The compression types depend on having
+# support compiled into both the controller's python and the client's python.
+# The names should match with the python Zipfile compression types:
+# * ZIP_STORED (no compression. available everywhere)
+# * ZIP_DEFLATED (uses zlib, the default)
+# These values may be set per host via the ansible_module_compression inventory
+# variable
+#module_compression = 'ZIP_DEFLATED'
+
+# This controls the cutoff point (in bytes) on --diff for files
+# set to 0 for unlimited (RAM may suffer!).
+#max_diff_size = 1048576
+
+[privilege_escalation]
+#become=True
+#become_method=sudo
+#become_user=root
+#become_ask_pass=False
+
+[paramiko_connection]
+
+# uncomment this line to cause the paramiko connection plugin to not record new host
+# keys encountered.  Increases performance on new host additions.  Setting works independently of the
+# host key checking setting above.
+#record_host_keys=False
+
+# by default, Ansible requests a pseudo-terminal for commands executed under sudo. Uncomment this
+# line to disable this behaviour.
+#pty=False
+
+[ssh_connection]
+
+# ssh arguments to use
+# Leaving off ControlPersist will result in poor performance, so use
+# paramiko on older platforms rather than removing it, -C controls compression use
+#ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s
+
+# The path to use for the ControlPath sockets. This defaults to
+# "%(directory)s/ansible-ssh-%%h-%%p-%%r", however on some systems with
+# very long hostnames or very long path names (caused by long user names or
+# deeply nested home directories) this can exceed the character limit on
+# file socket names (108 characters for most platforms). In that case, you
+# may wish to shorten the string below.
+#
+# Example:
+# control_path = %(directory)s/%%h-%%r
+#control_path = %(directory)s/ansible-ssh-%%h-%%p-%%r
+
+# Enabling pipelining reduces the number of SSH operations required to
+# execute a module on the remote server. This can result in a significant
+# performance improvement when enabled, however when using "sudo:" you must
+# first disable 'requiretty' in /etc/sudoers
+#
+# By default, this option is disabled to preserve compatibility with
+# sudoers configurations that have requiretty (the default on many distros).
+#
+#pipelining = False
+
+# Control the mechanism for transferring files
+#   * smart = try sftp and then try scp [default]
+#   * True = use scp only
+#   * False = use sftp only
+#scp_if_ssh = smart
+
+# if False, sftp will not use batch mode to transfer files. This may cause some
+# types of file transfer failures impossible to catch however, and should
+# only be disabled if your sftp version has problems with batch mode
+#sftp_batch_mode = False
+
+[accelerate]
+#accelerate_port = 5099
+#accelerate_timeout = 30
+#accelerate_connect_timeout = 5.0
+
+# The daemon timeout is measured in minutes. This time is measured
+# from the last activity to the accelerate daemon.
+#accelerate_daemon_timeout = 30
+
+# If set to yes, accelerate_multi_key will allow multiple
+# private keys to be uploaded to it, though each user must
+# have access to the system via SSH to add a new key. The default
+# is "no".
+#accelerate_multi_key = yes
+
+[selinux]
+# file systems that require special treatment when dealing with security context
+# the default behaviour that copies the existing context or uses the user default
+# needs to be changed to use the file system dependent context.
+#special_context_filesystems=nfs,vboxsf,fuse,ramfs
+
+# Set this to yes to allow libvirt_lxc connections to work without SELinux.
+#libvirt_lxc_noseclabel = yes
+
+[colors]
+#highlight = white
+#verbose = blue
+#warn = bright purple
+#error = red
+#debug = dark gray
+#deprecate = purple
+#skip = cyan
+#unreachable = red
+#ok = green
+#changed = yellow
+#diff_add = green
+#diff_remove = red
+#diff_lines = cyan

--- a/executor/ansible/inventory/README.md
+++ b/executor/ansible/inventory/README.md
@@ -1,0 +1,58 @@
+# Ansible Inventory
+-------------------
+
+This is the ansible default directory that holds the ```hosts``` file, which contains details of the host machines on which
+ansible tasks are executed.
+
+A brief description of the files in this directory is given below :
+
+- machines.in : Input file consisting of comma separated lines used by the pre-requisites playbook to generate ansible ```hosts```
+  file
+- hosts : Default inventory file referred to in the playbooks
+- group_vars/all.yml : Contains global variables for ansible playbooks
+- host_vars/localhost.yml : Contains localhost attributes such as sudo password which are needed for privilege escalation
+
+The machines.in needs to be updated with the details of the hosts used in the openebs setup prior to execution of the ansible
+playbooks. Provided below are some instructions to consider while doing this
+
+- Specify the machine details in the following manner :
+
+    hostcode,ipaddress,env(username),env(password) where,
+
+- hostcode is an identifier for the host machine and will be the name by which ansible will identify the machine. Ensure supported
+  host codes are provided, failing which inventory generation will not proceed. Current supported codes include 'localhost, 'mayamaster',
+  'mayahost', 'kubemaster', 'kubeminion'
+
+- A dictionary of supported codes ("SupportedHostCodes") is present in the python script files/generate_inventory.py, which can be
+  updated by interested users to include additional hostcodes
+
+- The 'localhost' hostcode is a mandatory line in this file and has a default IP of 127.0.0.1
+
+- Ensure the environment variables are set in the .profile of the ansible user
+
+- Lines can be commented (such as these) by inserting '#' symbol before the host code
+
+The contents of a typical ansible inventory 'hosts' file is as shown below :
+
+```
+localhost ansible_connection=local ansible_become_pass="{{ lookup('env','LOCAL_USER_PASSWORD') }}"
+
+[openebs-mayamasters]
+mayamaster01 ansible_ssh_host=20.10.49.11
+
+[openebs-mayamasters:vars]
+ansible_ssh_user="{{ lookup('env','MACHINES_USER_NAME') }}"
+ansible_ssh_pass="{{ lookup('env','MACHINES_USER_PASSWORD') }}"
+ansible_become_pass="{{ lookup('env','MACHINES_USER_PASSWORD') }}"
+ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
+
+[openebs-mayahosts]
+mayahost01 ansible_ssh_host=20.10.49.12
+mayahost02 ansible_ssh_host=20.10.49.13
+
+[openebs-mayahosts:vars]
+ansible_ssh_user="{{ lookup('env','USER_NAME') }}"
+ansible_ssh_pass="{{ lookup('env','USER_PASSWORD') }}"
+ansible_become_pass="{{ lookup('env','USER_PASSWORD') }}"
+ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
+```

--- a/executor/ansible/inventory/group_vars/all.yml
+++ b/executor/ansible/inventory/group_vars/all.yml
@@ -1,0 +1,41 @@
+---
+#########################################
+# E2E Environment Specification         #
+#########################################
+
+platform: ubuntu
+storage_provider: openebs
+storage_class: openebs-standard
+
+#########################################
+# Kubernetes Deployment Specification   #
+#########################################
+
+#Kubernetes Version to be used for deployment
+#Accepted Entries (Valid Kubernetes Version): default:1.6.3
+#Accepted Entries (Valid Weave Version): default:1.9.4
+
+k8s_version: 1.8.2
+weave_version: 2.0.4
+
+#list of kubernetes versions released.
+#do not tamper the list unless you know
+#what you are doing...
+
+k8s_version_list:
+  - 1.8.2
+  - 1.8.7
+
+weave_version_list:
+  - 1.9.4
+  - 2.0.4 
+
+#########################################
+# Ansible Runtime Specifications        #
+#########################################
+
+#Option to enable slack notifications to specified channel
+#Accepted Entries(true, false): default:true
+
+slack_notify: true
+

--- a/executor/ansible/inventory/host_vars/localhost.yml
+++ b/executor/ansible/inventory/host_vars/localhost.yml
@@ -1,0 +1,3 @@
+---
+ansible_connection: local 
+ansible_become_pass: "{{ lookup('env','LOCAL_USER_PASSWORD') }}"

--- a/executor/ansible/inventory/machines.in
+++ b/executor/ansible/inventory/machines.in
@@ -1,0 +1,39 @@
+###############################################################################
+# This is an input file used by the OpenEBS ansible framework to
+# generate the 'hosts' file (otherwise called ansible inventory)
+# It consists of multiple comma-separated lines which specify the
+# machine details in the following manner :
+#
+# hostcode,ipaddress,env(username),env(password)
+#
+# NOTES:
+#
+# 1. Ensure supported host codes are provided, failing which
+# the inventory generation will not proceed. Current supported
+# codes include 'localhost, 'mayamaster', 'mayahost', 'kubemaster',
+# 'kubeminion'
+#
+# 2. The 'localhost' hostcode is a mandataory line in this file
+# and has a default IP of 127.0.0.1
+#
+# 3. A dictionary of supported codes ("SupportedHostCodes") is present
+# in the python script generate_inventory.py, which can be updated by
+# interested users to include additional hostcodes
+#
+# 4. Lines can be commented (such as these) by inserting '#' symbol
+# before the host code
+#
+# 5. Ensure the environment variables are set in the .profile of the
+# ansible user
+#
+################################################################################
+
+# For example:
+#master,20.10.26.11,MACHINES_USER_NAME,MACHINES_USER_PASSWORD
+#host,20.10.26.12,USER_NAME,USER_PASSWORD
+#host,20.10.26.14,USER_NAME,USER_PASSWORD
+
+localhost,127.0.0.1,LOCAL_USER_NAME,LOCAL_USER_PASSWORD
+kubemaster,20.10.49.11,MACHINES_USER_NAME,MACHINES_USER_PASSWORD
+kubeminion,20.10.49.12,USER_NAME,USER_PASSWORD
+kubeminion,20.10.49.13,USER_NAME,USER_PASSWORD

--- a/executor/ansible/litmus_playbook.yml
+++ b/executor/ansible/litmus_playbook.yml
@@ -1,0 +1,14 @@
+---
+- hosts: localhost
+  gather_facts: yes
+
+  tasks:
+
+    - name: Obtain list of Kubernetes test job specifications 
+      include: utils/GetFiles.yaml
+        dir="{{ ansible_env.HOME }}/litmus/tests"
+        expr="^run_litmus"
+    
+    - name: Run the Kubernetes test jobs on selected storage providers 
+      include: utils/RunTest.yaml 
+      with_items: "{{ hostvars['localhost']['files'] }}"

--- a/executor/ansible/plugins/actions/ara_read.py
+++ b/executor/ansible/plugins/actions/ara_read.py
@@ -1,0 +1,162 @@
+#  Copyright (c) 2017 Red Hat, Inc.
+#
+#  This file is part of ARA: Ansible Run Analysis.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from ansible.plugins.action import ActionBase
+from oslo_serialization import jsonutils
+
+try:
+    from ara import models
+    from ara.webapp import create_app
+    from flask import current_app
+    HAS_ARA = True
+except ImportError:
+    HAS_ARA = False
+
+DOCUMENTATION = """
+---
+module: ara_read
+short_description: Ansible module to read recorded persistent data with ARA.
+version_added: "2.0"
+author: "RDO Community <rdo-list@redhat.com>"
+description:
+    - Ansible module to read recorded persistent data with ARA.
+options:
+    playbook:
+        description:
+            - uuid of the playbook to read the key from
+        required: false
+        version_added: 0.13.2
+    key:
+        description:
+            - Name of the key to read from
+        required: true
+
+requirements:
+    - "python >= 2.6"
+    - "ara >= 0.10.0"
+"""
+
+EXAMPLES = """
+# Write data
+- ara_record:
+    key: "foo"
+    value: "bar"
+
+# Read data
+- ara_read:
+    key: "foo"
+  register: foo
+
+# Read data from a specific playbook
+# (Retrieve playbook uuid's with 'ara playbook list')
+- ara_read:
+    playbook: uuuu-iiii-dddd-0000
+    key: logs
+  register: logs
+
+# Use data
+- debug:
+    msg: "{{ item }}"
+  with_items:
+    - foo.key
+    - foo.value
+    - foo.type
+    - foo.playbook_id
+"""
+
+
+class ActionModule(ActionBase):
+    """ Read from recorded persistent data as key/value pairs in ARA """
+
+    TRANSFERS_FILES = False
+    VALID_ARGS = frozenset(('playbook', 'key'))
+
+    def get_key(self, playbook_id, key):
+        try:
+            data = (models.Data.query
+                    .filter_by(key=key)
+                    .filter_by(playbook_id=playbook_id)
+                    .one())
+        except models.NoResultFound:
+            return False
+
+        return data
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        if not HAS_ARA:
+            result = {
+                'failed': True,
+                'msg': 'ARA is required to run this module.'
+            }
+            return result
+
+        app = create_app()
+        if not current_app:
+            context = app.app_context()
+            context.push()
+
+        for arg in self._task.args:
+            if arg not in self.VALID_ARGS:
+                result = {
+                    'failed': True,
+                    'msg': '{0} is not a valid option.'.format(arg)
+                }
+                return result
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        playbook_id = self._task.args.get('playbook', None)
+        key = self._task.args.get('key', None)
+
+        required = ['key']
+        for parameter in required:
+            if not self._task.args.get(parameter):
+                result['failed'] = True
+                result['msg'] = '{0} parameter is required'.format(parameter)
+                return result
+
+        if playbook_id is None:
+            # Retrieve the persisted playbook_id from tmpfile
+            tmpfile = os.path.join(app.config['ARA_TMP_DIR'], 'ara.json')
+            with open(tmpfile, 'rb') as file:
+                data = jsonutils.load(file)
+            playbook_id = data['playbook']['id']
+
+        try:
+            data = self.get_key(playbook_id, key)
+            if data:
+                result['key'] = data.key
+                result['value'] = data.value
+                result['type'] = data.type
+                result['playbook_id'] = data.playbook_id
+            msg = 'Sucessfully read data for the key {0}'.format(data.key)
+            result['msg'] = msg
+        # TODO: Do a better job for handling exception
+        except Exception as e:
+            result['key'] = None
+            result['value'] = None
+            result['type'] = None
+            result['playbook_id'] = None
+            result['failed'] = True
+            msg = 'Could not read data for key {0}: {1}'.format(key, str(e))
+            result['msg'] = msg
+        return result

--- a/executor/ansible/plugins/actions/ara_record.py
+++ b/executor/ansible/plugins/actions/ara_record.py
@@ -1,0 +1,198 @@
+#  Copyright (c) 2017 Red Hat, Inc.
+#
+#  This file is part of ARA: Ansible Run Analysis.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from ansible.plugins.action import ActionBase
+from oslo_serialization import jsonutils
+
+try:
+    from ara import models
+    from ara.models import db
+    from ara.webapp import create_app
+    from flask import current_app
+    HAS_ARA = True
+except ImportError:
+    HAS_ARA = False
+
+DOCUMENTATION = """
+---
+module: ara_record
+short_description: Ansible module to record persistent data with ARA.
+version_added: "2.0"
+author: "RDO Community <rdo-list@redhat.com>"
+description:
+    - Ansible module to record persistent data with ARA.
+options:
+    playbook:
+        description:
+            - uuid of the playbook to write the key to
+        required: false
+        version_added: 0.13.2
+    key:
+        description:
+            - Name of the key to write data to
+        required: true
+    value:
+        description:
+            - Value of the key written to
+        required: true
+    type:
+        description:
+            - Type of the key
+        choices: [text, url, json, list, dict]
+        default: text
+
+requirements:
+    - "python >= 2.6"
+    - "ara >= 0.10.0"
+"""
+
+EXAMPLES = """
+# Write static data
+- ara_record:
+    key: "foo"
+    value: "bar"
+
+# Write data to a specific (previously run) playbook
+# (Retrieve playbook uuid's with 'ara playbook list')
+- ara_record:
+    playbook: uuuu-iiii-dddd-0000
+    key: logs
+    value: "{{ lookup('file', '/var/log/ansible.log') }}"
+    type: text
+
+# Write dynamic data
+- shell: cd dev && git rev-parse HEAD
+  register: git_version
+  delegate_to: localhost
+
+# Registering the result of an ara_record task is equivalent to doing an
+# ara_read on the key
+- ara_record:
+    key: "git_version"
+    value: "{{ git_version.stdout }}"
+  register: version
+
+- name: Print recorded data
+  debug:
+    msg: "{{ version.playbook_id}} - {{ version.key }}: {{ version.value }}
+
+# Write data with a type (otherwise defaults to "text")
+# This changes the behavior on how the value is presented in the web interface
+- ara_record:
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
+    type: "{{ item.type }}"
+  with_items:
+    - { key: "log", value: "error", type: "text" }
+    - { key: "website", value: "http://domain.tld", type: "url" }
+    - { key: "data", value: "{ 'key': 'value' }", type: "json" }
+    - { key: "somelist", value: ['one', 'two'], type: "list" }
+    - { key: "somedict", value: {'key': 'value' }, type: "dict" }
+"""
+
+
+class ActionModule(ActionBase):
+    """ Record persistent data as key/value pairs in ARA """
+
+    TRANSFERS_FILES = False
+    VALID_ARGS = frozenset(('playbook', 'key', 'value', 'type'))
+    VALID_TYPES = ['text', 'url', 'json', 'list', 'dict']
+
+    def create_or_update_key(self, playbook_id, key, value, type):
+        try:
+            data = (models.Data.query
+                    .filter_by(key=key)
+                    .filter_by(playbook_id=playbook_id)
+                    .one())
+            data.value = value
+            data.type = type
+        except models.NoResultFound:
+            data = models.Data(playbook_id=playbook_id,
+                               key=key,
+                               value=value,
+                               type=type)
+        db.session.add(data)
+        db.session.commit()
+
+        return data
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        if not HAS_ARA:
+            result = {
+                'failed': True,
+                'msg': 'ARA is required to run this module.'
+            }
+            return result
+
+        app = create_app()
+        if not current_app:
+            context = app.app_context()
+            context.push()
+
+        for arg in self._task.args:
+            if arg not in self.VALID_ARGS:
+                result = {
+                    "failed": True,
+                    "msg": '{0} is not a valid option.'.format(arg)
+                }
+                return result
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        playbook_id = self._task.args.get('playbook', None)
+        key = self._task.args.get('key', None)
+        value = self._task.args.get('value', None)
+        type = self._task.args.get('type', 'text')
+
+        required = ['key', 'value']
+        for parameter in required:
+            if not self._task.args.get(parameter):
+                result['failed'] = True
+                result['msg'] = "Parameter '{0}' is required".format(parameter)
+                return result
+
+        if type not in self.VALID_TYPES:
+            result['failed'] = True
+            msg = "Type '{0}' is not supported, choose one of: {1}".format(
+                type, ", ".join(self.VALID_TYPES)
+            )
+            result['msg'] = msg
+            return result
+
+        if playbook_id is None:
+            # Retrieve the persisted playbook_id from tmpfile
+            tmpfile = os.path.join(app.config['ARA_TMP_DIR'], 'ara.json')
+            with open(tmpfile, 'rb') as file:
+                data = jsonutils.load(file)
+            playbook_id = data['playbook']['id']
+
+        try:
+            self.create_or_update_key(playbook_id, key, value, type)
+            result['key'] = key
+            result['value'] = value
+            result['type'] = type
+            result['playbook_id'] = playbook_id
+            result['msg'] = 'Data recorded in ARA for this playbook.'
+        except Exception as e:
+            result['failed'] = True
+            result['msg'] = 'Data not recorded in ARA: {0}'.format(str(e))
+        return result

--- a/executor/ansible/plugins/callback/README.md
+++ b/executor/ansible/plugins/callback/README.md
@@ -1,0 +1,6 @@
+# Ansible Plugins
+-----------------
+
+Contains custom plugins that can be integrated into Ansible. Currently holds the callback plugin which has been modified 
+to hide/suppress certain messages during failed retries in a loop-execution. 
+

--- a/executor/ansible/plugins/callback/log_ara.py
+++ b/executor/ansible/plugins/callback/log_ara.py
@@ -1,0 +1,372 @@
+#  Copyright (c) 2017 Red Hat, Inc.
+#
+#  This file is part of ARA: Ansible Run Analysis.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+
+import flask
+import itertools
+import logging
+import os
+
+from ansible import __version__ as ansible_version
+from ansible.plugins.callback import CallbackBase
+from ara import models
+from ara.models import db
+from ara.webapp import create_app
+from datetime import datetime
+from distutils.version import LooseVersion
+from oslo_serialization import jsonutils
+
+# To retrieve Ansible CLI options
+try:
+    from __main__ import cli
+except ImportError:
+    cli = None
+
+LOG = logging.getLogger('ara.callback')
+app = create_app()
+
+
+class IncludeResult(object):
+    """
+    This is used by the v2_playbook_on_include callback to synthesize a task
+    result for calling log_task.
+    """
+    def __init__(self, host, path):
+        self._host = host
+        self._result = {'included_file': path}
+
+
+class CallbackModule(CallbackBase):
+    """
+    Saves data from an Ansible run into a database
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'notification'
+    CALLBACK_NAME = 'ara'
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+
+        if not flask.current_app:
+            ctx = app.app_context()
+            ctx.push()
+
+        self.taskresult = None
+        self.task = None
+        self.play = None
+        self.playbook = None
+        self.stats = None
+        self.loop_items = []
+
+        self.play_counter = itertools.count()
+        self.task_counter = itertools.count()
+
+        if cli:
+            self._options = cli.options
+        else:
+            self._options = None
+
+    def get_or_create_host(self, hostname):
+        try:
+            host = (models.Host.query
+                    .filter_by(name=hostname)
+                    .filter_by(playbook_id=self.playbook.id)
+                    .one())
+        except models.NoResultFound:
+            host = models.Host(name=hostname, playbook=self.playbook)
+            db.session.add(host)
+            db.session.commit()
+
+        return host
+
+    def get_or_create_file(self, path):
+        try:
+            if self.playbook.id:
+                file_ = (models.File.query
+                         .filter_by(path=path)
+                         .filter_by(playbook_id=self.playbook.id)
+                         .one())
+                return file_
+        except models.NoResultFound:
+            pass
+
+        file_ = models.File(path=path, playbook=self.playbook)
+        db.session.add(file_)
+        db.session.commit()
+
+        try:
+            with open(path, 'r') as fd:
+                data = fd.read()
+            sha1 = models.content_sha1(data)
+            content = models.FileContent.query.get(sha1)
+
+            if content is None:
+                content = models.FileContent(content=data)
+
+            file_.content = content
+        except IOError:
+            LOG.warn('failed to open %s for reading', path)
+
+        return file_
+
+    def log_task(self, result, status, **kwargs):
+        """
+        'log_task' is called when an individual task instance on a single
+        host completes. It is responsible for logging a single
+        'TaskResult' record to the database.
+        """
+        LOG.debug('logging task result for task %s (%s), host %s',
+                  self.task.name, self.task.id, result._host.get_name())
+
+        # An include_role task might end up putting an IncludeRole object
+        # inside the result object which we don't need
+        # https://github.com/ansible/ansible/issues/30385
+        if 'include_role' in result._result:
+            del result._result['include_role']
+
+        result.task_start = self.task.time_start
+        result.task_end = datetime.now()
+        host = self.get_or_create_host(result._host.get_name())
+
+        # Use Ansible's CallbackBase._dump_results in order to strip internal
+        # keys, respect no_log directive, etc.
+        if self.loop_items:
+            # NOTE (dmsimard): There is a known issue in which Ansible can send
+            # callback hooks out of order and "exit" the task before all items
+            # have returned, this can cause one of the items to be missing
+            # from the task result in ARA.
+            # https://github.com/ansible/ansible/issues/24207
+            results = [self._dump_results(result._result)]
+            for item in self.loop_items:
+                results.append(self._dump_results(item._result))
+            results = jsonutils.loads(jsonutils.dumps(results))
+        else:
+            results = jsonutils.loads(self._dump_results(result._result))
+
+        # Ignore errors can be "yes" instead of a proper boolean in <2.3
+        # for some reason
+        ignore_errors = kwargs.get('ignore_errors', False)
+        if LooseVersion(ansible_version) < LooseVersion('2.3.0'):
+            if not isinstance(ignore_errors, bool):
+                ignore_errors = True if ignore_errors == "yes" else False
+
+        self.taskresult = models.TaskResult(
+            task=self.task,
+            host=host,
+            time_start=result.task_start,
+            time_end=result.task_end,
+            result=jsonutils.dumps(results),
+            status=status,
+            changed=result._result.get('changed', False),
+            failed=result._result.get('failed', False),
+            skipped=result._result.get('skipped', False),
+            unreachable=result._result.get('unreachable', False),
+            ignore_errors=ignore_errors,
+        )
+
+        db.session.add(self.taskresult)
+        db.session.commit()
+
+        if self.task.action == 'setup' and 'ansible_facts' in result._result:
+            values = jsonutils.dumps(result._result['ansible_facts'])
+            facts = models.HostFacts(values=values)
+            host.facts = facts
+
+            db.session.add(facts)
+            db.session.commit()
+
+    def log_stats(self, stats):
+        """
+        Logs playbook statistics to the database.
+        """
+        LOG.debug('logging stats')
+        hosts = sorted(stats.processed.keys())
+        for hostname in hosts:
+            host = self.get_or_create_host(hostname)
+            host_stats = stats.summarize(hostname)
+            db.session.add(models.Stats(
+                playbook=self.playbook,
+                host=host,
+                changed=host_stats['changed'],
+                unreachable=host_stats['unreachable'],
+                failed=host_stats['failures'],
+                ok=host_stats['ok'],
+                skipped=host_stats['skipped']
+            ))
+            db.session.commit()
+
+    def close_task(self):
+        """
+        Marks the completion time of the currently active task.
+        """
+        if self.task is not None:
+            LOG.debug('closing task %s (%s)',
+                      self.task.name,
+                      self.task.id)
+            self.task.stop()
+            db.session.add(self.task)
+            db.session.commit()
+
+            self.task = None
+            self.loop_items = []
+
+    def close_play(self):
+        """
+        Marks the completion time of the currently active play.
+        """
+        if self.play is not None:
+            LOG.debug('closing play %s (%s)', self.play.name, self.play.id)
+            self.play.stop()
+            db.session.add(self.play)
+            db.session.commit()
+
+            self.play = None
+
+    def close_playbook(self):
+        """
+        Marks the completion time of the currently active playbook.
+        """
+        if self.playbook is not None:
+            LOG.debug('closing playbook %s', self.playbook.path)
+            self.playbook.stop()
+            self.playbook.complete = True
+            db.session.add(self.playbook)
+            db.session.commit()
+
+    def v2_runner_item_on_ok(self, result):
+        self.loop_items.append(result)
+
+    def v2_runner_item_on_failed(self, result):
+        self.loop_items.append(result)
+
+    def v2_runner_item_on_skipped(self, result):
+        self.loop_items.append(result)
+
+    def v2_runner_retry(self, result):
+        self.loop_items.append(result)
+
+    def v2_runner_on_ok(self, result, **kwargs):
+        self.log_task(result, 'ok', **kwargs)
+
+    def v2_runner_on_unreachable(self, result, **kwargs):
+        self.log_task(result, 'unreachable', **kwargs)
+
+    def v2_runner_on_failed(self, result, **kwargs):
+        self.log_task(result, 'failed', **kwargs)
+
+    def v2_runner_on_skipped(self, result, **kwargs):
+        self.log_task(result, 'skipped', **kwargs)
+
+    def v2_playbook_on_task_start(self, task, is_conditional,
+                                  is_handler=False):
+        self.close_task()
+
+        LOG.debug('starting task %s (action %s)',
+                  task.name, task.action)
+        pathspec = task.get_path()
+        if pathspec:
+            path, lineno = pathspec.split(':', 1)
+            lineno = int(lineno)
+            file_ = self.get_or_create_file(path)
+        else:
+            path = self.playbook.path
+            lineno = 1
+            file_ = self.get_or_create_file(self.playbook.path)
+
+        self.task = models.Task(
+            name=task.get_name(),
+            sortkey=next(self.task_counter),
+            action=task.action,
+            play=self.play,
+            playbook=self.playbook,
+            tags=jsonutils.dumps(task._attributes['tags']),
+            file=file_,
+            lineno=lineno,
+            is_handler=is_handler)
+
+        self.task.start()
+        db.session.add(self.task)
+        db.session.commit()
+
+    def v2_playbook_on_handler_task_start(self, task):
+        self.v2_playbook_on_task_start(task, False, is_handler=True)
+
+    def v2_playbook_on_start(self, playbook):
+        path = os.path.abspath(playbook._file_name)
+        if self._options is not None:
+            options = self._options.__dict__.copy()
+        else:
+            options = {}
+
+        # Potentially sanitize some user-specified keys
+        for parameter in app.config['ARA_IGNORE_PARAMETERS']:
+            if parameter in options:
+                msg = "Parameter not saved by ARA due to configuration"
+                options[parameter] = msg
+
+        LOG.debug('starting playbook %s', path)
+        self.playbook = models.Playbook(
+            ansible_version=ansible_version,
+            path=path,
+            options=options
+        )
+
+        self.playbook.start()
+        db.session.add(self.playbook)
+        db.session.commit()
+
+        file_ = self.get_or_create_file(path)
+        file_.is_playbook = True
+
+        # We need to persist the playbook id so it can be used by the modules
+        data = {
+            'playbook': {
+                'id': self.playbook.id
+            }
+        }
+        tmpfile = os.path.join(app.config['ARA_TMP_DIR'], 'ara.json')
+        with open(tmpfile, 'w') as file:
+            file.write(jsonutils.dumps(data))
+
+    def v2_playbook_on_play_start(self, play):
+        self.close_task()
+        self.close_play()
+
+        LOG.debug('starting play %s', play.name)
+        if self.play is not None:
+            self.play.stop()
+
+        self.play = models.Play(
+            name=play.name,
+            sortkey=next(self.play_counter),
+            playbook=self.playbook
+        )
+
+        self.play.start()
+        db.session.add(self.play)
+        db.session.commit()
+
+    def v2_playbook_on_stats(self, stats):
+        self.log_stats(stats)
+
+        self.close_task()
+        self.close_play()
+        self.close_playbook()
+
+        LOG.debug('closing database')
+        db.session.close()

--- a/executor/ansible/plugins/callback/openebs.py
+++ b/executor/ansible/plugins/callback/openebs.py
@@ -1,0 +1,63 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+from ansible.plugins.callback.default import (
+    CallbackModule as CallbackModule_default
+)
+from ansible import constants as C
+
+"""Implementation of Custom Class that inherits the 'default' stdout_callback
+plugin and overrides the v2_runner_retry api for displaying the 'FAILED -
+RETRYING' only during verbose mode."""
+
+
+class CallbackModule(CallbackModule_default):
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'openebs'
+    CALLBACK_NEEDS_WHITELIST = False
+
+    def v2_runner_retry(self, result):
+        task_name = result.task_name or result._task
+        final_result = result._result['retries'] - result._result['attempts']
+        msg = "FAILED - RETRYING: %s (%d retries left)." % (task_name,
+                                                            final_result)
+        display_verbosity = self._display.verbosity
+        required_result = '_ansible_verbose_always'
+        if (display_verbosity > 2 or required_result in result._result):
+            if required_result not in result._result:
+                msg += "Result was: %s" % self._dump_results(result._result)
+        self._display.v('%s' % (msg))
+
+    def v2_runner_on_skipped(self, result):
+        my_result = result._result
+        required_result = '_ansible_verbose_always'
+
+        if C.DISPLAY_SKIPPED_HOSTS:
+            if (self._display.verbosity > 0 or required_result in my_result):
+                if required_result not in my_result:
+                    dumped_results = self._dump_results(my_result)
+                    msg = "skipping: [%s] => %s" % (result._host.get_name(),
+                                                    dumped_results)
+                    self._display.display(msg, color=C.COLOR_SKIP)
+
+            else:
+                self._display.display("skipping task..", color=C.COLOR_SKIP)
+
+    def v2_runner_item_on_skipped(self, result):
+        my_result = result._result
+        required_result = '_ansible_verbose_always'
+
+        if C.DISPLAY_SKIPPED_HOSTS:
+            if (self._display.verbosity > 0 or required_result in my_result):
+                if required_result not in my_result:
+                    required_item = self._get_item(my_result)
+                    dumped_result = self._dump_results(my_result)
+                    result_host = result._host.get_name()
+                    msg = "skipping: [%s] => (item=%s) => %s" % (result_host,
+                                                                 required_item,
+                                                                 dumped_result)
+                self._display.display(msg, color=C.COLOR_SKIP)

--- a/executor/ansible/plugins/modules/ara_read.py
+++ b/executor/ansible/plugins/modules/ara_read.py
@@ -1,0 +1,74 @@
+#  Copyright (c) 2017 Red Hat, Inc.
+#
+#  This file is part of ARA: Ansible Run Analysis.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file is purposefully left empty due to an Ansible issue
+# Details at: https://github.com/ansible/ansible/pull/18208
+
+# TODO: Remove this file and update the documentation when the issue is fixed,
+# released and present in all supported versions.
+
+DOCUMENTATION = """
+---
+module: ara_read
+short_description: Ansible module to read recorded persistent data with ARA.
+version_added: "2.0"
+author: "RDO Community <rdo-list@redhat.com>"
+description:
+    - Ansible module to read recorded persistent data with ARA.
+options:
+    playbook:
+        description:
+            - uuid of the playbook to read the key from
+        required: false
+        version_added: 0.13.2
+    key:
+        description:
+            - Name of the key to read from
+        required: true
+
+requirements:
+    - "python >= 2.6"
+    - "ara >= 0.10.0"
+"""
+
+EXAMPLES = """
+# Write data
+- ara_record:
+    key: "foo"
+    value: "bar"
+
+# Read data
+- ara_read:
+    key: "foo"
+  register: foo
+
+# Read data from a specific playbook
+# (Retrieve playbook uuid's with 'ara playbook list')
+- ara_read:
+    playbook: uuuu-iiii-dddd-0000
+    key: logs
+  register: logs
+
+# Use data
+- debug:
+    msg: "{{ item }}"
+  with_items:
+    - foo.key
+    - foo.value
+    - foo.type
+    - foo.playbook_id
+"""

--- a/executor/ansible/plugins/modules/ara_record.py
+++ b/executor/ansible/plugins/modules/ara_record.py
@@ -1,0 +1,92 @@
+#  Copyright (c) 2017 Red Hat, Inc.
+#
+#  This file is part of ARA: Ansible Run Analysis.
+#
+#  ARA is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  ARA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with ARA.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file is purposefully left empty due to an Ansible issue
+# Details at: https://github.com/ansible/ansible/pull/18208
+
+# TODO: Remove this file and update the documentation when the issue is fixed,
+# released and present in all supported versions.
+
+DOCUMENTATION = """
+---
+module: ara_record
+short_description: Ansible module to record persistent data with ARA.
+version_added: "2.0"
+author: "RDO Community <rdo-list@redhat.com>"
+description:
+    - Ansible module to record persistent data with ARA.
+options:
+    playbook:
+        description:
+            - uuid of the playbook to write the key to
+        required: false
+        version_added: 0.13.2
+    key:
+        description:
+            - Name of the key to write data to
+        required: true
+    value:
+        description:
+            - Value of the key written to
+        required: true
+    type:
+        description:
+            - Type of the key
+        choices: [text, url, json, list, dict]
+        default: text
+
+requirements:
+    - "python >= 2.6"
+    - "ara >= 0.10.0"
+"""
+
+EXAMPLES = """
+# Write static data
+- ara_record:
+    key: "foo"
+    value: "bar"
+
+# Write data to a specific (previously run) playbook
+# (Retrieve playbook uuid's with 'ara playbook list')
+- ara_record:
+    playbook: uuuu-iiii-dddd-0000
+    key: logs
+    value: "{{ lookup('file', '/var/log/ansible.log') }}"
+    type: text
+
+# Write dynamic data
+- shell: cd dev && git rev-parse HEAD
+  register: git_version
+  delegate_to: localhost
+
+- ara_record:
+    key: "git_version"
+    value: "{{ git_version.stdout }}"
+
+# Write data with a type (otherwise defaults to "text")
+# This changes the behavior on how the value is presented in the web interface
+- ara_record:
+    key: "{{ item.key }}"
+    value: "{{ item.value }}"
+    type: "{{ item.type }}"
+  with_items:
+    - { key: "log", value: "error", type: "text" }
+    - { key: "website", value: "http://domain.tld", type: "url" }
+    - { key: "data", value: "{ 'key': 'value' }", type: "json" }
+    - { key: "somelist", value: ['one', 'two'], type: "list" }
+    - { key: "somedict", value: {'key': 'value' }, type: "dict" }
+"""

--- a/executor/ansible/provider/openebs/setup-openebs.yml
+++ b/executor/ansible/provider/openebs/setup-openebs.yml
@@ -1,0 +1,5 @@
+---
+- hosts: kubernetes-kubemasters 
+  roles: 
+    - {role: k8s-openebs-operator}
+

--- a/executor/ansible/roles/README.md
+++ b/executor/ansible/roles/README.md
@@ -1,0 +1,42 @@
+# Ansible Roles 
+---------------
+
+Ansible "roles" are reusable abstractions which can be created based on an overall function performed by a set of
+tasks, and can be included into playbooks. Each role has a default structure with ```vars```, ```defaults``` ,```tasks```,
+```meta``` and ```handler``` folders, with each containing a ```main.yml``` file. 
+
+- The vars & defaults folders consist of variables used by the tasks in the role. 
+- The meta folder contains role dependencies, i.e., tasks to be run before running current role tasks
+- The handler takes care of service handling and is invoked by the ```notify``` keyword inside tasks
+
+A brief outline of the functions associated with above components is described below :
+
+- prerequisites : Installs python packages necessary for inventory generation
+
+- inventory : Generates the hosts file based on entries in machines.in. The also role provides an option to
+              setup passwordless SSH between the ansible host (localhost)  and the target hosts. In case the 
+              same is setup, the hosts file will not contain hostvars for the ansible_ssh_password
+
+- common : Installs apt packages common to Maya Server & Storage Node cluster
+
+- master : Installs & configures maya server
+
+- hosts : Installs & configures openebs storage hosts
+
+- vagrant : Makes some config changes in maya server & node setup if machines are vagrant VMs
+
+- volume : Creates a volume according to input parameters in all.yml
+
+- localhost : Configures the client machine to run FIO container
+
+- fio : Runs FIO profile in a test container after mounting block storage
+
+- cleanup : Tear down iSCSI sessions & destroys volume on the storage nodes
+
+- k8s-localhost: Prepares the test-harness for execution of kubernetes roles
+
+- k8s-master: Installs and configures the kubernetes-master
+
+- k8s-host: Installs and configures the kubernetes-minions. Also installs the openebs flexvol driver
+
+

--- a/executor/ansible/roles/ara/defaults/main.yml
+++ b/executor/ansible/roles/ara/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+#####################################
+#    ARA COMMON PRE-REQUISITES      #
+#####################################
+
+ara_apt_packages: 
+  - gcc 
+  - python-dev
+  - libffi-dev
+  - libssl-dev
+  - python-pip
+  - libxml2-dev
+  - libxslt1-dev
+  - python-setuptools 
+
+ara_pip_packages:
+  - tox
+  - ara 
+
+ara_webserver_port: 9191
+
+ara_webserver: embedded
+

--- a/executor/ansible/roles/ara/handlers/main.yml
+++ b/executor/ansible/roles/ara/handlers/main.yml
@@ -1,0 +1,3 @@
+- name: Reload systemctl
+  command: systemctl daemon-reload
+  become: true 

--- a/executor/ansible/roles/ara/tasks/main.yml
+++ b/executor/ansible/roles/ara/tasks/main.yml
@@ -1,0 +1,102 @@
+---
+- name: Install ara apt packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ ara_apt_packages }}"
+  become: true 
+  delegate_to: 127.0.0.1
+
+- name: Install ara pip packages
+  pip:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ ara_pip_packages }}"
+  become: true 
+  delegate_to: 127.0.0.1
+
+- name: Get ara location
+  command: python -c "import os,ara; print(os.path.dirname(ara.__file__))"
+  register: ara_location  
+
+- name: Create plugins folder in playbook directory if it doesn't exist
+  file:
+    path: "{{ playbook_dir }}/plugins/callback"
+    recurse: yes
+    state: directory
+
+- name: Copy ara callback plugin to openebs custom plugins location
+  copy: 
+    src: "{{ ara_location.stdout }}/plugins/callbacks/log_ara.py"  
+    dest: "{{ playbook_dir }}/plugins/callback" 
+
+- name: Copy ara action plugins to openebs custom plugins location
+  copy:
+    src: "{{ ara_location.stdout }}/plugins/actions"
+    dest: "{{ playbook_dir }}/plugins"
+
+- name: Copy ara modules to openebs custom plugins location
+  copy:
+    src: "{{ ara_location.stdout }}/plugins/modules"
+    dest: "{{ playbook_dir }}/plugins"
+
+- name: Update ansible.cfg with ara module library path
+  ini_file:
+    path: "{{ playbook_dir }}/ansible.cfg"
+    section: defaults
+    option: library
+    value: "./plugins/modules"
+    backup: yes
+
+- name: Update ansible.cfg with callback plugin path
+  ini_file:
+    path: "{{ playbook_dir }}/ansible.cfg"
+    section: defaults
+    option: callback_plugins
+    value: "./plugins/callback"
+
+- name: Update ansible.cfg with ara action plugins path
+  ini_file:
+    path: "{{ playbook_dir }}/ansible.cfg"
+    section: defaults
+    option: action_plugins
+    value: "./plugins/actions"
+
+- name: Update ansible.cfg with ara notification callback
+  ini_file:
+    path: "{{ playbook_dir }}/ansible.cfg"
+    section: defaults
+    option: notification_callback 
+    value: "ara"
+
+- block:
+    - name: Get ara-manage binary location
+      command: which ara-manage
+      register: ara_manage_binary
+
+    - name: Copy systemd service template
+      template:
+        src: templates/ara-service.conf.j2
+        dest: /etc/systemd/system/ara.service
+        owner: root
+        group: root
+        mode: 0644
+      become: true 
+      notify: 
+        - Reload systemctl
+
+    - name: Flush handlers
+      meta: flush_handlers
+
+    - name: Start and enable the embedded server service
+      service:
+        name: ara
+        state: started
+        enabled: yes
+      become: true 
+  when: ara_webserver == "embedded"
+
+- name: Display ara UI URL  
+  debug: 
+    msg: "Access playbook records at http://{{ ansible_default_ipv4.address }}:{{ ara_webserver_port }}"
+

--- a/executor/ansible/roles/ara/templates/ara-service.conf.j2
+++ b/executor/ansible/roles/ara/templates/ara-service.conf.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=ARA
+After=network.target
+
+[Service]
+Type=simple
+TimeoutStartSec=0
+Restart=on-failure
+RestartSec=10
+RemainAfterExit=yes
+ExecStart={{ ara_manage_binary.stdout }} runserver -h {{ ansible_default_ipv4.address }} -p {{ ara_webserver_port }}
+
+[Install]
+WantedBy=multi-user.target

--- a/executor/ansible/roles/inventory/defaults/main.yml
+++ b/executor/ansible/roles/inventory/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+inventory_input_path: "{{hostvars['localhost'].playbook_dir}}/inventory"

--- a/executor/ansible/roles/inventory/files/generate_inventory.py
+++ b/executor/ansible/roles/inventory/files/generate_inventory.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+
+#####################################################################
+# This is a script used by the OpenEBS Ansible based CI to generate
+# the inventory ('hosts') file which holds host groups and their
+# respective variables. The script takes an input file 'machines.in',
+# which contains host info as  mandatory argument while optionally
+# taking arguments to set log-level and establish passwordless SSH
+# between ansible test harness and target hosts.
+#
+# Upon successful execution, the script outputs an ansible 'hosts'
+# file inside an inventory location, along with a status log which
+# holds execution details.
+#
+# The script can be used in a standalone manner apart from its use
+# in the 'pre-requisites' ansible role
+#
+# Usage Examples:
+#
+# python generate_inventory.py <path>/machines.in
+#
+# python generate_inventory.py <path>/machines.in --loglevel=Debug
+#
+# python generate_inventory.py <path>/machines.in --loglevel=Info \
+#       --passwordless=True
+#
+######################################################################
+
+import os
+import sys
+from utils import executeCmd
+from passwordless import setupSSH
+import logging
+import argparse
+import configparser
+import warnings
+from validator import Validator
+from inventory import Inventory
+from utils import replace
+
+
+def main():
+
+    """Suppress warnings from deprecated functions (configparser compatibility
+    for python 3)"""
+    warnings.simplefilter("ignore", category=DeprecationWarning)
+    warnings.filterwarnings("ignore")
+
+    """Specify, parse & assign positional (compulsory) & optional arguments for
+    the script"""
+    arg_parser_description = 'Take the hostfile, logging level and SSH details'
+    parser = argparse.ArgumentParser(description=arg_parser_description)
+
+    parser_help_text = "Provide a hostfile in ip,username,password format"
+    parser.add_argument("hostfile", help=parser_help_text)
+
+    parser.add_argument("--loglevel", help="Provide a log level. Supported values: (Info,Debug);\
+            Default is Info")
+
+    parser.add_argument("--passwordless", help="Setup passwordless SSH with hosts.\
+             Supported values: (True,False); Default is False")
+
+    args = parser.parse_args()
+
+    Hosts = args.hostfile
+
+    # Specify SSH details
+    key_rsa_path = '~/.ssh/id_rsa.pub'
+    key_append_path = '~/.ssh/authorized_keys'
+    key_gen_cmd = 'echo -e  "y\n"|ssh-keygen -q -t rsa -N "" -f ~/.ssh/id_rsa'
+
+    # Create the configparser object
+    config = configparser.ConfigParser()
+
+    # Specify path for inventory
+    current_path = os.path.dirname(os.path.realpath(sys.argv[0]))
+
+    if "ansible/roles/inventory/files" in current_path:
+        parent_dirname = os.path.dirname(os.path.dirname(current_path))
+        ansible_path = os.path.dirname(parent_dirname)
+        ansible_cfg_path = ansible_path + 'ansible.cfg'
+        default_inventory_path = ansible_path + '/inventory/'
+        try:
+            config.read_file(open(ansible_cfg_path))
+            inventory_path = ansible_path + config.get('defaults', 'inventory')
+        except IOError:
+            if os.path.isdir(default_inventory_path) is not True:
+                os.makedirs(default_inventory_path)
+            inventory_path = default_inventory_path + 'hosts'
+    else:
+        os.makedirs('inventory')
+        default_inventory_path = current_path + '/inventory/'
+        inventory_path = default_inventory_path + 'hosts'
+
+    # Define logging levels for script execution
+    logfile = '%s/host-status.log' % (default_inventory_path)
+
+    if args.loglevel and args.loglevel.upper() == "DEBUG":
+        logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
+                            filename=logfile, filemode='a', level=10)
+    else:
+        logging.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
+                            filename=logfile, filemode='a', level=20)
+
+    # Initiate log file
+    clearLogCmd = '> %s' % (logfile)
+    executeCmd(clearLogCmd)
+
+    # Initialize dictionary holding supported host codes
+    SupportedHostCodes = {
+            'localhost': None,
+            'mayamaster': 'openebs-mayamasters',
+            'mayahost': 'openebs-mayahosts',
+            'kubemaster': 'kubernetes-kubemasters',
+            'kubeminion': 'kubernetes-kubeminions'
+            }
+
+    """Create list of tuples containing individual machine info & initialize
+    localhost password"""
+    HostList = []
+    local_password = None
+    v = Validator()
+    with open(Hosts, "rb") as fp:
+        for i in fp.readlines():
+            tmp = i.split(",")
+            if tmp[0] != '\n' and "#" not in tmp[0]:
+                ret, msg = v.validateInput(tmp, SupportedHostCodes)
+                if not ret:
+                    print msg
+                    exit()
+
+                if tmp[0] == "localhost":
+                    local_password = tmp[3].rstrip('\n')
+                try:
+                    HostList.append((tmp[0], tmp[1],
+                                     tmp[2], tmp[3].rstrip('\n')))
+                except IndexError as e:
+                    info_text = "Unable to parse input, failed with error %s"
+                    logging.info(info_text, e)
+                    exit()
+
+    if args.passwordless and args.passwordless.upper() == "TRUE":
+        # Setup passwordless SSH between the localhost and target hosts
+        setupSSH(key_rsa_path, key_append_path, key_gen_cmd, HostList)
+        passwdless = True
+    else:
+        passwdless = False
+
+    # Generate Ansible hosts file from 'machines.in'
+    codes = list(SupportedHostCodes)
+    inventory = Inventory()
+    for i in codes:
+        codeSubList = []
+        for j in HostList:
+            if i in j:
+                codeSubList.append(j)
+        ret, msg = inventory.generateInventory(config, codeSubList,
+                                               inventory_path,
+                                               SupportedHostCodes,
+                                               passwdless)
+        if not ret:
+            print msg
+            exit()
+
+    print "Inventory config generated successfully"
+    logging.info("Inventory config generated successfully")
+
+    # Insert localhost line into beginning of inventory file
+    if local_password:
+        lpasswd = "\"{{ lookup('env','%s') }}\"" % (local_password)
+        localhostString = """localhost ansible_connection=local
+        ansible_become_pass=%s\n\n""" % (lpasswd)
+
+        with open(inventory_path, 'rb') as f:
+            with open('hosts.tmp', 'wb') as f2:
+                f2.write(localhostString)
+                f2.write(f.read())
+        os.rename('hosts.tmp', inventory_path)
+
+    # Sanitize the Ansible inventory file
+    replace(inventory_path, " = ", "=")
+
+
+if __name__ == "__main__":
+    main()

--- a/executor/ansible/roles/inventory/files/inventory.py
+++ b/executor/ansible/roles/inventory/files/inventory.py
@@ -1,0 +1,56 @@
+'''
+Class for managing Inventory generation
+'''
+
+
+class Inventory(object):
+
+    def __init__(self):
+        pass
+
+    def generateInventory(self, config, boxlist, path, codes, pwdless):
+        """ Generates inventory.cfg file using configparser module  """
+
+        c = 1
+        for i in boxlist:
+            if i[0] != 'localhost':
+                hostgroupname = codes[i[0]]
+                user = "\"{{ lookup('env','%s') }}\"" % (i[2])
+                passwd = "\"{{ lookup('env','%s') }}\"" % (i[3])
+
+                try:
+                    if c == 1:
+                        hostaliasname = '%s0%s ansible_ssh_host' % (i[0], c)
+                        config[hostgroupname] = {hostaliasname: i[1]}
+                        f = open(path, 'w')
+                        config.write(f)
+                        f.close()
+                        c = c + 1
+
+                        varsgroupname = '%s:vars' % (hostgroupname)
+                        config[varsgroupname] = {'ansible_ssh_user': user}
+
+                        if not pwdless:
+                            config[varsgroupname]['ansible_ssh_pass'] = passwd
+
+                        config[varsgroupname]['ansible_become_pass'] = passwd
+
+                        eargs = "'-o StrictHostKeyChecking=no'"
+                        config[varsgroupname]['ansible_ssh_extra_args'] = eargs
+
+                        f = open(path, 'w')
+                        config.write(f)
+                        f.close()
+
+                    elif c > 1:
+                        hostaliasname = '%s0%s ansible_ssh_host' % (i[0], c)
+                        config[hostgroupname][hostaliasname] = i[1]
+                        f = open(path, 'w')
+                        config.write(f)
+                        f.close()
+                        c = c + 1
+
+                except KeyError:
+                    err_text = "Unable to construct hosts file,received error:"
+                    return False, err_text
+        return True, "Success"

--- a/executor/ansible/roles/inventory/files/passwordless.py
+++ b/executor/ansible/roles/inventory/files/passwordless.py
@@ -1,0 +1,101 @@
+#######################################################################
+# This utils file can be used to setup passwordless SSH between the
+# machine on which it is executed and other target hosts. The method
+# to invoke the function and arguments required are explained below :
+#
+# setupSSH(key_rsa_path, key_append_path, key_gen_cmd, HostList), where
+#
+# key_rsa_path = Location of the rsa public key file
+# key_append_path = Location of the authorized_keys file on localhost
+# key_gen_cmd = Key generation command to be used on local/remote hosts
+# HostList = A list which contains tuples of details for each host
+#
+# The sample HostList is constructed as shown. Note that the USERNAME
+# and PASSWORD here are environment variables from the .profile of the
+# local user.
+#
+# [('mayamaster',20.10.49.11,'USERNAME','PASSWORD'),
+# ('mayahost',20.10.49.12,'USERNAME','PASSWORD')]
+#######################################################################
+
+from utils import sshToOtherClient, executeCmd
+import logging
+import paramiko
+import subprocess
+import socket
+
+
+def getLocalKey(cmd, path):
+    """ Uses ssh-keygen command to generate id_rsa.pub on localhost """
+
+    executeCmd(cmd)
+    out = subprocess.Popen("cat" + " " + path, shell=True,
+                           stdout=subprocess.PIPE)
+    key = out.stdout.read().rstrip('\n')
+    logging.debug("Local key has been generated successfully : %s ", key)
+    return key
+
+
+def getRemoteKey(cmd, path, ip, user, passwd):
+    """Uses ssh-keygen command over SSH to generate id_rsa.pub on remotehost"""
+
+    sshToOtherClient(ip, user, passwd, cmd)
+    showKeyCmd = 'cat %s' % (path)
+    remote_key = sshToOtherClient(ip, user, passwd, showKeyCmd)
+    logging.debug("Remote key for %s has been generated successfully : %s",
+                  ip, remote_key)
+    return remote_key
+
+
+def appendLocalKeyInRemote(key, authorized_key_path, ip, user, passwd):
+    """ Adds localkey as an authorized key in remotehost over SSH """
+
+    key_append_cmd = 'echo "%s" >> %s' % (key, authorized_key_path)
+    sshToOtherClient(ip, user, passwd, key_append_cmd)
+    logging.debug("Local key has been added into authorized_keys in %s", ip)
+
+
+def appendRemoteKeyInLocal(key, authorized_key_path, ip):
+    """ Adds remote key as an authorized key into localhost """
+
+    key_append_cmd = 'echo "%s" >> %s' % (key, authorized_key_path)
+    executeCmd(key_append_cmd)
+    debug_text = """Remote key for %s has been added into authorized_keys in
+    LocalHost"""
+    logging.debug(debug_text, ip)
+
+
+def setupSSH(key_rsa_path, key_append_path, key_gen_cmd, HostList):
+    """Setups up passwordless SSH between the localhost
+    and other target hosts"""
+    # Generate SSH key on localhost
+    LocalKey = getLocalKey(key_gen_cmd, key_rsa_path)
+
+    # Setup passwordless SSH with each of the specified machines
+    for i in HostList:
+        if i[0] != 'localhost':
+
+            box_ip = i[1]
+            user = i[2]
+            pwd = i[3]
+
+            out = subprocess.Popen("echo $" + user, shell=True,
+                                   stdout=subprocess.PIPE)
+            box_user = out.stdout.read().rstrip('\n')
+            out = subprocess.Popen("echo $" + pwd, shell=True,
+                                   stdout=subprocess.PIPE)
+            box_pwd = out.stdout.read().rstrip('\n')
+            try:
+
+                RemoteKey = getRemoteKey(key_gen_cmd, key_rsa_path, box_ip,
+                                         box_user, box_pwd)
+                appendLocalKeyInRemote(LocalKey, key_append_path, box_ip,
+                                       box_user, box_pwd)
+                appendRemoteKeyInLocal(RemoteKey, key_append_path, box_ip)
+                logging.info("Passwordless SSH has been setup b/w \
+                localhost & %s", box_ip)
+
+            except (paramiko.SSHException, paramiko.BadHostKeyException,
+                    paramiko.AuthenticationException, socket.error) as e:
+                logging.info("Passwordless SSH setup failed b/w localhost & %s \
+                with %s, please verify host connectivity", box_ip, e)

--- a/executor/ansible/roles/inventory/files/test/ansible.cfg
+++ b/executor/ansible/roles/inventory/files/test/ansible.cfg
@@ -1,0 +1,363 @@
+# config file for ansible -- http://ansible.com/
+# ==============================================
+
+# nearly all parameters can be overridden in ansible-playbook
+# or with command line flags. ansible will read ANSIBLE_CONFIG,
+# ansible.cfg in the current working directory, .ansible.cfg in
+# the home directory or /etc/ansible/ansible.cfg, whichever it
+# finds first
+
+[defaults]
+
+# some basic default values...
+
+inventory      = ./inventory/hosts
+callback_plugins   = ./plugins/callback
+stdout_callback = openebs 
+#library        = /usr/share/my_modules/
+#remote_tmp     = ~/.ansible/tmp
+#local_tmp      = ~/.ansible/tmp
+#forks          = 5
+#poll_interval  = 15
+#sudo_user      = root
+#ask_sudo_pass = True
+#ask_pass      = True
+#transport      = smart
+#remote_port    = 22
+#module_lang    = C
+#module_set_locale = False
+
+# plays will gather facts by default, which contain information about
+# the remote system.
+#
+# smart - gather by default, but don't regather if already gathered
+# implicit - gather by default, turn off with gather_facts: False
+# explicit - do not gather by default, must say gather_facts: True
+#gathering = implicit
+
+# by default retrieve all facts subsets
+# all - gather all subsets
+# network - gather min and network facts
+# hardware - gather hardware facts (longest facts to retrieve)
+# virtual - gather min and virtual facts
+# facter - import facts from facter
+# ohai - import facts from ohai
+# You can combine them using comma (ex: network,virtual)
+# You can negate them using ! (ex: !hardware,!facter,!ohai)
+# A minimal set of facts is always gathered.
+#gather_subset = all
+
+# some hardware related facts are collected
+# with a maximum timeout of 10 seconds. This
+# option lets you increase or decrease that
+# timeout to something more suitable for the
+# environment. 
+# gather_timeout = 10
+
+# additional paths to search for roles in, colon separated
+roles_path    = ./roles/
+
+# uncomment this to disable SSH key host checking
+#host_key_checking = False
+
+# change the default callback
+#stdout_callback = skippy
+# enable additional callbacks
+#callback_whitelist = timer, mail
+
+# Determine whether includes in tasks and handlers are "static" by
+# default. As of 2.0, includes are dynamic by default. Setting these
+# values to True will make includes behave more like they did in the
+# 1.x versions.
+#task_includes_static = True
+#handler_includes_static = True
+
+# Controls if a missing handler for a notification event is an error or a warning
+#error_on_missing_handler = True
+
+# change this for alternative sudo implementations
+#sudo_exe = sudo
+
+# What flags to pass to sudo
+# WARNING: leaving out the defaults might create unexpected behaviours
+#sudo_flags = -H -S -n
+
+# SSH timeout
+#timeout = 10
+
+# default user to use for playbooks if user is not specified
+# (/usr/bin/ansible will use current user as default)
+#remote_user = root
+
+# logging is off by default unless this path is defined
+# if so defined, consider logrotate
+#log_path = /var/log/ansible.log
+
+# default module name for /usr/bin/ansible
+#module_name = command
+
+# use this shell for commands executed under sudo
+# you may need to change this to bin/bash in rare instances
+# if sudo is constrained
+#executable = /bin/sh
+
+# if inventory variables overlap, does the higher precedence one win
+# or are hash values merged together?  The default is 'replace' but
+# this can also be set to 'merge'.
+#hash_behaviour = replace
+
+# by default, variables from roles will be visible in the global variable
+# scope. To prevent this, the following option can be enabled, and only
+# tasks and handlers within the role will see the variables there
+#private_role_vars = yes
+
+# list any Jinja2 extensions to enable here:
+#jinja2_extensions = jinja2.ext.do,jinja2.ext.i18n
+
+# if set, always use this private key file for authentication, same as
+# if passing --private-key to ansible or ansible-playbook
+#private_key_file = /path/to/file
+
+# If set, configures the path to the Vault password file as an alternative to
+# specifying --vault-password-file on the command line.
+#vault_password_file = /path/to/vault_password_file
+
+# format of string {{ ansible_managed }} available within Jinja2
+# templates indicates to users editing templates files will be replaced.
+# replacing {file}, {host} and {uid} and strftime codes with proper values.
+#ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
+# {file}, {host}, {uid}, and the timestamp can all interfere with idempotence
+# in some situations so the default is a static string:
+#ansible_managed = Ansible managed
+
+# by default, ansible-playbook will display "Skipping [host]" if it determines a task
+# should not be run on a host.  Set this to "False" if you don't want to see these "Skipping"
+# messages. NOTE: the task header will still be shown regardless of whether or not the
+# task is skipped.
+#display_skipped_hosts = True
+
+# by default, if a task in a playbook does not include a name: field then
+# ansible-playbook will construct a header that includes the task's action but
+# not the task's args.  This is a security feature because ansible cannot know
+# if the *module* considers an argument to be no_log at the time that the
+# header is printed.  If your environment doesn't have a problem securing
+# stdout from ansible-playbook (or you have manually specified no_log in your
+# playbook on all of the tasks where you have secret information) then you can
+# safely set this to True to get more informative messages.
+#display_args_to_stdout = False
+
+# by default (as of 1.3), Ansible will raise errors when attempting to dereference
+# Jinja2 variables that are not set in templates or action lines. Uncomment this line
+# to revert the behavior to pre-1.3.
+#error_on_undefined_vars = False
+
+# by default (as of 1.6), Ansible may display warnings based on the configuration of the
+# system running ansible itself. This may include warnings about 3rd party packages or
+# other conditions that should be resolved if possible.
+# to disable these warnings, set the following value to False:
+#system_warnings = True
+
+# by default (as of 1.4), Ansible may display deprecation warnings for language
+# features that should no longer be used and will be removed in future versions.
+# to disable these warnings, set the following value to False:
+#deprecation_warnings = True
+
+# (as of 1.8), Ansible can optionally warn when usage of the shell and
+# command module appear to be simplified by using a default Ansible module
+# instead.  These warnings can be silenced by adjusting the following
+# setting or adding warn=yes or warn=no to the end of the command line
+# parameter string.  This will for example suggest using the git module
+# instead of shelling out to the git command.
+# command_warnings = False
+
+
+# set plugin path directories here, separate with colons
+#action_plugins     = /usr/share/ansible/plugins/action
+#cache_plugins      = /usr/share/ansible/plugins/cache
+#callback_plugins   = /usr/share/ansible/plugins/callback
+#connection_plugins = /usr/share/ansible/plugins/connection
+#lookup_plugins     = /usr/share/ansible/plugins/lookup
+#inventory_plugins  = /usr/share/ansible/plugins/inventory
+#vars_plugins       = /usr/share/ansible/plugins/vars
+#filter_plugins     = /usr/share/ansible/plugins/filter
+#test_plugins       = /usr/share/ansible/plugins/test
+#strategy_plugins   = /usr/share/ansible/plugins/strategy
+
+# by default callbacks are not loaded for /bin/ansible, enable this if you
+# want, for example, a notification or logging callback to also apply to
+# /bin/ansible runs
+#bin_ansible_callbacks = False
+
+
+# don't like cows?  that's unfortunate.
+# set to 1 if you don't want cowsay support or export ANSIBLE_NOCOWS=1
+#nocows = 1
+
+# set which cowsay stencil you'd like to use by default. When set to 'random',
+# a random stencil will be selected for each task. The selection will be filtered
+# against the `cow_whitelist` option below.
+#cow_selection = default
+#cow_selection = random
+
+# when using the 'random' option for cowsay, stencils will be restricted to this list.
+# it should be formatted as a comma-separated list with no spaces between names.
+# NOTE: line continuations here are for formatting purposes only, as the INI parser
+#       in python does not support them.
+#cow_whitelist=bud-frogs,bunny,cheese,daemon,default,dragon,elephant-in-snake,elephant,eyes,\
+#              hellokitty,kitty,luke-koala,meow,milk,moofasa,moose,ren,sheep,small,stegosaurus,\
+#              stimpy,supermilker,three-eyes,turkey,turtle,tux,udder,vader-koala,vader,www
+
+# don't like colors either?
+# set to 1 if you don't want colors, or export ANSIBLE_NOCOLOR=1
+#nocolor = 1
+
+# if set to a persistent type (not 'memory', for example 'redis') fact values
+# from previous runs in Ansible will be stored.  This may be useful when
+# wanting to use, for example, IP information from one group of servers
+# without having to talk to them in the same playbook run to get their
+# current IP information.
+#fact_caching = memory
+
+
+# retry files
+# When a playbook fails by default a .retry file will be created in ~/
+# You can disable this feature by setting retry_files_enabled to False
+# and you can change the location of the files by setting retry_files_save_path
+
+retry_files_enabled = False
+#retry_files_save_path = ~/.ansible-retry
+
+# squash actions
+# Ansible can optimise actions that call modules with list parameters
+# when looping. Instead of calling the module once per with_ item, the
+# module is called once with all items at once. Currently this only works
+# under limited circumstances, and only with parameters named 'name'.
+#squash_actions = apk,apt,dnf,homebrew,package,pacman,pkgng,yum,zypper
+
+# prevents logging of task data, off by default
+#no_log = False
+
+# prevents logging of tasks, but only on the targets, data is still logged on the master/controller
+#no_target_syslog = False
+
+# controls whether Ansible will raise an error or warning if a task has no
+# choice but to create world readable temporary files to execute a module on
+# the remote machine.  This option is False by default for security.  Users may
+# turn this on to have behaviour more like Ansible prior to 2.1.x.  See
+# https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user
+# for more secure ways to fix this than enabling this option.
+#allow_world_readable_tmpfiles = False
+
+# controls the compression level of variables sent to
+# worker processes. At the default of 0, no compression
+# is used. This value must be an integer from 0 to 9.
+#var_compression_level = 9
+
+# controls what compression method is used for new-style ansible modules when
+# they are sent to the remote system.  The compression types depend on having
+# support compiled into both the controller's python and the client's python.
+# The names should match with the python Zipfile compression types:
+# * ZIP_STORED (no compression. available everywhere)
+# * ZIP_DEFLATED (uses zlib, the default)
+# These values may be set per host via the ansible_module_compression inventory
+# variable
+#module_compression = 'ZIP_DEFLATED'
+
+# This controls the cutoff point (in bytes) on --diff for files
+# set to 0 for unlimited (RAM may suffer!).
+#max_diff_size = 1048576
+
+[privilege_escalation]
+#become=True
+#become_method=sudo
+#become_user=root
+#become_ask_pass=False
+
+[paramiko_connection]
+
+# uncomment this line to cause the paramiko connection plugin to not record new host
+# keys encountered.  Increases performance on new host additions.  Setting works independently of the
+# host key checking setting above.
+#record_host_keys=False
+
+# by default, Ansible requests a pseudo-terminal for commands executed under sudo. Uncomment this
+# line to disable this behaviour.
+#pty=False
+
+[ssh_connection]
+
+# ssh arguments to use
+# Leaving off ControlPersist will result in poor performance, so use
+# paramiko on older platforms rather than removing it, -C controls compression use
+#ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s
+
+# The path to use for the ControlPath sockets. This defaults to
+# "%(directory)s/ansible-ssh-%%h-%%p-%%r", however on some systems with
+# very long hostnames or very long path names (caused by long user names or
+# deeply nested home directories) this can exceed the character limit on
+# file socket names (108 characters for most platforms). In that case, you
+# may wish to shorten the string below.
+#
+# Example:
+# control_path = %(directory)s/%%h-%%r
+#control_path = %(directory)s/ansible-ssh-%%h-%%p-%%r
+
+# Enabling pipelining reduces the number of SSH operations required to
+# execute a module on the remote server. This can result in a significant
+# performance improvement when enabled, however when using "sudo:" you must
+# first disable 'requiretty' in /etc/sudoers
+#
+# By default, this option is disabled to preserve compatibility with
+# sudoers configurations that have requiretty (the default on many distros).
+#
+#pipelining = False
+
+# Control the mechanism for transferring files
+#   * smart = try sftp and then try scp [default]
+#   * True = use scp only
+#   * False = use sftp only
+#scp_if_ssh = smart
+
+# if False, sftp will not use batch mode to transfer files. This may cause some
+# types of file transfer failures impossible to catch however, and should
+# only be disabled if your sftp version has problems with batch mode
+#sftp_batch_mode = False
+
+[accelerate]
+#accelerate_port = 5099
+#accelerate_timeout = 30
+#accelerate_connect_timeout = 5.0
+
+# The daemon timeout is measured in minutes. This time is measured
+# from the last activity to the accelerate daemon.
+#accelerate_daemon_timeout = 30
+
+# If set to yes, accelerate_multi_key will allow multiple
+# private keys to be uploaded to it, though each user must
+# have access to the system via SSH to add a new key. The default
+# is "no".
+#accelerate_multi_key = yes
+
+[selinux]
+# file systems that require special treatment when dealing with security context
+# the default behaviour that copies the existing context or uses the user default
+# needs to be changed to use the file system dependent context.
+#special_context_filesystems=nfs,vboxsf,fuse,ramfs
+
+# Set this to yes to allow libvirt_lxc connections to work without SELinux.
+#libvirt_lxc_noseclabel = yes
+
+[colors]
+#highlight = white
+#verbose = blue
+#warn = bright purple
+#error = red
+#debug = dark gray
+#deprecate = purple
+#skip = cyan
+#unreachable = red
+#ok = green
+#changed = yellow
+#diff_add = green
+#diff_remove = red
+#diff_lines = cyan

--- a/executor/ansible/roles/inventory/files/test/test_inventory.py
+++ b/executor/ansible/roles/inventory/files/test/test_inventory.py
@@ -1,0 +1,30 @@
+"""Tests for utils."""
+from __future__ import absolute_import
+
+import unittest
+import sys
+import os
+import configparser
+
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+from inventory import Inventory # flake8: noqa
+
+
+class inventoryTest(unittest.TestCase):
+
+    def test_010_validate_inventory(self):
+        i = Inventory()
+        config = configparser.ConfigParser()
+        config.read_file(open('./ansible.cfg'))
+        box_list = [['local', '127.0.0.1', 'USER_NAME', 'USER_PASSWORD']]
+        codes = {'local':'test'}
+        ret, msg = i.generateInventory(config,box_list, "./test.hosts", codes, "")
+        self.assertEqual(ret,True)
+
+    def tearDown(self):
+        os.remove('./test.hosts')
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(inventoryTest)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/executor/ansible/roles/inventory/files/test/test_utils.py
+++ b/executor/ansible/roles/inventory/files/test/test_utils.py
@@ -1,0 +1,28 @@
+"""Tests for utils."""
+from __future__ import absolute_import
+
+import unittest
+import sys
+import os
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+from utils import replace # flake8: noqa
+
+
+class utilsTest(unittest.TestCase):
+    def setUp(self):
+        with open('./test.txt', 'w') as outfile:
+            outfile.write('foo = bar')
+
+    def test_010_replace(self):
+        replace('./test.txt', ' = ', '=')
+        with open('./test.txt', 'r') as infile:
+            txt = infile.read()
+        self.assertEqual(txt, 'foo=bar')
+
+    def tearDown(self):
+        os.remove('./test.txt')
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(utilsTest)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/executor/ansible/roles/inventory/files/test/test_validator.py
+++ b/executor/ansible/roles/inventory/files/test/test_validator.py
@@ -1,0 +1,37 @@
+"""Tests for utils."""
+from __future__ import absolute_import
+
+import unittest
+import sys
+import os
+
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+from validator import Validator # flake8: noqa
+
+
+class validatorTest(unittest.TestCase):
+    def setUp(self):
+        os.environ['USER_NAME'] = 'test'
+        os.environ['USER_PASSWORD'] = 'test'
+
+    def test_010_validateip(self):
+        v = Validator()
+        self.assertEqual(v.validateIP("127.0.0.1"), True)
+        self.assertEqual(v.validateIP("foo"), False)
+
+    def test_020_validate_input(self):
+        v = Validator()
+        good_line = ['localhost', '127.0.0.1', 'USER_NAME', 'USER_PASSWORD']
+        bad_line = ['localhost', '127.0.0.1', 'USER_NAME1', 'USER_PASSWORD1']
+        ret, msg = v.validateInput(good_line, ['localhost'])
+        self.assertEqual(ret, True)
+        ret, msg = v.validateInput(good_line, ['local'])
+        self.assertEqual(ret, False)
+        ret, msg = v.validateInput(bad_line, ['localhost'])
+        self.assertEqual(ret, False)
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(validatorTest)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/executor/ansible/roles/inventory/files/utils.py
+++ b/executor/ansible/roles/inventory/files/utils.py
@@ -1,0 +1,41 @@
+import subprocess
+import paramiko
+import re
+
+
+def executeCmd(command):
+    link = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, close_fds=True)
+    output, errors = link.communicate()
+    rco = link.returncode
+    if rco != 0:
+        return "FAILED", str(errors)
+    return "PASSED", ""
+
+
+ssh = paramiko.SSHClient()
+ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+
+def sshToOtherClient(ip, usrname, pwd, cmd):
+    ssh.connect(ip, username=usrname, password=pwd)
+    stdin, stdout, stderr = ssh.exec_command(cmd)
+    output = stdout.read()
+    error = stderr.read()
+    ssh.close()
+    if not error and output:
+        return output
+    else:
+        return error
+
+
+def replace(file, pattern, subst):
+    """ Replace extra spaces around assignment operator in inventory """
+
+    file_handle = open(file, 'rb')
+    file_string = file_handle.read()
+    file_handle.close()
+    file_string = (re.sub(pattern, subst, file_string))
+    file_handle = open(file, 'wb')
+    file_handle.write(file_string)
+    file_handle.close()

--- a/executor/ansible/roles/inventory/files/validator.py
+++ b/executor/ansible/roles/inventory/files/validator.py
@@ -1,0 +1,36 @@
+import socket
+import os
+'''
+Class for validation methods
+'''
+
+
+class Validator(object):
+    def __init__(self):
+        pass
+
+    def validateIP(self, ip):
+        try:
+            socket.inet_aton(ip)
+            return True
+        except socket.error:
+            return False
+
+    def validateInput(self, i_line, codes):
+        """ Validates the host codes against a supported list """
+        msg = ""
+        codelist = list(codes)
+        if len(i_line) != 4:
+            msg = "Invalid row length in line: %s" % (','.join(i_line))
+            return False, msg
+        if self.validateIP(i_line[1]) is False:
+            msg = "IP is invalid in line: %s" % (','.join(i_line))
+            return False, msg
+        for j in i_line[2], i_line[3].rstrip('\n'):
+            if j not in os.environ:
+                msg = "Variable not in env, from line: %s" % (','.join(i_line))
+                return False, msg
+        if i_line[0].lower() not in codelist:
+            msg = "Invalid host code in line: %s" % (','.join(i_line))
+            return (False, msg)
+        return True, msg

--- a/executor/ansible/roles/inventory/meta/main.yml
+++ b/executor/ansible/roles/inventory/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: prerequisites }

--- a/executor/ansible/roles/inventory/tasks/main.yml
+++ b/executor/ansible/roles/inventory/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Generate Inventory
+  shell: source ~/.profile; python {{role_path}}/files/generate_inventory.py {{inventory_input_path}}/machines.in --passwordless=True
+  args:
+    executable: /bin/bash
+  delegate_to: 127.0.0.1
+
+- name: Sync Inventory
+  meta: refresh_inventory
+

--- a/executor/ansible/roles/k8s-hosts-centos/defaults/main.yml
+++ b/executor/ansible/roles/k8s-hosts-centos/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+# Do not change the order of the scripts.
+# They have to been run in the order defined below.
+
+configure_scripts: configure_k8s_host.sh
+
+k8s_images: k8s_images_{{ k8s_version }}.tar
+
+k8s_images_path: "{{ ansible_env.HOME }}/setup/k8s"
+
+
+k8s_rpmd_packages:
+  - kubelet.rpm
+  - kubernetes-cni.rpm
+  - kubectl.rpm
+  - kubeadm.rpm
+
+openebs_iscsi_driver: https://raw.githubusercontent.com/openebs/openebs/v0.2/k8s/lib/plugin/flexvolume/openebs-iscsi
+
+flexvol_driver_alias: openebs-iscsi
+
+flexvol_driver_path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/openebs~openebs-iscsi/
+

--- a/executor/ansible/roles/k8s-hosts-centos/handlers/main.yml
+++ b/executor/ansible/roles/k8s-hosts-centos/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Reload systemd
+  command: systemctl daemon-reload
+  become: true
+
+- name: Restart kubelet
+  service:
+    name: kubelet 
+    state: restarted
+    enabled: yes
+  become: true

--- a/executor/ansible/roles/k8s-hosts-centos/k8s.conf
+++ b/executor/ansible/roles/k8s-hosts-centos/k8s.conf
@@ -1,0 +1,2 @@
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1

--- a/executor/ansible/roles/k8s-hosts-centos/meta/main.yml
+++ b/executor/ansible/roles/k8s-hosts-centos/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: kubernetes-centos }
+

--- a/executor/ansible/roles/k8s-hosts-centos/tasks/main.yml
+++ b/executor/ansible/roles/k8s-hosts-centos/tasks/main.yml
@@ -1,0 +1,161 @@
+---
+- name: Get Master Status
+  command: ansible "{{groups['kubernetes-kubemasters'].0}}" -m ping
+  register: result_status
+  delegate_to: 127.0.0.1
+
+- name: 
+  debug:
+    msg: "Ending play, Master UNREACHABLE."
+  when: "'FAILED' in result_status.stdout"
+
+- name: Ending Playbook Run - Master is not UP.
+  meta: end_play
+  when: "'FAILED' in result_status.stdout"
+
+- block:
+    - name: Load images from Archive
+      command: docker load --input "{{ k8s_images }}"
+      args:
+        chdir: "{{ k8s_images_path }}"
+      become: true
+
+    - name: Install rpm packages
+      yum:
+        name: "{{ k8s_images_path }}/{{ item }}"
+      with_items: "{{ k8s_rpmd_packages }}"
+      become: true
+    
+    - name: Copy the volume claim to kube master
+      copy:
+        src: "{{ k8s_conf }}"
+        dest: "{{ sysctl_path }}"
+      become: true    
+
+    - name:
+      shell: |
+        sed -i -E 's/--cgroup-driver=systemd/--cgroup-driver=cgroupfs/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+        sysctl --system
+        systemctl start kubelet && systemctl enable kubelet
+      become: true
+
+  when: build_type == "normal"
+
+- name: Get Token Name from Master
+  shell: >
+    source ~/.bash_profile;
+    kubectl -n kube-system get secrets
+    | grep bootstrap-token | cut -d " " -f1
+    | cut -d "-" -f3
+    | sed "s|\r||g"
+  args:
+    executable: /bin/bash
+  register: result_token_name
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Get Token from Master
+  shell: >
+    source ~/.bash_profile; 
+    kubectl -n kube-system get secrets bootstrap-token-"{{result_token_name.stdout}}"
+    -o yaml | grep token-secret | cut -d ":" -f2
+    | cut -d " " -f2 | base64 -d
+    | sed "s|{||g;s|}||g"
+    | sed "s|:|.|g" | xargs echo
+  args:
+    executable: /bin/bash
+  register: result_token
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  
+- name: Get Cluster IP from Master
+  shell: >
+    source ~/.bash_profile;
+    kubectl get svc -o yaml | grep clusterIP | cut -d ":" -f2 | cut -d " " -f2
+  args:
+    executable: /bin/bash
+  register: result_cluster
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Get Token-sha from Master
+  shell: >
+    openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt 
+    | openssl rsa -pubin -outform der 2>/dev/null 
+    | openssl dgst -sha256 -hex 
+    | sed "s/^.* //"
+  args:
+    executable: /bin/bash
+  register: result_token_sha
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Save Token and Cluster IP
+  set_fact:
+    cluster_ip: "{{ result_cluster.stdout }}"
+    token: "{{ result_token }}"
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  delegate_facts: True
+
+- block:
+   - name: Get the openebs-iscsi flexvolume driver
+     get_url:
+       url: "{{ openebs_iscsi_driver }}"
+       dest: "{{ ansible_env.HOME}}/{{ flexvol_driver_alias }}"
+       force: yes
+     register: result
+     until:  "'OK' in result.msg"
+     delay: 5
+     retries: 3
+
+   - name: Create flexvol driver destination
+     file:
+       path: "{{ flexvol_driver_path }}"
+       state: directory
+       mode: 0755
+     become: true
+
+   - name: Copy script to flexvol driver location
+     copy:
+       src: "{{ ansible_env.HOME }}/{{ flexvol_driver_alias }}"
+       dest: "{{ flexvol_driver_path }}"
+       mode: "u+rwx"
+       force: yes
+       remote_src: yes
+     become: true
+          
+   - name: Reset kubeadm
+     command: kubeadm reset
+     become: true
+
+   - name: Setup k8s Hosts 
+     script: "{{configure_scripts}} 
+             --masterip={{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}} 
+             --token={{result_token_name.stdout}}.{{result_token.stdout}} 
+             --clusterip={{result_cluster.stdout}}
+             --token-sha={{result_token_sha.stdout}}"
+     become: true  
+     notify: 
+       - Reload systemd
+       - Restart kubelet
+  when: build_type == "normal"
+
+- block:
+   - name: Change file mode
+     file:
+       path: "{{k8s_images_path}}/{{configure_scripts}}"
+       mode: "u+rwx"
+     become: true
+
+   - name: Setup k8s Hosts
+     shell: >
+       source ~/.bash_profile;
+       "{{k8s_images_path}}/{{configure_scripts}}"
+       --masterip="{{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}}"
+       --token="{{result_token_name.stdout}}.{{result_token.stdout}}"
+       --clusterip="{{result_cluster.stdout}}"
+     args:
+       executable: /bin/bash
+     become: true
+     notify:
+       - Reload systemd
+       - Restart kubelet
+  when: build_type == "quick"
+
+- meta: flush_handlers 

--- a/executor/ansible/roles/k8s-hosts/defaults/main.yml
+++ b/executor/ansible/roles/k8s-hosts/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+# Do not change the order of the scripts.
+# They have to been run in the order defined below.
+
+configure_scripts: configure_k8s_host.sh
+
+k8s_images: k8s_images_{{ k8s_version }}.tar
+
+k8s_images_path: "{{ ansible_env.HOME }}/setup/k8s"
+
+k8s_dpkg_packages:
+  - kubelet.deb
+  - kubernetes-cni.deb
+  - kubectl.deb
+  - kubeadm.deb
+
+openebs_iscsi_driver: https://raw.githubusercontent.com/openebs/openebs/v0.2/k8s/lib/plugin/flexvolume/openebs-iscsi
+
+flexvol_driver_alias: openebs-iscsi
+
+flexvol_driver_path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/openebs~openebs-iscsi/
+

--- a/executor/ansible/roles/k8s-hosts/handlers/main.yml
+++ b/executor/ansible/roles/k8s-hosts/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Reload systemd
+  command: systemctl daemon-reload
+  become: true
+
+- name: Restart kubelet
+  service:
+    name: kubelet 
+    state: restarted
+    enabled: yes
+  become: true

--- a/executor/ansible/roles/k8s-hosts/meta/main.yml
+++ b/executor/ansible/roles/k8s-hosts/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: kubernetes }
+

--- a/executor/ansible/roles/k8s-hosts/tasks/main.orig
+++ b/executor/ansible/roles/k8s-hosts/tasks/main.orig
@@ -1,0 +1,136 @@
+---
+- name: Get Master Status
+  command: ansible "{{groups['kubernetes-kubemasters'].0}}" -m ping
+  register: result_status
+  delegate_to: 127.0.0.1
+
+- name: 
+  debug:
+    msg: "Ending play, Master UNREACHABLE."
+  when: "'FAILED' in result_status.stdout"
+
+- name: Ending Playbook Run - Master is not UP.
+  meta: end_play
+  when: "'FAILED' in result_status.stdout"
+
+- block:
+    - name: Load images from Archive
+      command: docker load --input "{{ k8s_images }}"
+      args:
+        chdir: "{{ k8s_images_path }}"
+      become: true
+
+    - name: Install deb packages
+      apt:
+        deb: "{{ k8s_images_path }}/{{ item }}"
+      with_items: "{{ k8s_dpkg_packages }}"
+      become: true
+  when: build_type == "normal"
+
+- name: Get Token Name from Master
+  shell: >
+    source ~/.profile;
+    kubectl -n kube-system get secrets
+    | grep bootstrap-token | cut -d " " -f1
+    | cut -d "-" -f3
+    | sed "s|\r||g"
+  args:
+    executable: /bin/bash
+  register: result_token_name
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Get Token from Master
+  shell: >
+    source ~/.profile; 
+    kubectl -n kube-system get secrets bootstrap-token-"{{result_token_name.stdout}}"
+    -o yaml | grep token-secret | cut -d ":" -f2
+    | cut -d " " -f2 | base64 -d
+    | sed "s|{||g;s|}||g"
+    | sed "s|:|.|g" | xargs echo
+  args:
+    executable: /bin/bash
+  register: result_token
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  
+- name: Get Cluster IP from Master
+  shell: >
+    source ~/.profile;
+    kubectl get svc -o yaml | grep clusterIP | cut -d ":" -f2 | cut -d " " -f2
+  args:
+    executable: /bin/bash
+  register: result_cluster
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Save Token and Cluster IP
+  set_fact:
+    cluster_ip: "{{ result_cluster.stdout }}"
+    token: "{{ result_token }}"
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  delegate_facts: True
+
+- block:
+   - name: Get the openebs-iscsi flexvolume driver
+     get_url:
+       url: "{{ openebs_iscsi_driver }}"
+       dest: "{{ ansible_env.HOME}}/{{ flexvol_driver_alias }}"
+       force: yes
+     register: result
+     until:  "'OK' in result.msg"
+     delay: 5
+     retries: 3
+
+   - name: Create flexvol driver destination
+     file:
+       path: "{{ flexvol_driver_path }}"
+       state: directory
+       mode: 0755
+     become: true
+
+   - name: Copy script to flexvol driver location
+     copy:
+       src: "{{ ansible_env.HOME }}/{{ flexvol_driver_alias }}"
+       dest: "{{ flexvol_driver_path }}"
+       mode: "u+rwx"
+       force: yes
+       remote_src: yes
+     become: true
+          
+   - name: Reset kubeadm
+     command: kubeadm reset
+     become: true
+
+   - name: Setup k8s Hosts 
+     script: "{{configure_scripts}} 
+             --masterip={{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}} 
+             --token={{result_token_name.stdout}}.{{result_token.stdout}} 
+             --clusterip={{result_cluster.stdout}}
+             --token-sha={{result_token_sha.stdout}}"
+     become: true  
+     notify: 
+       - Reload systemd
+       - Restart kubelet
+  when: build_type == "normal"
+
+- block:
+   - name: Change file mode
+     file:
+       path: "{{k8s_images_path}}/{{configure_scripts}}"
+       mode: "u+rwx"
+     become: true
+
+   - name: Setup k8s Hosts
+     shell: >
+       source ~/.profile;
+       "{{k8s_images_path}}/{{configure_scripts}}"
+       --masterip="{{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}}"
+       --token="{{result_token_name.stdout}}.{{result_token.stdout}}"
+       --clusterip="{{result_cluster.stdout}}"
+     args:
+       executable: /bin/bash
+     become: true
+     notify:
+       - Reload systemd
+       - Restart kubelet
+  when: build_type == "quick"
+
+- meta: flush_handlers 

--- a/executor/ansible/roles/k8s-hosts/tasks/main.yml
+++ b/executor/ansible/roles/k8s-hosts/tasks/main.yml
@@ -1,0 +1,147 @@
+---
+- name: Get Master Status
+  command: ansible "{{groups['kubernetes-kubemasters'].0}}" -m ping
+  register: result_status
+  delegate_to: 127.0.0.1
+
+- name: 
+  debug:
+    msg: "Ending play, Master UNREACHABLE."
+  when: "'FAILED' in result_status.stdout"
+
+- name: Ending Playbook Run - Master is not UP.
+  meta: end_play
+  when: "'FAILED' in result_status.stdout"
+
+- block:
+    - name: Load images from Archive
+      command: docker load --input "{{ k8s_images }}"
+      args:
+        chdir: "{{ k8s_images_path }}"
+      become: true
+
+    - name: Install deb packages
+      apt:
+        deb: "{{ k8s_images_path }}/{{ item }}"
+      with_items: "{{ k8s_dpkg_packages }}"
+      become: true
+  when: build_type == "normal"
+
+- name: Get Token Name from Master
+  shell: >
+    source ~/.profile;
+    kubectl -n kube-system get secrets
+    | grep bootstrap-token | cut -d " " -f1
+    | cut -d "-" -f3
+    | sed "s|\r||g"
+  args:
+    executable: /bin/bash
+  register: result_token_name
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Get Token from Master
+  shell: >
+    source ~/.profile; 
+    kubectl -n kube-system get secrets bootstrap-token-"{{result_token_name.stdout}}"
+    -o yaml | grep token-secret | cut -d ":" -f2
+    | cut -d " " -f2 | base64 -d
+    | sed "s|{||g;s|}||g"
+    | sed "s|:|.|g" | xargs echo
+  args:
+    executable: /bin/bash
+  register: result_token
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  
+- name: Get Cluster IP from Master
+  shell: >
+    source ~/.profile;
+    kubectl get svc -o yaml | grep clusterIP | cut -d ":" -f2 | cut -d " " -f2
+  args:
+    executable: /bin/bash
+  register: result_cluster
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Get Token-sha from Master
+  shell: >
+    openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt
+    | openssl rsa -pubin -outform der 2>/dev/null
+    | openssl dgst -sha256 -hex
+    | sed "s/^.* //"
+  args:
+    executable: /bin/bash
+  register: result_token_sha
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Save Token and Cluster IP
+  set_fact:
+    cluster_ip: "{{ result_cluster.stdout }}"
+    token: "{{ result_token }}"
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  delegate_facts: True
+
+- block:
+   - name: Get the openebs-iscsi flexvolume driver
+     get_url:
+       url: "{{ openebs_iscsi_driver }}"
+       dest: "{{ ansible_env.HOME}}/{{ flexvol_driver_alias }}"
+       force: yes
+     register: result
+     until:  "'OK' in result.msg"
+     delay: 5
+     retries: 3
+
+   - name: Create flexvol driver destination
+     file:
+       path: "{{ flexvol_driver_path }}"
+       state: directory
+       mode: 0755
+     become: true
+
+   - name: Copy script to flexvol driver location
+     copy:
+       src: "{{ ansible_env.HOME }}/{{ flexvol_driver_alias }}"
+       dest: "{{ flexvol_driver_path }}"
+       mode: "u+rwx"
+       force: yes
+       remote_src: yes
+     become: true
+          
+   - name: Reset kubeadm
+     command: kubeadm reset
+     become: true
+
+   - name: Setup k8s Hosts 
+     script: "{{configure_scripts}} 
+             --masterip={{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}} 
+             --token={{result_token_name.stdout}}.{{result_token.stdout}}
+             --clusterip={{result_cluster.stdout}} 
+             --token-sha={{result_token_sha.stdout}}"
+     become: true  
+     notify: 
+       - Reload systemd
+       - Restart kubelet
+  when: build_type == "normal"
+
+- block:
+   - name: Change file mode
+     file:
+       path: "{{k8s_images_path}}/{{configure_scripts}}"
+       mode: "u+rwx"
+     become: true
+
+   - name: Setup k8s Hosts
+     shell: >
+       source ~/.profile;
+       "{{k8s_images_path}}/{{configure_scripts}}"
+       --masterip="{{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}}"
+       --token="{{result_token_name.stdout}}.{{result_token.stdout}}"
+       --clusterip="{{result_cluster.stdout}}"
+     args:
+       executable: /bin/bash
+     become: true
+     notify:
+       - Reload systemd
+       - Restart kubelet
+  when: build_type == "quick"
+
+- meta: flush_handlers 

--- a/executor/ansible/roles/k8s-localhost-centos/defaults/main.yml
+++ b/executor/ansible/roles/k8s-localhost-centos/defaults/main.yml
@@ -1,0 +1,63 @@
+---
+##################################################### PREPARATION OF K8S-LOCALHOST BOX #########################################################
+
+pip_local_packages:
+  - 'docker-py==1.9.0'
+
+###################################################### PREPARATION OF KUBERNETES ROLE  ##########################################################
+
+# Links for rpm packages that will be installed on all K8s boxes (masters, minions), i.e, 
+# these packages will be copied into kubernetes role's .files
+
+k8s_cni_rpm_package: https://packages.cloud.google.com/yum/pool/e7a4403227dd24036f3b0615663a371c4e07a95be5fee53505e647fd8ae58aa6-kubernetes-cni-0.5.1-0.x86_64.rpm
+
+k8s_rpm_package_alias:
+  - kubeadm.rpm
+  - kubectl.rpm
+  - kubelet.rpm
+
+k8s_log_aggregator_url: https://github.com/wercker/stern/releases/download/1.6.0/stern_linux_amd64 
+
+k8s_log_aggregator: stern
+
+# Container images that needs to be placed on all K8s boxes (masters, minions)
+# These images will be downloaded, tar'ed and pushed into the kubernetes role's .files
+
+k8s_images:
+  - gcr.io/google_containers/pause-amd64:3.0
+  - gcr.io/google_containers/etcd-amd64:3.0.17
+  - gcr.io/google_containers/kube-scheduler-amd64:v{{ k8s_version }}
+  - gcr.io/google_containers/kube-apiserver-amd64:v{{ k8s_version }}
+  - gcr.io/google_containers/kube-controller-manager-amd64:v{{ k8s_version }}
+  - gcr.io/google_containers/kube-proxy-amd64:v{{ k8s_version }}
+  - gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1
+  - gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1
+  - gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1
+
+###################################################### PREPARATION OF K8S-MASTER ROLE ###########################################################
+
+# Links for scripts to be placed into K8s-master role's .files 
+
+k8s_master_scripts: 
+  - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_master.sh
+  - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_cni.sh
+
+# Container images that needs to be placed in K8s-master box
+# These images will be downloaded, tar'ed and pushed into K8s-master role's .files 
+
+weave_images: 
+  - weaveworks/weave-kube:{{ weave_version }}
+  - weaveworks/weave-npc:{{ weave_version }}
+
+# Link to download default weave template (.yaml) to be placed in roles/kubernetes/templates
+
+weave_template_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/vagrant/boxes/k8s-weave/external/weave-daemonset-k8s-1.6.yaml
+
+###################################################### PREPARATION OF K8S-HOST ROLE #############################################################
+
+# Links for scripts to be placed into K8s-host role's .files
+
+k8s_host_scripts: 
+  - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_host.sh
+
+

--- a/executor/ansible/roles/k8s-localhost-centos/handlers/main.yml
+++ b/executor/ansible/roles/k8s-localhost-centos/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Start docker
+  command: systemctl start docker && systemctl start docker
+  become: true
+

--- a/executor/ansible/roles/k8s-localhost-centos/tasks/main.yml
+++ b/executor/ansible/roles/k8s-localhost-centos/tasks/main.yml
@@ -1,0 +1,229 @@
+---
+## K8S-LOCALHOST PREPARATION
+
+- name: Install RPM dependencies
+  shell: "yum install -y yum-utils device-mapper-persistent-data lvm2 socat ebtables"
+  become: true
+  delegate_to: 127.0.0.1
+
+- name: Add docker repo
+  shell: "yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo"
+  become: true
+  delegate_to: 127.0.0.1
+
+- name: Install RPM Packages
+  shell: "yum install -y docker-ce-17.03.0.ce-1.el7.centos docker-ce-selinux-17.03.0.ce-1.el7.centos" 
+  become: true
+  delegate_to: 127.0.0.1
+
+- name: get-pip
+  shell: "curl 'https://bootstrap.pypa.io/get-pip.py' -o 'get-pip.py'"
+  become: true
+  delegate_to: 127.0.0.1
+
+- name: Install pip
+  shell: "python get-pip.py"
+  become: true
+  delegate_to: 127.0.0.1
+
+- name: Install PIP Packages
+  pip:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ pip_local_packages }}"
+  delegate_to: 127.0.0.1
+  become: true
+
+## Common preparation tasks
+
+- name: Create files directory in kubernetes role
+  file:
+    path: "{{ playbook_dir }}/roles/{{item}}/files"
+    state: directory
+    mode: 0755
+  with_items:
+    - kubernetes
+    - k8s-master
+    - k8s-hosts
+
+## kubernetes role preparation
+
+- name: Get .rpm package details
+  shell: curl -sS https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64/repodata/primary.xml | grep -- -{{ k8s_version }} | grep "location href" | awk '{print $2}' | cut -d '/' -f4 | cut -d '"' -f1
+  register: k8s_rpm_packages
+
+- name: Get .rpm kubernetes packages google cloud 
+  get_url: 
+    url: "https://packages.cloud.google.com/yum/pool/{{ item.0 }}"
+    dest: "{{ playbook_dir }}/roles/kubernetes-centos/files/{{item.1}}"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+  with_together: 
+    - "{{ k8s_rpm_packages.stdout_lines }}"
+    - "{{ k8s_rpm_package_alias }}"
+
+- name: Get CNI .rpm package from google cloud
+  get_url:
+    url: "{{k8s_cni_rpm_package}}"
+    dest: "{{ playbook_dir }}/roles/kubernetes-centos/files/kubernetes-cni.rpm"
+    force: yes
+  register: result
+  until: "'OK' in result.msg"
+  delay: 5
+  retries: 3
+
+- name: Check whether rpm packages and images are already downloaded
+  stat: 
+    path: "{{ playbook_dir }}/roles/kubernetes-centos/files/k8s_images_{{ k8s_version }}.tar"
+  register: stat_result
+
+- block:
+    - name: Start and Enable docker
+      shell: "systemctl start docker && systemctl enable docker"
+      become: true
+
+    - name: Fetch K8s images from gcr.io/google_containers
+      docker_image: 
+        name: "{{item}}"
+        state: present
+        pull: true
+        force: yes
+      register: result
+      until: "'Pulled image' and item in result.actions[0]"
+      delay: 60
+      retries: 3  
+      with_items: "{{ k8s_images }}"
+      become: true
+
+    - name: Print K8s image names
+      shell: printf "{{ item }}\n" >> imagelist.tmp
+      with_items: "{{ k8s_images }}"
+
+    - name: TAR the K8s images 
+      shell: docker save $(cat imagelist.tmp) -o k8s_images_{{ k8s_version }}.tar
+      become: true
+
+    - name: Remove the .tmp file created to hold image list
+      file: path="{{playbook_dir}}/imagelist.tmp" state=absent
+
+    - name: Move K8s_images_{{ k8s_version }}.tar into kubernetes role
+      shell: mv {{playbook_dir}}/k8s_images_{{ k8s_version }}.tar {{ playbook_dir }}/roles/kubernetes-centos/files
+      become: true
+
+    - name: Remove K8s images from K8s-localhost
+      docker_image:
+        name: "{{ item }}" 
+        state: absent
+      with_items: "{{ k8s_images }}"
+      become: true
+  
+  when: stat_result.stat.exists == false 
+
+## K8S-MASTER ROLE PREPARATION
+
+- name: Get Log Aggregator
+  get_url:
+    url: "{{k8s_log_aggregator_url}}"
+    dest: "{{ playbook_dir }}/roles/k8s-master-centos/files/{{k8s_log_aggregator}}"
+    force: yes
+  register: result
+  until: "'OK' in result.msg"
+  delay: 5
+  retries: 3
+
+- name: Fetch configure_K8s scripts into k8s-master role
+  get_url: 
+    url: "{{ item }}"
+    dest: "{{ playbook_dir }}/roles/k8s-master-centos/files"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3 
+  with_items: "{{ k8s_master_scripts }}"
+
+- name: Change Kubernetes version in configure scripts
+  replace:
+    path: "{{ playbook_dir }}/roles/k8s-master-centos/files/configure_k8s_master.sh"
+    regexp: "kubeversion=\"v[1-9].[0-9].[0-9]\""
+    replace: "kubeversion=\"v{{ k8s_version }}\""
+
+- block: 
+    - name: Fetch weave images from dockerhub
+      docker_image:
+        name: "{{ item }}"
+        state: present
+        pull: true
+        force: yes
+      register: result
+      until: "'Pulled image' and item in result.actions[0]"
+      delay: 60
+      retries: 3
+      with_items: "{{ weave_images }}" 
+      become: true
+
+    - name: Print weave image names
+      shell: printf "{{ item }}\n" >> imagelist.tmp
+      with_items: "{{ weave_images }}"
+
+    - name: TAR the weave images
+      shell: docker save $(cat imagelist.tmp) -o weave_images_{{ weave_version }}.tar
+      become: true
+
+    - name: Remove the .tmp file created to hold image list
+      file: path="{{playbook_dir}}/imagelist.tmp" state=absent
+
+    - name: Move weave_images_{{ weave_version }}.tar into k8s-master role
+      shell: mv {{playbook_dir}}/weave_images_{{ weave_version }}.tar {{ playbook_dir }}/roles/k8s-master-centos/files
+      become: true
+
+    - name: Remove weave images from K8s-localhost
+      docker_image:
+        name: "{{ item }}" 
+        state: absent
+      with_items: "{{ weave_images }}"
+      become: true
+  
+  when: stat_result.stat.exists == false
+
+- name: Fetch the weave .yaml template from GitHub
+  get_url:
+    url: "{{ weave_template_link }}"
+    dest: "{{ playbook_dir }}/roles/k8s-master-centos/files"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+
+## K8S-HOSTS ROLE PREPARATION
+
+- name: Fetch configure_K8s scripts into k8s-host role
+  get_url:
+    url: "{{ item }}"
+    dest: "{{ playbook_dir }}/roles/k8s-hosts-centos/files"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3 
+  with_items: "{{ k8s_host_scripts }}"
+
+- name: Get Current User
+  command: whoami 
+  register: user
+
+- name: Change Folder Permissions
+  file:
+    path: "{{ item }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true
+  with_items:
+    - "{{ playbook_dir }}/roles/k8s-hosts-centos/files"
+    - "{{ playbook_dir }}/roles/k8s-master-centos/files"
+    - "{{ playbook_dir }}/roles/kubernetes-centos/files"

--- a/executor/ansible/roles/k8s-localhost/defaults/main.yml
+++ b/executor/ansible/roles/k8s-localhost/defaults/main.yml
@@ -1,0 +1,67 @@
+---
+##################################################### PREPARATION OF K8S-LOCALHOST BOX #########################################################
+
+deb_local_packages:
+  - docker.io
+
+pip_local_packages:
+  - 'docker-py==1.9.0'
+
+###################################################### PREPARATION OF KUBERNETES ROLE  ##########################################################
+
+# Links for .deb packages that will be installed on all K8s boxes (masters, minions), i.e, 
+# these packages will be copied into kubernetes role's .files
+
+k8s_cni_deb_package: https://packages.cloud.google.com/apt/pool/kubernetes-cni_0.6.0-00_amd64_43460dd3c97073851f84b32f5e8eebdc84fadedb5d5a00d1fc6872f30a4dd42c.deb
+
+k8s_deb_package_alias:
+  - kubeadm.deb
+  - kubectl.deb
+  - kubelet.deb
+
+k8s_log_aggregator_url: https://github.com/wercker/stern/releases/download/1.6.0/stern_linux_amd64 
+
+k8s_log_aggregator: stern
+
+# Container images that needs to be placed on all K8s boxes (masters, minions)
+# These images will be downloaded, tar'ed and pushed into the kubernetes role's .files
+
+k8s_images:
+  - gcr.io/google_containers/pause-amd64:3.0
+  - gcr.io/google_containers/etcd-amd64:3.0.17
+  - gcr.io/google_containers/kube-scheduler-amd64:v{{ k8s_version }}
+  - gcr.io/google_containers/kube-apiserver-amd64:v{{ k8s_version }}
+  - gcr.io/google_containers/kube-controller-manager-amd64:v{{ k8s_version }}
+  - gcr.io/google_containers/kube-proxy-amd64:v{{ k8s_version }}
+  - gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1
+  - gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1
+  - gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1
+
+###################################################### PREPARATION OF K8S-MASTER ROLE ###########################################################
+
+# Links for scripts to be placed into K8s-master role's .files 
+
+k8s_master_scripts: 
+  - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_master.sh
+  #- https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_weave.sh
+  - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_cni.sh
+
+# Container images that needs to be placed in K8s-master box
+# These images will be downloaded, tar'ed and pushed into K8s-master role's .files 
+
+weave_images: 
+  - weaveworks/weave-kube:{{ weave_version }}
+  - weaveworks/weave-npc:{{ weave_version }}
+
+# Link to download default weave template (.yaml) to be placed in roles/kubernetes/templates
+
+weave_template_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/vagrant/boxes/k8s-weave/external/weave-daemonset-k8s-1.6.yaml
+
+###################################################### PREPARATION OF K8S-HOST ROLE #############################################################
+
+# Links for scripts to be placed into K8s-host role's .files
+
+k8s_host_scripts: 
+  - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_host.sh
+
+

--- a/executor/ansible/roles/k8s-localhost/tasks/main.yml
+++ b/executor/ansible/roles/k8s-localhost/tasks/main.yml
@@ -1,0 +1,208 @@
+---
+## K8S-LOCALHOST PREPARATION
+
+- name: Install APT Packages
+  apt: 
+    name: "{{item}}"
+    state: present
+  with_items: "{{deb_local_packages}}"
+  become: true
+  delegate_to: 127.0.0.1
+
+- name: Install PIP Packages
+  pip:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ pip_local_packages }}"
+  delegate_to: 127.0.0.1
+  become: true 
+
+## Common preparation tasks
+
+- name: Create files directory in kubernetes role
+  file:
+    path: "{{ playbook_dir }}/roles/{{item}}/files"
+    state: directory
+    mode: 0755
+  with_items:
+    - kubernetes
+    - k8s-master
+    - k8s-hosts
+
+## kubernetes role preparation
+
+- name: Get .deb package details
+  shell: "curl -s https://packages.cloud.google.com/apt/dists/kubernetes-xenial/main/binary-amd64/Packages | grep _{{ k8s_version }} | awk '{print $2}' | cut -d '/' -f2"
+  register: k8s_deb_packages
+
+- name: Get .deb kubernetes packages google cloud 
+  get_url: 
+    url: "https://packages.cloud.google.com/apt/pool/{{ item.0 }}"
+    dest: "{{ playbook_dir }}/roles/kubernetes/files/{{item.1}}"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+  with_together: 
+    - "{{ k8s_deb_packages.stdout_lines }}"
+    - "{{ k8s_deb_package_alias }}"
+
+- name: Get CNI .deb package from google cloud
+  get_url:
+    url: "{{k8s_cni_deb_package}}"
+    dest: "{{ playbook_dir }}/roles/kubernetes/files/kubernetes-cni.deb"
+    force: yes
+  register: result
+  until: "'OK' in result.msg"
+  delay: 5
+  retries: 3
+
+- name: Check whether deb packages and images are already downloaded
+  stat: 
+    path: "{{ playbook_dir }}/roles/kubernetes/files/k8s_images_{{ k8s_version }}.tar"
+  register: stat_result
+
+- block:
+    - name: Fetch K8s images from gcr.io/google_containers
+      docker_image: 
+        name: "{{item}}"
+        state: present
+        pull: true
+        force: yes
+      register: result
+      until: "'Pulled image' and item in result.actions[0]"
+      delay: 60
+      retries: 3  
+      with_items: "{{ k8s_images }}"
+      become: true
+
+    - name: Print K8s image names
+      shell: printf "{{ item }}\n" >> imagelist.tmp
+      with_items: "{{ k8s_images }}"
+
+    - name: TAR the K8s images 
+      shell: docker save $(cat imagelist.tmp) -o k8s_images_{{ k8s_version }}.tar
+      become: true
+
+    - name: Remove the .tmp file created to hold image list
+      file: path="{{playbook_dir}}/imagelist.tmp" state=absent
+
+    - name: Move K8s_images_{{ k8s_version }}.tar into kubernetes role
+      shell: mv {{playbook_dir}}/k8s_images_{{ k8s_version }}.tar {{ playbook_dir }}/roles/kubernetes/files
+      become: true
+
+    - name: Remove K8s images from K8s-localhost
+      docker_image:
+        name: "{{ item }}" 
+        state: absent
+      with_items: "{{ k8s_images }}"
+      become: true
+  
+  when: stat_result.stat.exists == false 
+
+## K8S-MASTER ROLE PREPARATION
+
+#- name: Get Log Aggregator
+#  get_url:
+#    url: "{{k8s_log_aggregator_url}}"
+#    dest: "{{ playbook_dir }}/roles/k8s-master/files/{{k8s_log_aggregator}}"
+#    force: yes
+#  register: result
+#  until: "'OK' in result.msg"
+#  delay: 5
+#  retries: 3
+
+- name: Fetch configure_K8s scripts into k8s-master role
+  get_url: 
+    url: "{{ item }}"
+    dest: "{{ playbook_dir }}/roles/k8s-master/files"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3 
+  with_items: "{{ k8s_master_scripts }}"
+
+- name: Change Kubernetes version in configure scripts
+  replace:
+    path: "{{ playbook_dir }}/roles/k8s-master/files/configure_k8s_master.sh"
+    regexp: "kubeversion=\"v[1-9].[0-9].[0-9]\""
+    replace: "kubeversion=\"v{{ k8s_version }}\""
+
+- block: 
+    - name: Fetch weave images from dockerhub
+      docker_image:
+        name: "{{ item }}"
+        state: present
+        pull: true
+        force: yes
+      register: result
+      until: "'Pulled image' and item in result.actions[0]"
+      delay: 60
+      retries: 3
+      with_items: "{{ weave_images }}" 
+      become: true
+
+    - name: Print weave image names
+      shell: printf "{{ item }}\n" >> imagelist.tmp
+      with_items: "{{ weave_images }}"
+
+    - name: TAR the weave images
+      shell: docker save $(cat imagelist.tmp) -o weave_images_{{ weave_version }}.tar
+      become: true
+
+    - name: Remove the .tmp file created to hold image list
+      file: path="{{playbook_dir}}/imagelist.tmp" state=absent
+
+    - name: Move weave_images_{{ weave_version }}.tar into k8s-master role
+      shell: mv {{playbook_dir}}/weave_images_{{ weave_version }}.tar {{ playbook_dir }}/roles/k8s-master/files
+      become: true
+
+    - name: Remove weave images from K8s-localhost
+      docker_image:
+        name: "{{ item }}" 
+        state: absent
+      with_items: "{{ weave_images }}"
+      become: true
+  
+  when: stat_result.stat.exists == false
+
+- name: Fetch the weave .yaml template from GitHub
+  get_url:
+    url: "{{ weave_template_link }}"
+    dest: "{{ playbook_dir }}/roles/k8s-master/files"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+
+## K8S-HOSTS ROLE PREPARATION
+
+- name: Fetch configure_K8s scripts into k8s-host role
+  get_url:
+    url: "{{ item }}"
+    dest: "{{ playbook_dir }}/roles/k8s-hosts/files"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3 
+  with_items: "{{ k8s_host_scripts }}"
+
+- name: Get Current User
+  command: whoami 
+  register: user
+
+- name: Change Folder Permissions
+  file:
+    path: "{{ item }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true
+  with_items:
+    - "{{ playbook_dir }}/roles/k8s-hosts/files"
+    - "{{ playbook_dir }}/roles/k8s-master/files"
+    - "{{ playbook_dir }}/roles/kubernetes/files"

--- a/executor/ansible/roles/k8s-master-centos/defaults/main.yml
+++ b/executor/ansible/roles/k8s-master-centos/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not change the order of the scripts.
+# They have to be run in the order defined below.
+
+configure_scripts:
+  - configure_k8s_master.sh
+  - configure_k8s_cni.sh
+
+weave_depends:
+  - weave_images_{{ weave_version }}.tar
+  - weave-daemonset-k8s-1.6.yaml
+
+k8s_images: k8s_images_{{ k8s_version }}.tar
+
+weave_images_path: "{{ ansible_env.HOME}}/setup/weave"
+
+k8s_images_path: "{{ ansible_env.HOME}}/setup/k8s"
+
+k8s_logs_path: "{{ ansible_env.HOME}}/setup/logs"
+
+k8s_log_aggregator: stern
+# Do not change the order of the packages
+# They have to be installed in the order defined below.
+
+k8s_rpmd_packages:
+  - kubelet.rpm
+  - kubernetes-cni.rpm
+  - kubectl.rpm
+  - kubeadm.rpm
+

--- a/executor/ansible/roles/k8s-master-centos/k8s.conf
+++ b/executor/ansible/roles/k8s-master-centos/k8s.conf
@@ -1,0 +1,2 @@
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1

--- a/executor/ansible/roles/k8s-master-centos/meta/main.yml
+++ b/executor/ansible/roles/k8s-master-centos/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: kubernetes-centos }
+

--- a/executor/ansible/roles/k8s-master-centos/tasks/main.yml
+++ b/executor/ansible/roles/k8s-master-centos/tasks/main.yml
@@ -1,0 +1,172 @@
+---
+- name: Get Current User
+  command: whoami
+  register: user
+
+- stat:
+    path: "{{ weave_images_path }}"
+  register: status
+
+- name: Create Directory
+  file:
+    path: "{{ weave_images_path }}"
+    state: directory
+  become: true
+  when: status.stat.isdir is not defined
+
+- stat:
+    path: "{{ weave_images_path }}"
+  register: status
+
+- name: Change Folder Permissions
+  file:
+    path: "{{ weave_images_path }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true
+  when: status.stat.isdir is defined and status.stat.isdir
+
+- stat:
+    path: "{{ k8s_logs_path }}"
+  register: status
+
+- name: Create Directory
+  file:
+    path: "{{ k8s_logs_path }}"
+    state: directory
+  become: true
+  when: status.stat.isdir is not defined
+
+- stat:
+    path: "{{ k8s_logs_path }}"
+  register: status
+
+- name: Change Folder Permissions
+  file:
+    path: "{{ k8s_logs_path }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true
+  when: status.stat.isdir is defined and status.stat.isdir
+
+- name: Copy log aggregator to remote
+  copy:
+    src: "{{ k8s_log_aggregator }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    dest: /usr/local/bin
+    mode: "u+rwx"
+  become: true
+
+- block:
+   - name: Copy Pod YAML to remote
+     copy:
+       src: "{{ weave_depends[1] }}"
+       dest: "{{ weave_images_path }}"
+
+   - name: Copy Script to remote
+     copy:
+       src: "{{ configure_scripts[1] }}"
+       dest: "{{ k8s_images_path }}"
+       mode: "u+rwx"
+
+   - name: Copy TAR to remote
+     copy:
+       src: "{{ weave_depends[0] }}"
+       dest: "{{ weave_images_path }}"
+     become: true
+
+   - name: Load k8s images from Archive
+     command: docker load --input "{{ k8s_images }}"
+     args:
+       chdir: "{{ k8s_images_path }}"
+     become: true
+
+   - name: Load weave images from Archive
+     command: docker load --input "{{ weave_depends[0] }}"
+     args:
+       chdir: "{{ weave_images_path }}"
+     become: true
+
+   - name: Install rpmd packages
+     yum:
+       name: "{{ k8s_images_path }}/{{ item }}"
+     with_items: "{{ k8s_rpmd_packages }}"
+     become: true
+ 
+   - name: kubeadm reset before init
+     command: kubeadm reset
+     become: true
+  
+   - name: Copy the volume claim to kube master
+     copy:
+       src: "{{ k8s_conf }}"
+       dest: "{{ sysctl_path }}"
+     become: true
+ 
+   - name:
+     shell: |
+       sed -i -E 's/--cgroup-driver=systemd/--cgroup-driver=cgroupfs/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+       sysctl --system
+       systemctl start kubelet && systemctl enable kubelet
+     become: true
+
+   - name: kubeadm init
+     script: "{{ configure_scripts[0] }}"
+     become: true
+
+  when: build_type == "normal"
+
+- block:
+   - name: Change file modes
+     file:
+       path: "{{k8s_images_path}}/{{item}}"
+       mode: "u+rwx"
+     become: true
+     with_items: "{{ configure_scripts}}"
+
+   - name: kubeadm init
+     shell: "{{ k8s_images_path }}/{{ configure_scripts[0] }}"
+     args:
+       executable: /bin/bash
+     become: true
+  when: build_type == "quick"
+
+- name: Get Current User
+  command: whoami
+  register: user
+
+- name: Copy k8s credentials to $HOME 
+  copy:
+    src: "/etc/kubernetes/admin.conf" 
+    remote_src: True
+    dest: "{{ ansible_env.HOME}}"
+  become: true
+
+- name: Change file permissions
+  file:
+    path: "{{ ansible_env.HOME }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"     
+    state: directory
+  become: true
+
+- name: Update KUBECONFIG in .profile
+  lineinfile:
+    destfile: "{{ansible_env.HOME}}/.bash_profile"
+    line: export KUBECONFIG=$HOME/admin.conf
+    state: present
+
+- name: Patch kube-proxy for CNI Networks
+  shell: source ~/.bash_profile; "{{ k8s_images_path }}/{{ configure_scripts[1] }}" 
+  args:
+    executable: /bin/bash
+  when: build_type == "normal"
+
+- name: Patch kube-proxy for CNI Networks
+  shell: source ~/.bash_profile; "{{ k8s_images_path }}/{{ configure_scripts[1] }}"
+  args:
+    executable: /bin/bash
+  when: build_type == "quick"

--- a/executor/ansible/roles/k8s-master/defaults/main.yml
+++ b/executor/ansible/roles/k8s-master/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+# Do not change the order of the scripts.
+# They have to be run in the order defined below.
+
+configure_scripts:
+  - configure_k8s_master.sh
+  - configure_k8s_cni.sh
+
+weave_depends:
+  - weave_images_{{ weave_version }}.tar
+  - weave-daemonset-k8s-1.6.yaml
+
+k8s_images: k8s_images_{{ k8s_version }}.tar
+
+weave_images_path: "{{ ansible_env.HOME}}/setup/weave"
+
+k8s_images_path: "{{ ansible_env.HOME}}/setup/k8s"
+
+k8s_logs_path: "{{ ansible_env.HOME}}/setup/logs"
+
+k8s_log_aggregator: stern
+# Do not change the order of the packages
+# They have to be installed in the order defined below.
+
+k8s_dpkg_packages:
+  - kubelet.deb
+  - kubernetes-cni.deb
+  - kubectl.deb
+  - kubeadm.deb
+

--- a/executor/ansible/roles/k8s-master/meta/main.yml
+++ b/executor/ansible/roles/k8s-master/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: kubernetes }
+

--- a/executor/ansible/roles/k8s-master/tasks/main.yml
+++ b/executor/ansible/roles/k8s-master/tasks/main.yml
@@ -1,0 +1,159 @@
+---
+- name: Get Current User
+  command: whoami
+  register: user
+
+- stat:
+    path: "{{ weave_images_path }}"
+  register: status
+
+- name: Create Directory
+  file:
+    path: "{{ weave_images_path }}"
+    state: directory
+  become: true
+  when: status.stat.isdir is not defined
+
+- stat:
+    path: "{{ weave_images_path }}"
+  register: status
+
+- name: Change Folder Permissions
+  file:
+    path: "{{ weave_images_path }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true
+  when: status.stat.isdir is defined and status.stat.isdir
+
+- stat:
+    path: "{{ k8s_logs_path }}"
+  register: status
+
+- name: Create Directory
+  file:
+    path: "{{ k8s_logs_path }}"
+    state: directory
+  become: true
+  when: status.stat.isdir is not defined
+
+- stat:
+    path: "{{ k8s_logs_path }}"
+  register: status
+
+- name: Change Folder Permissions
+  file:
+    path: "{{ k8s_logs_path }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true
+  when: status.stat.isdir is defined and status.stat.isdir
+
+#- name: Copy log aggregator to remote
+#  copy:
+#    src: "{{ k8s_log_aggregator }}"
+#    owner: "{{ user.stdout }}"
+#    group: "{{ user.stdout }}"
+#    dest: /usr/local/bin
+#    mode: "u+rwx"
+#  become: true
+
+- block:
+   - name: Copy Pod YAML to remote
+     copy:
+       src: "{{ weave_depends[1] }}"
+       dest: "{{ weave_images_path }}"
+
+   - name: Copy Script to remote
+     copy:
+       src: "{{ configure_scripts[1] }}"
+       dest: "{{ k8s_images_path }}"
+       mode: "u+rwx"
+
+   - name: Copy TAR to remote
+     copy:
+       src: "{{ weave_depends[0] }}"
+       dest: "{{ weave_images_path }}"
+     become: true
+
+   - name: Load images from Archive
+     command: docker load --input "{{ k8s_images }}"
+     args:
+       chdir: "{{ k8s_images_path }}"
+     become: true
+
+   - name: Load images from Archive
+     command: docker load --input "{{ weave_depends[0] }}"
+     args:
+       chdir: "{{ weave_images_path }}"
+     become: true
+
+   - name: Install deb packages
+     apt:
+       deb: "{{ k8s_images_path }}/{{ item }}"
+     with_items: "{{ k8s_dpkg_packages }}"
+     become: true
+ 
+   - name: kubeadm reset before init
+     command: kubeadm reset
+     become: true
+
+   - name: kubeadm init
+     script: "{{ configure_scripts[0] }}"
+     become: true
+
+  when: build_type == "normal"
+
+- block:
+   - name: Change file modes
+     file:
+       path: "{{k8s_images_path}}/{{item}}"
+       mode: "u+rwx"
+     become: true
+     with_items: "{{ configure_scripts}}"
+
+   - name: kubeadm init
+     shell: "{{ k8s_images_path }}/{{ configure_scripts[0] }}"
+     args:
+       executable: /bin/bash
+     become: true
+  when: build_type == "quick"
+
+- name: Get Current User
+  command: whoami
+  register: user
+
+- name: Copy k8s credentials to $HOME 
+  copy:
+    src: "/etc/kubernetes/admin.conf" 
+    remote_src: True
+    dest: "{{ ansible_env.HOME}}"
+  become: true
+
+- name: Change file permissions
+  file:
+    path: "{{ ansible_env.HOME }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"     
+    state: directory
+  become: true
+
+- name: Update KUBECONFIG in .profile
+  lineinfile:
+    destfile: "{{ansible_env.HOME}}/.profile"
+    line: export KUBECONFIG=$HOME/admin.conf
+    state: present
+
+- name: Patch kube-proxy for CNI Networks
+  shell: source ~/.profile; "{{ k8s_images_path }}/{{ configure_scripts[1] }}" 
+  args:
+    executable: /bin/bash
+  when: build_type == "normal"
+
+- name: Patch kube-proxy for CNI Networks
+  shell: source ~/.profile; "{{ k8s_images_path }}/{{ configure_scripts[1] }}"
+  args:
+    executable: /bin/bash
+  when: build_type == "quick"

--- a/executor/ansible/roles/k8s-openebs-cleanup/defaults/main.yml
+++ b/executor/ansible/roles/k8s-openebs-cleanup/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+openebs_operator_alias: openebs-operator.yaml 
+
+openebs_storageclasses_alias: openebs-storageclasses.yaml

--- a/executor/ansible/roles/k8s-openebs-cleanup/tasks/main.yml
+++ b/executor/ansible/roles/k8s-openebs-cleanup/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Delete the openebs storage classes
+  shell: source ~/.profile; kubectl delete -f {{ openebs_storageclasses_alias }}
+  args: 
+    executable: /bin/bash
+
+- name: Confirm storage classes have been deleted
+  shell: source ~/.profile; kubectl get sc
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'openebs.io/provisioner-iscsi' not in result.stdout" 
+  delay: 10
+  retries: 6
+
+- name: Delete the openebs operator 
+  shell: source ~/.profile; kubectl delete -f {{ openebs_operator_alias }}
+  args: 
+    executable: /bin/bash
+
+- name: Confirm pod has been deleted
+  shell: source ~/.profile; kubectl get pods 
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'maya-apiserver' or 'openebs-provisioner' not in result.stdout"
+  delay: 10
+  retries: 6
+
+
+  
+

--- a/executor/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
+++ b/executor/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
@@ -1,0 +1,4 @@
+---
+charts: https://openebs.github.io/charts/
+namespace: openebs
+update_deploy_file: update.json

--- a/executor/ansible/roles/k8s-openebs-operator-helm/files/update.json
+++ b/executor/ansible/roles/k8s-openebs-operator-helm/files/update.json
@@ -1,0 +1,6 @@
+{
+    "spec": {
+       "template": {
+            "spec": {
+                "serviceAccountName": "tiller"}}}}
+

--- a/executor/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
+++ b/executor/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
@@ -1,0 +1,126 @@
+---
+- name: Install helm
+  shell: curl -Lo /tmp/helm-linux-amd64.tar.gz https://kubernetes-helm.storage.googleapis.com/helm-v2.6.2-linux-amd64.tar.gz; tar -xvf /tmp/helm-linux-amd64.tar.gz -C /tmp/; chmod +x  /tmp/linux-amd64/helm && sudo mv /tmp/linux-amd64/helm /usr/local/bin/
+  args:
+    executable: /bin/bash
+  
+#- name: Check if helm is installed
+#  shell: helm version
+#  args:
+#    executable: /bin/bash
+#  register: helm_version
+#  until: "'version.Version' in helm_version.stdout"
+#  delay: 10
+#  retries: 3
+
+- name: Tiller setup
+  shell: helm init
+  args:
+    executable: /bin/bash
+  register: tiller_out
+  until: "'Happy Helming' in tiller_out.stdout"
+  delay: 10
+  retries: 6
+
+- name: Check if tiller is configured
+  shell: helm version
+  args: 
+    executable: /bin/bash
+  register: tiller_version
+  until: "'Server: &version.Version' in tiller_version.stdout"
+  delay: 20
+  retries: 5
+
+- name: Creating service account
+  shell: kubectl -n kube-system create sa tiller
+  args:
+    executable: /bin/bash
+  register: tiller
+  until: "'serviceaccount \"tiller\" created' in tiller.stdout"
+  delay: 10
+  retries: 6
+
+- name: Create cluster rolebinding
+  shell: kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+  args:
+    executable: /bin/bash
+  register: crb
+  until: "'clusterrolebinding \"tiller\" created' in crb.stdout"
+  delay: 20
+  retries: 5
+
+- name: Getting home directory in kubernetes master
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+
+- name: Copy yaml file to kubernetes master
+  copy:
+    src: "{{ update_deploy_file }}"
+    dest: "{{ result_kube_home.stdout }}"
+
+- name : Update the deployment
+  shell: kubectl -n kube-system patch deploy/tiller-deploy -p "$(cat {{ update_deploy_file }})"
+  args:
+    executable: /bin/bash
+  register: tiller_deploy
+  until: "'deployment \"tiller-deploy\" patched' in tiller_deploy.stdout"
+  delay: 20
+  retries: 6
+
+- name: Adding OpenEBS charts to repo
+  shell: helm repo add openebs-charts "{{ charts }}"
+  args:
+    executable: /bin/bash
+  register: repos
+  until: "'\"openebs-charts\" has been added to your repositories' in repos.stdout"
+  delay: 20
+  retries: 6
+
+- name: Update the repo
+  shell: helm repo update
+  args:
+    executable: /bin/bash
+  register: update
+  until: "'Update Complete' in update.stdout"
+  delay: 20
+  retries: 6
+ 
+- name: Install openebs
+  shell: helm install openebs-charts/openebs
+  args:
+    executable: /bin/bash
+  register: openebs_out
+  until: "'The OpenEBS has been installed' in openebs_out.stdout"
+  delay: 20
+  retries: 6  
+
+- name: Check if provisioner is deployed
+  shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-provisioner" 
+  args:
+    executable: /bin/bash
+  register: deployment
+  until: "'Running' in deployment.stdout"
+  delay: 20
+  retries: 6
+
+- name: Check if maya-apiserver is deployed
+  shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-maya-apiserver"
+  args:
+    executable: /bin/bash
+  register: api_server
+  until: "'Running' in api_server.stdout"
+  delay: 20
+  retries: 6
+
+- name: Check if storage classes are created
+  shell: kubectl get sc
+  args:
+    executable: /bin/bash
+  register: storage_classes
+  until: "'openebs-cassandra' in storage_classes.stdout"
+  delay: 10
+  retries: 3
+
+

--- a/executor/ansible/roles/k8s-openebs-operator/defaults/main.yml
+++ b/executor/ansible/roles/k8s-openebs-operator/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+openebs_operator_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
+
+openebs_operator_alias: openebs-operator.yaml 
+
+openebs_storageclasses_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml
+
+openebs_storageclasses_alias: openebs-storageclasses.yaml
+
+# Image tag for openebs containers
+# Accepted entries (ci, latest): Default: latest
+test_tag: latest

--- a/executor/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/executor/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -1,0 +1,117 @@
+---
+- name: Download YAML for openebs operator
+  get_url:
+    url: "{{ openebs_operator_link }}"
+    dest: "{{ ansible_env.HOME }}/{{ openebs_operator_alias }}"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+
+- name: Change m-apiserver image to desired tag in operator YAML
+  replace:
+    path: "{{ ansible_env.HOME }}/{{ openebs_operator_alias }}" 
+    regexp: "{{item}}:[\\w.-]+"
+    replace: "{{item}}:{{ test_tag }}"
+  with_items: 
+    - m-apiserver
+    - jiva
+    - openebs-k8s-provisioner
+
+- name: Get kubernetes master name
+  shell: hostname
+  args:
+    executable: /bin/bash
+  register: result
+
+- name: Get kubernetes master status
+  shell: source ~/.profile; kubectl get nodes | grep {{ result.stdout.lower()}} | awk '{print $2}'
+  args:
+    executable: /bin/bash
+  register: result
+  until:  result.stdout == 'Ready'
+  delay: 60
+  retries: 10 
+  ignore_errors: true  
+
+- name: 
+  debug: 
+    msg: "Ending play, K8S Master NOT READY"
+  when: result.stdout != "Ready"
+
+- name: Ending Playbook Run - K8S master is NOT READY
+  meta: end_play
+  when: result.stdout != "Ready"
+
+#- name: Start the log aggregator to capture operator logs
+#  shell: source ~/.profile; nohup stern "maya*|openebs*" --since 1m >"{{ ansible_env.HOME }}/setup/logs/operator.log" &
+#  args:
+#    executable: /bin/bash
+
+- name: Deploy the openebs operator yml
+  shell: >
+    source ~/.profile; 
+    kubectl apply -f {{ openebs_operator_alias }} 
+    | grep deployment | awk '{print $2}'
+    | tr -d '"'
+  args:
+    executable: /bin/bash
+  register: labels
+
+- name: Confirm provisioner & apiserver are running
+  shell: source ~/.profile; kubectl get pods --selector=name={{item}} | grep Running |wc -l 
+  args:
+    executable: /bin/bash
+  register: result_pod
+  until: result_pod.stdout|int >= 1
+  delay: 120
+  retries: 15
+  with_items: "{{ labels.stdout_lines }}"
+
+- name: Get maya-apiserver pod name
+  shell: source ~/.profile; kubectl get pods --selector=name=maya-apiserver 
+  args:
+    executable: /bin/bash
+  register: result_name
+
+- name: Create fact for pod name
+  set_fact: 
+    pod_name: "{{ result_name.stdout_lines[1].split()[0] }}"
+
+- name: Confirm that maya-cli is available in the maya-apiserver pod
+  #shell: source ~/.profile; kubectl exec {{pod_name}} -c maya-apiserver -- mayactl version
+  shell: source ~/.profile; kubectl exec {{pod_name}} -c maya-apiserver -- maya version
+  args:
+    executable: /bin/bash
+  register: result_vers
+  failed_when: "'Maya' not in result_vers.stdout"
+
+- name: Download YAML for openebs storage classes
+  get_url:
+    url: "{{ openebs_storageclasses_link }}"
+    dest: "{{ ansible_env.HOME }}/{{ openebs_storageclasses_alias }}"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+
+- name: Deploy the openebs storageclasses yml
+  shell: source ~/.profile; kubectl apply -f {{ openebs_storageclasses_alias }}
+  args:
+    executable: /bin/bash
+
+- name: Confirm that openebs storage classes are created
+  shell: source ~/.profile; kubectl get sc
+  args:
+    executable: /bin/bash
+  register: result_sc
+  until: "'openebs.io/provisioner-iscsi' in result_sc.stdout"
+  delay: 10
+  retries: 6
+
+#- name: Terminate the log aggregator
+#  shell: source ~/.profile; killall stern
+#  args:
+#    executable: /bin/bash

--- a/executor/ansible/roles/k8s-openebs-uninstall-helm/defaults/main.yaml
+++ b/executor/ansible/roles/k8s-openebs-uninstall-helm/defaults/main.yaml
@@ -1,0 +1,2 @@
+
+soft_uninstall: yes

--- a/executor/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
+++ b/executor/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
@@ -1,0 +1,40 @@
+---
+# From the charts list, finding out the OpenEBS chart name.
+- name: Getting OpenEBS chart name
+  shell: helm ls --all | grep openebs | grep DEPLOYED | awk '{print $1}'
+  args:
+    executable: /bin/bash
+  register: charts
+
+- name: Uninstall OpenEBS
+  shell: helm del --purge "{{charts.stdout}}"
+  args:
+    executable: /bin/bash
+  register: purge_out
+  until: "'deleted' in purge_out.stdout"
+  delay: 20
+  retries: 10
+  when: "{{soft_uninstall}}" == "no"
+
+- name: Uninstall OpenEBS
+  shell: helm del "{{charts.stdout}}"
+  args:
+    executable: /bin/bash
+  register: purge_out
+  until: "'deleted' in purge_out.stdout"
+  delay: 20
+  retries: 10
+  when: "{{soft_uninstall}}" == "yes"
+
+
+- name: Check if OpenEBS namespace is deleted.
+  shell: kubectl get ns 
+  args:
+    executable: /bin/bash
+  register: ns_out
+  until: "'openebs' not in ns_out.stdout"
+  delay: 20
+  retries: 10 
+ 
+  
+

--- a/executor/ansible/roles/kubernetes-centos/defaults/main.yml
+++ b/executor/ansible/roles/kubernetes-centos/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+k8s_rpm_packages:
+  - epel-release
+  - unzip
+  - curl
+  - wget
+  - socat
+  - ebtables
+
+k8s_images_path: "{{ ansible_env.HOME}}/setup/k8s"
+k8s_conf: k8s.conf
+sysctl_path: /etc/sysctl.d/
+k8s_images: k8s_images_{{ k8s_version }}.tar
+
+k8s_rpmd_packages:
+  - kubeadm.rpm
+  - kubectl.rpm
+  - kubelet.rpm 
+  - kubernetes-cni.rpm
+

--- a/executor/ansible/roles/kubernetes-centos/tasks/main.yml
+++ b/executor/ansible/roles/kubernetes-centos/tasks/main.yml
@@ -1,0 +1,94 @@
+---
+- block:
+   - name: Add Kubernetes yum repository
+     yum_repository:
+       name: Kubernetes
+       description: Kube YUM repo
+       baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64 
+       gpgkey: https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+     become: true
+
+   - name: Install RPM dependencies
+     shell: "yum install -y yum-utils device-mapper-persistent-data lvm2 socat ebtables"
+     become: true
+
+   - name: Add docker repo
+     shell: "yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo"
+     become: true
+
+   - name: Install RPM Packages
+     shell: "yum install -y --setopt=obsoletes=0 docker-ce-17.03.0.ce-1.el7.centos docker-ce-selinux-17.03.0.ce-1.el7.centos"
+     become: true
+
+   - name: get-pip
+     shell: "curl 'https://bootstrap.pypa.io/get-pip.py' -o 'get-pip.py'"
+     become: true
+
+   - name: Install pip
+     shell: "python get-pip.py"
+     become: true
+
+   - name: Install RPM Packages
+     yum:
+       name: "{{ item }}" 
+       state: present
+     become: true
+     with_items: "{{ k8s_rpm_packages }}"
+  
+   - name: Disable swap
+     shell: |
+       swapoff -a
+       sed -i '/swap/s/^/#/g' /etc/fstab
+       setenforce 0
+       systemctl start docker && systemctl enable docker
+     become: true
+
+   - name: Install jq-devel
+     yum:
+       name: jq-devel
+       state: present
+     become: true
+
+  when: build_type == "normal"
+
+- name: Get Current User
+  command: whoami
+  register: user
+
+- stat:
+    path: "{{ k8s_images_path }}"
+  register: status
+
+- name: Create Directory
+  file:
+    path: "{{ k8s_images_path }}"
+    state: directory
+  become: true
+  when: status.stat.isdir is not defined
+
+- stat:
+    path: "{{ k8s_images_path }}"
+  register: status
+
+- name: Change Folder Permissions
+  file:
+    path: "{{ k8s_images_path }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true
+  when: status.stat.isdir is defined and status.stat.isdir
+
+- block:
+   - name: Copy TAR to remote
+     copy:
+       src: "{{ k8s_images }}"
+       dest: "{{ k8s_images_path }}"
+
+   - name: Copy local rpm files to K8s-Master and K8s-Minions
+     copy:
+       src: "{{ item }}"
+       dest: "{{ k8s_images_path }}"
+     with_items: "{{ k8s_rpmd_packages }}"
+
+  when: build_type == "normal"

--- a/executor/ansible/roles/kubernetes/defaults/main.yml
+++ b/executor/ansible/roles/kubernetes/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+k8s_deb_packages:
+  - unzip
+  - curl
+  - wget
+  - apt-transport-https
+  - docker-engine
+  - jq
+  - socat
+  - ebtables
+
+k8s_images_path: "{{ ansible_env.HOME}}/setup/k8s"
+
+k8s_images: k8s_images_{{ k8s_version }}.tar
+
+k8s_dpkg_packages:
+  - kubeadm.deb
+  - kubectl.deb
+  - kubelet.deb 
+  - kubernetes-cni.deb  
+

--- a/executor/ansible/roles/kubernetes/tasks/main.yml
+++ b/executor/ansible/roles/kubernetes/tasks/main.yml
@@ -1,0 +1,74 @@
+---
+- block:
+   - name: Get Package Updates
+     apt:
+       update_cache: yes
+     become: true
+
+   - name: Add apt-key
+     apt_key:
+       url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+       state: present
+     become: true
+
+   - name: Add Kubernetes apt repository
+     apt_repository:
+       repo: deb http://apt.kubernetes.io/ kubernetes-xenial main
+       state: present
+     become: true
+
+   - name: Get Package Updates
+     apt:
+       update_cache: yes
+     become: true
+
+   - name: Install APT Packages
+     apt:
+       name: "{{ item }}" 
+       state: present
+     become: true
+     with_items: "{{ k8s_deb_packages }}"
+  
+  when: build_type == "normal"
+
+- name: Get Current User
+  command: whoami
+  register: user
+
+- stat:
+    path: "{{ k8s_images_path }}"
+  register: status
+
+- name: Create Directory
+  file:
+    path: "{{ k8s_images_path }}"
+    state: directory
+  become: true
+  when: status.stat.isdir is not defined
+
+- stat:
+    path: "{{ k8s_images_path }}"
+  register: status
+
+- name: Change Folder Permissions
+  file:
+    path: "{{ k8s_images_path }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true
+  when: status.stat.isdir is defined and status.stat.isdir
+
+- block:
+   - name: Copy TAR to remote
+     copy:
+       src: "{{ k8s_images }}"
+       dest: "{{ k8s_images_path }}"
+
+   - name: Copy local deb files to K8s-Master and K8s-Minions
+     copy:
+       src: "{{ item }}"
+       dest: "{{ k8s_images_path }}"
+     with_items: "{{ k8s_dpkg_packages }}"
+
+  when: build_type == "normal"

--- a/executor/ansible/roles/logging/tasks/main.yml
+++ b/executor/ansible/roles/logging/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: Generate a unique name for the folder
+  shell: echo "$(date +%Y%m%d_%H%M%S)"
+  register: log_folder
+
+- name: Create a unique folder to copy logs
+  file:
+    path: "{{ playbook_dir }}/roles/logging/{{log_folder.stdout}}"
+    state: directory
+    mode: 0755
+
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: use find to get the files list which you want to copy/fetch
+  find: 
+    paths: "{{ result_kube_home.stdout }}/setup/logs"
+  register: file_2_fetch
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: use fetch to get the files
+  fetch:
+    src: "{{ item.path }}"
+    dest: "{{ playbook_dir }}/roles/logging/{{log_folder.stdout}}"
+    flat: yes
+  with_items: "{{ file_2_fetch.files }}"  
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: tar the logdir to generate a support bundle 
+  archive: 
+    path: "{{ playbook_dir }}/roles/logging/{{log_folder.stdout}}"
+    dest: "{{ playbook_dir }}/roles/logging/{{log_folder.stdout}}.tgz"
+
+- name: remove the source logdir post archival
+  file:  
+    path: "{{ playbook_dir }}/roles/logging/{{log_folder.stdout}}"
+    state: absent 
+
+- name: Cleanup the logs directory on kube-master 
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ file_2_fetch.files }}"
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/executor/ansible/roles/prerequisites/defaults/main.yml
+++ b/executor/ansible/roles/prerequisites/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+pip_pre_packages:
+  - paramiko
+  - configparser
+
+

--- a/executor/ansible/roles/prerequisites/tasks/main.yml
+++ b/executor/ansible/roles/prerequisites/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Install PIP Packages
+  pip:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ pip_pre_packages }}"
+  delegate_to: 127.0.0.1
+  become: true

--- a/executor/ansible/run_litmus.sh
+++ b/executor/ansible/run_litmus.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+
+# TODO
+# Functions : a) Ansible health-check b) K8s health-check
+# Improved Error handling 
+
+###################################
+# Perform a sample Health check   #
+###################################
+
+# Is ansible present, if not install
+if [ ! $(which ansible) ]; then
+  echo "Please install ansible..(pip install ansible)"
+  exit 1
+fi
+
+# Is inventory generated?
+if [ ! -s inventory/hosts ]; then
+  echo "Inventory file is not available.."
+  echo "Generate inventory w/ host details..(Edit machines.in, Run pre-requisites.yml)" 
+  exit 1
+fi 
+
+###################################
+#     Setup Storage Provider      # 
+###################################
+
+storage=$(grep "provider" inventory/group_vars/all.yml | cut -d ":" -f 2 | xargs) 
+ansible-playbook provider/$storage/setup-$storage.yml
+
+###################################
+#     Run Litmus Test Suite       #
+###################################
+
+ansible-playbook litmus_playbook.yml
+
+

--- a/executor/ansible/setup/pre-requisites.yml
+++ b/executor/ansible/setup/pre-requisites.yml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+
+  roles:
+    - inventory
+      
+

--- a/executor/ansible/setup/setup-ara.yml
+++ b/executor/ansible/setup/setup-ara.yml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+  roles:
+      - {role: ara}
+
+
+

--- a/executor/ansible/setup/setup-kubernetes.yml
+++ b/executor/ansible/setup/setup-kubernetes.yml
@@ -1,0 +1,16 @@
+---
+- hosts: localhost
+  roles:
+    - {role: k8s-localhost, when: build_type == "normal" and ansible_distribution == 'Ubuntu'} 
+    - {role: k8s-localhost-centos, when: build_type == "normal" and ansible_distribution == 'CentOS'} 
+
+- hosts: kubernetes-kubemasters
+  roles:
+    - {role: k8s-master, when: ansible_distribution == 'Ubuntu'}
+    - {role: k8s-master-centos, when: ansible_distribution == 'CentOS'}
+
+- hosts: kubernetes-kubeminions
+  roles: 
+    - {role: k8s-hosts, when: ansible_distribution == 'Ubuntu'} 
+    - {role: k8s-hosts-centos, when: ansible_distribution == 'CentOS'}
+

--- a/executor/ansible/utils/GetFiles.yaml
+++ b/executor/ansible/utils/GetFiles.yaml
@@ -1,0 +1,17 @@
+---
+- name: Obtain list of Kubernetes test job specifications
+  find:
+    paths: "{{ dir }}"
+    patterns: "{{ expr }}"
+    recurse: yes
+    use_regex: yes
+  register: result
+
+- name: Initialize an empty list for our files
+  set_fact:
+    files: []
+
+- name: Check output of files obtained
+  set_fact:
+    files: "{{ files }} + [ '{{ result.files[item|int].path }}' ]"
+  with_sequence: start=0 count="{{result.matched}}"

--- a/executor/ansible/utils/RunTest.yaml
+++ b/executor/ansible/utils/RunTest.yaml
@@ -1,0 +1,73 @@
+---
+- name: Get the Test item from Test Job List
+  set_fact: 
+    test: "{{ item }}"
+
+- block:
+
+    - name: Replace the storage class based on provider
+      replace:
+        path: "{{ test }}"  
+        regexp: "openebs-standard"
+        replace: "{{ storage_class }}"
+
+    - name: Get $HOME of K8s master for kubernetes user
+      shell: source ~/.profile; echo $HOME
+      args:
+        executable: /bin/bash
+      register: result_kube_home
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+   
+    - name: Copy the test job spec into master
+      copy: 
+        src: "{{ test }}" 
+        dest: "{{ result_kube_home.stdout }}"
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+ 
+    - name: Run the test Kubernetes job YAML
+      shell: source ~/.profile; kubectl apply -f run_litmus_test.yaml
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+    - name: Verify the test Kubernetes job is Successful
+      # Using a default job name "litmus-test"
+      # Is it better to check "Completed" v/s "Successful"
+      shell: >
+        source ~/.profile; 
+        kubectl get job litmus-test --no-headers 
+        -o custom-columns=:status.succeeded
+      args:
+        executable: /bin/bash
+      register: result
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      until: "result.stdout|int == 1"
+      delay: 120
+      retries: 10
+
+    - name: Delete test Kubernetes job
+      # Using a default job name "run_litmus_test.yaml"  
+      shell: source ~/.profile; kubectl delete -f run_litmus_test.yaml
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+    
+    - name: Verify job is deleted successfully
+      # Using a default job name "litmus-test"
+      shell: >
+        source ~/.profile; 
+        kubectl get job --no-headers -o custom-columns=:metadata.name
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      until: "'litmus-test' not in result.stdout"
+     
+  rescue: 
+    - name: Handle job failure 
+      debug: 
+        msg: "Unable to complete test, please examine the job spec for {{ test }}" 
+  
+  always: 
+    - name: Message b/w test job runs 
+      debug: 
+        msg: "Moving to next test..."

--- a/executor/ansible/vagrant/Vagrantfile
+++ b/executor/ansible/vagrant/Vagrantfile
@@ -1,0 +1,115 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/xenial64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", type: "dhcp"
+  config.vm.provision "shell", inline: <<-SHELL
+      echo "ubuntu:ubuntu" | sudo chpasswd
+  SHELL
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+
+  config.vm.define "master" do |vmCfg|
+    vmCfg.vm.hostname = "omm-01"
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true
+  end
+
+  config.vm.define "host-01" do |vmCfg|
+    vmCfg.vm.hostname = "osh-01"        
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true
+  end
+
+  config.vm.define "host-02" do |vmCfg|
+    vmCfg.vm.hostname = "osh-02"    
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true
+  end
+
+  config.vm.define "client" do |vmCfg|
+    vmCfg.vm.hostname = "openebs-client"    
+
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get update",
+    privileged: true
+
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-pip libffi-dev python-dev libssl-dev sshpass",
+    privileged: true
+
+    vmCfg.vm.provision :shell,
+    inline: "pip install ansible ",
+    privileged: true
+
+    vmCfg.vm.synced_folder '.', '/home/ubuntu/demo/openebs/ansible'
+
+  end
+end

--- a/tests/mysql/mysql_load/Dockerfile
+++ b/tests/mysql/mysql_load/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu
+LABEL maintainer="OpenEBS"
+RUN apt-get update || true && \
+    apt-get install -y python-minimal python-pip \
+    curl openssh-client
+
+RUN pip install ansible
+
+ENV KUBE_LATEST_VERSION="v1.8.2"
+RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
+RUN mkdir /etc/ansible/ /ansible
+
+RUN echo "[local]" >> /etc/ansible/hosts && \
+    echo "127.0.0.1" >> /etc/ansible/hosts
+
+RUN mkdir -p /ansible/playbooks
+
+WORKDIR /ansible/playbooks
+
+COPY mysql.yaml test.yaml test_vars.yaml test_cleanup.yaml /ansible/playbooks/

--- a/tests/mysql/mysql_load/mysql.yaml
+++ b/tests/mysql/mysql_load/mysql.yaml
@@ -1,0 +1,90 @@
+##############################################################################
+#  This YAML runs a TPC-C workload against a percona database container      #
+#  Obtain the TransactionsPerMinuteCount (TpmC) using the given command      #
+#                                                                            #
+#  kubectl logs percona -c tpcc-bench | awk '/TpmC/ && !/^<TpmC>/{print $0}' #
+#                                                                            #
+##############################################################################
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tpcc-config
+data:
+  
+  ## Customize the values as per test requirement
+  tpcc.conf: |-
+    {
+    "db_user": "root",
+    "db_password": "k8sDem0",
+    "warehouses": "1",
+    "connections": "16",
+    "warmup_period": "10",
+    "run_duration": "60",
+    "interval": "10"
+    }
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: percona
+  labels:
+    name: percona
+spec:
+  
+  ## Ensures the pod enters "completed" state after 
+  ## the tpcc-workload test duration 
+  restartPolicy: Never
+  
+  containers:
+  
+  # Runs latest percona database container
+  - name: percona
+    image: percona
+    args:
+      - "--ignore-db-dir"
+      - "lost+found"
+    env:
+      - name: MYSQL_ROOT_PASSWORD
+        value: k8sDem0
+    ports:
+      - containerPort: 3306
+        name: percona
+    volumeMounts:
+    - mountPath: /var/lib/mysql
+      name: mysql-path 
+  
+  # Runs a sample tpc-c workload sidecar container
+  # Wait for 60s to wait for MySQL to accept connections 
+  - name: tpcc-bench
+    image: openebs/tests-tpcc-client
+    command: ["/bin/bash"]
+    args: ["-c", "sleep 60; ./tpcc-runner.sh 127.0.0.1 tpcc.conf; exit 0"]
+    volumeMounts:
+      - name: tpcc-configmap
+        mountPath: /tpcc-mysql/tpcc.conf
+        subPath: tpcc.conf
+    tty: true
+  
+  volumes:
+  - name: mysql-path
+    persistentVolumeClaim:
+      claimName: mysql-vol-claim
+  - name: tpcc-configmap
+    configMap:
+      name: tpcc-config
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mysql-vol-claim
+spec:
+  storageClassName: testClass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G

--- a/tests/mysql/mysql_load/run_litmus_test.yaml
+++ b/tests/mysql/mysql_load/run_litmus_test.yaml
@@ -1,0 +1,91 @@
+# TODO
+# Separate out the testjob & sa,rbac definitions
+# Maintain identical resource names as a standard
+# Change test container 
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: litmus-test
+  namespace: default
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: litmus-test
+rules:
+  # The role's capabilities can be enhanced in future (ex: crd)
+- apiGroups: ["*"]
+  resources: ["nodes","nodes/proxy"]
+  verbs: ["get","list"]
+- apiGroups: ["*"]
+  resources: ["namespaces","services","pods","pods/exec","deployments","daemonsets","statefulsets","configmaps"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["persistentvolumes","persistentvolumeclaims"]
+  verbs: ["*"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["*"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: litmus-test
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: litmus-test
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: litmus-test
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: litmus-test
+spec:
+  template:
+    metadata:
+      name: litmus-test
+    spec:
+      serviceAccountName: litmus-test
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: ksatchit/ansibletest
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: log_plays 
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-standard 
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook test.yaml -i /etc/ansible/hosts; exit 0"]
+        volumeMounts:
+          - name: logs 
+            mountPath: /var/log/ansible 
+        tty: true
+      - name: logger
+        image: openebs/logger
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d 10 -r maya,openebs,pvc,percona; exit 0"] 
+        volumeMounts:
+          - name: kubeconfig 
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt 
+        tty: true 
+      volumes: 
+        - name: kubeconfig
+          configMap: 
+            name: kubeconfig 
+        - name: logs 
+          hostPath:
+            path: /mnt
+            type: Directory 
+

--- a/tests/mysql/mysql_load/test.yaml
+++ b/tests/mysql/mysql_load/test.yaml
@@ -1,0 +1,84 @@
+# TODO 
+# Change pod status checks to container status checks (containerStatuses)
+# O/P result
+
+- hosts: localhost
+  connection: local  
+
+  vars_files:
+    - test_vars.yaml
+ 
+  tasks:
+   - block:
+       - name: Check whether maya-apiserver pod is deployed
+         shell: >
+           kubectl get pod -l name=maya-apiserver --no-headers 
+           -o custom-columns=:status.phase 
+         args: 
+           executable: /bin/bash
+         register: result
+         until: "result.stdout == 'Running'"
+         delay: 30
+         retries: 12
+
+       - name: Replace volume-claim name with test params 
+         replace:
+           path: "{{ pod_yaml_alias }}"
+           regexp: '{{ item.0 }}'
+           replace: '{{ item.1 }}'
+         with_together:
+           - "{{replace_item}}"
+           - "{{replace_with}}"
+
+       - name: Replace the load duration with test params
+         lineinfile: 
+           path: "{{ pod_yaml_alias }}"
+           regexp: "\"run_duration\": \"60\""
+           line: "    \"run_duration\": \"{{mysql_load_duration}}\""
+
+       - name: Replace the storageclass placeholder with provider
+         replace:
+           path: "{{ pod_yaml_alias }}"
+           regexp: "testClass"
+           #replace: "{{ provider_sc }}"
+           replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+       - name: Deploy percona mysql pod
+         shell: kubectl apply -f {{ pod_yaml_alias }} 
+         args: 
+           executable: /bin/bash
+
+       - name: Confirm pod status is running
+         shell: >
+           kubectl get pods -l name=percona --no-headers 
+           -o custom-columns=:status.phase
+         args: 
+           executable: /bin/bash
+         register: result
+         until: "result.stdout == 'Running'"
+         delay: 120 
+         retries: 15
+
+       - name: Wait for I/O completion
+         wait_for: 
+           timeout: "{{ mysql_load_duration }}"
+
+       - name: Confirm pod status is completed
+         shell: >
+           kubectl get pods -l name=percona --no-headers 
+         args: 
+           executable: /bin/bash
+         register: result
+         until: "'Completed' in result.stdout"
+         delay: 120 
+         retries: 15
+
+       - set_fact:
+           flag: "Pass"
+
+     rescue: 
+       - set_fact: 
+           flag: "Fail"
+
+     always:
+       - include: test_cleanup.yaml

--- a/tests/mysql/mysql_load/test_cleanup.yaml
+++ b/tests/mysql/mysql_load/test_cleanup.yaml
@@ -1,0 +1,31 @@
+---
+- name: Get pvc name to verify successful pvc deletion
+  shell: >
+    kubectl get pvc {{ replace_with.0 }} 
+    -o custom-columns=:spec.volumeName --no-headers
+  args:
+    executable: /bin/bash
+  register: pvc
+
+- name: Delete percona mysql pod 
+  shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
+  args:
+    executable: /bin/bash
+
+- name: Confirm percona pod has been deleted
+  shell: source ~/.profile; kubectl get pods
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'percona' not in result.stdout"
+  delay: 30 
+  retries: 12
+
+- name: Confirm pvc pod has been deleted
+  shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
+  args:
+    executable: /bin/bash
+  register: result
+  failed_when: "'pvc' and 'Running' in result.stdout"
+  delay: 30
+  retries: 12

--- a/tests/mysql/mysql_load/test_vars.yaml
+++ b/tests/mysql/mysql_load/test_vars.yaml
@@ -1,0 +1,23 @@
+---
+test_name: DBSx_SQLx_LDTx_Run_TPCC_Load_On_SQL
+
+pod_yaml_alias: mysql.yaml
+
+replace_item:
+  - mysql-vol-claim
+  - mysql-path
+
+replace_with:
+  - percona-db-claim
+  - percona-db
+
+mysql_load_duration: 120
+
+test_logger: stern
+
+test_logger_url: https://github.com/wercker/stern/releases/download/1.6.0/stern_linux_amd64 
+
+test_pod_regex: maya*|openebs*|pvc*|percona*
+
+test_log_path: /var/logs/ansible/DBSx_SQLx_LDTx_Run_TPCC_Load_On_SQL
+


### PR DESCRIPTION
## Changes: 

- This PR adds an ansible-based MySQL test container to perform a simple  load test, with the corresponding Kubernetes test job manifest 

- Also includes the initial implementation of an ansible-based litmus executor framework, which helps with: 
     - Setting up a kubeadm-based Kubernetes cluster on Ubuntu & CentOS
     - Setting up OpenEBS storage provider 
     - Running litmus tests against desired storage provider 

  (This adds a typical ansible directory structure with roles, plugins, wrapper scripts, inventory files with group vars, taskfiles etc.,) 
 
## Note to Reviewers 

- The litmus test suite can be triggered by running the command `./run_litmus.sh`
- README around usage of the executor framework & ansible-based test container will be added as part of a separate PR.
- This is an initial implementation. 

Signed-off-by: ksatchit <karthik.s@cloudbyte.com>