### PR TITLE
Implement retry logic based on mysql server state in tpcc-runner (mysql-benchmark test) 

### DIFF
--- a/tests/mysql/mysql_storage_benchmark/mysql.yaml
+++ b/tests/mysql/mysql_storage_benchmark/mysql.yaml
@@ -45,7 +45,7 @@ spec:
   - name: tpcc-bench
     image: openebs/tests-tpcc-client
     command: ["/bin/bash"]
-    args: ["-c", "sleep 60; ./tpcc-runner.sh 127.0.0.1 tpcc.conf; exit 0"]
+    args: ["-c", "./tpcc-runner.sh 127.0.0.1 tpcc.conf; exit 0"]
     volumeMounts:
       - name: tpcc-configmap
         mountPath: /tpcc-mysql/tpcc.conf

--- a/tests/mysql/mysql_storage_benchmark/run_litmus_test.yaml
+++ b/tests/mysql/mysql_storage_benchmark/run_litmus_test.yaml
@@ -1,5 +1,3 @@
-# TODO
-# Change test container 
 ---
 apiVersion: batch/v1
 kind: Job
@@ -15,7 +13,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: ksatchit/ansibletest
+        image: openebs/ansible-runner
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK
             value: log_plays

--- a/tools/tpcc-client/tpcc-mysql/tpcc-runner.sh
+++ b/tools/tpcc-client/tpcc-mysql/tpcc-runner.sh
@@ -29,6 +29,22 @@ fi
 # runtime     : ${T_P[5]}
 # interval    : ${T_P[6]}
 
+echo -e "\nWaiting for mysql server to start accepting connections.."
+retries=10;wait_retry=30
+for i in `seq 1 $retries`; do 
+  mysql -h $DB_SERVER_IP -u${T_P[0]} -p${T_P[1]} -e 'status' > /dev/null 2>&1
+  rc=$?
+  [ $rc -eq 0 ] && break
+  sleep $wait_retry 
+done 
+
+if [ $rc -ne 0 ];
+then
+  echo -e "\nFailed to connect to db server after trying for $(($retries * $wait_retry))s, exiting\n"
+  exit 1
+fi
+
+
 echo -e "\nCreating database.."
 mysqladmin -h $DB_SERVER_IP create $DB_NAME --user=${T_P[0]} --password=${T_P[1]} > /dev/null 2>&1
 if [ $? -ne 0 ];


### PR DESCRIPTION
Changes: 

- Improve tpcc-runner to check mysql server connectivity & perform fixed retries
- Removed the default wait time in the tpcc-bench sidecar of percona-mysql pod
- Replaced the litmus ansible-runner image

Notes for reviewers: 

- The MySQL DB initialization sequence (at the end of which the mysqld is ready to take connections) is seen to take different amount on time on : 
  - Different platforms 
  - Different storage backends 

- The existing mysql pod runs the tpcc-bench container as a sidecar, which waits for a fixed period of 60s before attempting database creation as part of the benchmark preparation. This was seen to error out on the OpenEBS volume, on which the init took > 60s (values ranged from 80-100s based on nature of underlying disks) 

- The PR uses an improved method as part of which the server status check is retried via `mysql -h <host> -u<user> -p<pass> -e 'status'`  for a fixed number of times (10), with an interval of 30s, before erroring out, citing a long wait for server to be available (cases where server init fails due to other reasons) 

Signed-off-by: ksatchit <karthik.s@openebs.io>