### PR TITLE
makes the contents inside readme more generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist: trusty
 sudo: required
 install: true
+language: go
+go:
+  - 1.9.1
 env:
   global:
     - GOARCH=amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ before_install:
   - sudo apt-get install -y
   - sudo apt-get install -y curl
 script:
+  - make godeps
   - make

--- a/Makefile
+++ b/Makefile
@@ -21,20 +21,13 @@ help:
 	@echo "\tmake all   -- [default] builds the litmus containers"
 	@echo ""
 
-_build_check_docker:
-	@if [ $(IS_DOCKER_INSTALLED) -eq 1 ]; \
-		then echo "" \
-		&& echo "ERROR:\tdocker is not installed. Please install it before build." \
-		&& echo "" \
-		&& exit 1; \
-		fi;
-
 # `make deps` needs to be run in a completely new environment
 # In case of go related issues, run below commands & verify:
 # go version    # ensure go1.9.1 or above
 # go env        # ensure if GOPATH is set
 # echo $PATH    # ensure if $GOPATH/bin is set
-deps: _build_check_docker
+.PHONY: godeps
+godeps:
 	@echo ""
 	@echo "INFO:\tverifying dependencies for Litmus ..."
 	@go get -u -v github.com/golang/lint/golint
@@ -43,6 +36,17 @@ deps: _build_check_docker
 	@go get -u -v github.com/DATA-DOG/godog/cmd/godog
 	@go get -u -v github.com/alecthomas/gometalinter
 	@gometalinter --install
+
+_build_check_docker:
+	@if [ $(IS_DOCKER_INSTALLED) -eq 1 ]; \
+		then echo "" \
+		&& echo "ERROR:\tdocker is not installed. Please install it before build." \
+		&& echo "" \
+		&& exit 1; \
+		fi;
+
+.PHONY: deps
+deps: _build_check_docker godeps
 
 .PHONY: format
 format:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ IS_DOCKER_INSTALLED = $(shell which docker >> /dev/null 2>&1; echo $$?)
 # list only our namespaced directories
 PACKAGES = $(shell go list ./... | grep -v '/vendor/')
 
+.PHONY: all
+all: format metalint compile
+
 .PHONY: help
 help:
 	@echo ""
@@ -17,7 +20,6 @@ help:
 	@echo "\tmake deps  -- will verify build dependencies are installed"
 	@echo "\tmake all   -- [default] builds the litmus containers"
 	@echo ""
-
 
 _build_check_docker:
 	@if [ $(IS_DOCKER_INSTALLED) -eq 1 ]; \
@@ -41,9 +43,6 @@ deps: _build_check_docker
 	@go get -u -v github.com/DATA-DOG/godog/cmd/godog
 	@go get -u -v github.com/alecthomas/gometalinter
 	@gometalinter --install
-
-.PHONY: all
-all: format metalint compile
 
 .PHONY: format
 format:

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# Overview
+# Litmus
+Litmus test your application without the learning curves
+
+## Overview
 
 [![Build Status](https://travis-ci.org/openebs/litmus.svg?branch=master)](https://travis-ci.org/openebs/litmus)
 
-The primary objective of Litmus is to ensure a consistent and reliable behavior of Kubernetes for various persistent workloads and to catch hard-to-test bugs and unacceptable behaviors before users do.  Litmus can detect many more real-world issues than relatively simple issues identified by unit and integration tests. 
+The primary objective of Litmus is to ensure a consistent and reliable behavior of workloads running in Kubernetes. It also aims to catch hard-to-test bugs and unacceptable behaviors before users do. Litmus strives to detect real-world issues which escape during unit and integration tests.
 
-Litmus can also be used to determine if a given Kubernetes deployment is suitable for stateful workloads.  While Litmus tests and metrics were developed initially to test the resilience of container attached storage from OpenEBS and others - the use cases are broader and overall system resilience can be characterized.  
+While Litmus tests and metrics were developed initially to test if a given Kubernetes deployment is suitable for running on OpenEBS (_a kubernetes dynamic storage provisioner_); the use cases are broader and overall system resilience can be characterized.
 
-Litmus tests range from initial setup and configuration validation to deploying and running persistent workloads under various conditions and failures. Litmus comprises the following major components:
-- **Deployments** that help in setting up different types of Kubernetes Clusters like on-premise, cloud, OpenShift, etc. The default is that the deployment scripts to provision and configure OpenEBS storage, however, these deployments are easily extended to support other storage. 
-- **Framework** for test execution that includes: 
-  * Defining and running test suites 
-  * Capturing logs and generating reports about the test runs
-  * Fault/Error injection tools that help to perform chaos tests
-  * Examples that demonstrate how to integrate these test pipelines with Slack notifications
-- **Test modules** that can be triggered from within a Kubernetes cluster. Think of these a containerized tests. For instance, the **_mysql-client_** can be launched as a pod to validate the MySQL resiliency while the underlying nodes and the connected storage are subjected to chaos engineering.
-- **Tests** that themselves are written in easy to understand formats, either in plain English (thanks Godog!) or in Ansible Playbooks. These tests primarily interact with the Kubernetes cluster via **_kubectl_** making them highly portable.
+## How is Litmus different than others
+Litmus keeps end user in mind while designing its test scenarios. Litmus accepts user story & converts it to respective test logic. In other words, Litmus translates each statement present in the user story into corresponding kubernetes command. This provides a transparent view to the users if any particular statement was executed successfully or resulted in failures.
 
-Litmus can be used to test a given workload in a variety of Kubernetes environments, for example, a developer minikube or a GKE cluster with a specific storage solution or as a part of a full-fledged CI setup.
+In addition, each test logic is packaged as a dedicated container image making them highly portable across kubernetes deployments. This also helps verifying a feature by endusers after importing these containers in their CI/CD environments.
+
+There are other aspects to Litmus which may be refered from:
+- [litmus deep dive](docs/litmus_deep_dive.md)
+- [running test suite](docs/running_test_suite.md)
 
 # Running a specific Test
 
@@ -55,32 +55,7 @@ As the test ends, the logs of the various storage pods, including the test resul
 collected and saved in a temporary location. The `run_litmus_test.yaml` can be customized for the location for 
 saving the logs, type of storage (StorageClass) to be used, etc..,
 
-# Running a Complete Test Suite
-
-The Litmus test suite can be run on a kubernetes cluster using an ansible-based executor framework. 
-This involves: 
-
-- Setting up ansible on any linux machine (ansible test harness), with SSH access to the kubernetes cluster 
-- Generating the ansible inventory file with host information (master/control node & hosts)
-- Modifying a global variables file to:
-   
-  - Set Provider and storage class
-  - Select test Category (call or subset)
-  - Enable/Disable some services like log collection, notifications etc..,
-
-Follow the executor/README for detailed instructions on how to perform above steps. Once these pre-requisites 
-have been met, execute the following on the ansible test harness:
-
-```
-./litmus/executor/ansible/run-litmus.sh
-```
-
-The above script will verify that it has all the details required for it to proceed and provides you with 
-test task execution status. 
-
-*Litmus may take a while to show a reaction as it puts the system through rigorous scrutiny!*
-
-# Contributing
+## Ways to Contribute
 
 Litmus is in *_alpha_* stage and needs all the help you can provide to have it cover the ever-growing Kubernetes landscape. Please contribute by raising issues, improving the documentation, contributing to the core framework and tooling, etc. 
 

--- a/docs/litmus_deep_dive.md
+++ b/docs/litmus_deep_dive.md
@@ -1,0 +1,15 @@
+# Litmus Deep Dive
+
+Litmus tests range from initial setup and configuration validation to deploying and running workloads under various conditions and failures. 
+
+Litmus comprises the following major components:
+- **Deployments** that help in setting up different types of Kubernetes Clusters like on-premise, cloud, OpenShift, etc. The default is that the deployment scripts to provision and configure OpenEBS storage, however, these deployments are easily extended to support other storage. 
+- **Framework** for test execution that includes: 
+  * Defining and running test suites 
+  * Capturing logs and generating reports about the test runs
+  * Fault/Error injection tools that help to perform chaos tests
+  * Examples that demonstrate how to integrate these test pipelines with Slack notifications
+- **Test modules** that can be triggered from within a Kubernetes cluster. Think of these a containerized tests. For instance, the **_mysql-client_** can be launched as a pod to validate the MySQL resiliency while the underlying nodes and the connected storage are subjected to chaos engineering.
+- **Tests** that themselves are written in easy to understand formats, either in plain English (thanks Godog!) or in Ansible Playbooks. These tests primarily interact with the Kubernetes cluster via **_kubectl_** making them highly portable.
+
+Litmus can be used to test a given workload in a variety of Kubernetes environments, for example, a developer minikube or a GKE cluster with a specific storage solution or as a part of a full-fledged CI setup.

--- a/docs/running_test_suite.md
+++ b/docs/running_test_suite.md
@@ -1,0 +1,24 @@
+# Running a Complete Test Suite
+
+The Litmus test suite can be run on a kubernetes cluster using an ansible-based executor framework. 
+This involves: 
+
+- Setting up ansible on any linux machine (ansible test harness), with SSH access to the kubernetes cluster 
+- Generating the ansible inventory file with host information (master/control node & hosts)
+- Modifying a global variables file to:
+   
+  - Set Provider and storage class
+  - Select test Category (call or subset)
+  - Enable/Disable some services like log collection, notifications etc..,
+
+Follow the executor/README for detailed instructions on how to perform above steps. Once these pre-requisites 
+have been met, execute the following on the ansible test harness:
+
+```
+./litmus/executor/ansible/run-litmus.sh
+```
+
+The above script will verify that it has all the details required for it to proceed and provides you with 
+test task execution status. 
+
+*Litmus may take a while to show a reaction as it puts the system through rigorous scrutiny!*


### PR DESCRIPTION
Litmus can be used by various teams & end users to
test their kubernetes deployments. Hence, the tone of
the content has been made generic.

A docs folder with 2 topics has been added. This was
separated from readme as readme will focus more on
building a test case & running it versus how to run
the entire test suite.

A simple readme will enable contributors to understand
fast and hence make contributions. Running test suite
is seen as a step that should be taught later once the
initial hurdle is passed.

In future, the readme will have build the test logic,
containerizing & running the same. There is also a plan
to have a video to build, containerize & run a test case.

Signed-off-by: AmitKumarDas <amit.das@openebs.io>