### PR TITLE
Include litmus test for fio-based benchmark

### DIFF
--- a/tests/fio/fio.yaml
+++ b/tests/fio/fio.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fio
+spec:
+  template:
+    metadata:
+      name: fio
+      labels:
+        name: fio 
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: testNode
+      containers:
+      - name: perfrunner
+        image: openebs/tests-fio
+        command: ["/bin/bash"]
+        args: ["-c", "./fio_runner.sh --template file/basic-rw --size 256m --duration 60; exit 0"]
+        volumeMounts:
+           - mountPath: /datadir
+             name: fio-vol
+        tty: true
+      volumes:
+      - name: fio-vol
+        persistentVolumeClaim:
+          claimName: testClaim 
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testClaim 
+spec:
+  storageClassName: testClass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "5G"

--- a/tests/fio/run_litmus_test.yaml
+++ b/tests/fio/run_litmus_test.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: litmus
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: log_plays
+ 
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-standard
+            #value: local-storage
+
+          - name: APP_NODE_SELECTOR
+            value: kubeminion-01 
+
+          - name: FIO_TEST_PROFILE
+            value: standard-ssd
+
+          - name: FIO_SAMPLE_SIZE
+            value: "128m"
+ 
+          - name: FIO_TESTRUN_PERIOD
+            value: "60"
+ 
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./fio/test.yaml -i /etc/ansible/hosts -v; exit 0"]
+        volumeMounts:
+          - name: logs 
+            mountPath: /var/log/ansible 
+        tty: true
+      - name: logger
+        image: openebs/logger
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d 10 -r maya,openebs,pvc,fio; exit 0"] 
+        volumeMounts:
+          - name: kubeconfig 
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt 
+        tty: true 
+      volumes: 
+        - name: kubeconfig
+          configMap: 
+            name: kubeconfig 
+        - name: logs 
+          hostPath:
+            path: /mnt
+            type: Directory 
+

--- a/tests/fio/test.yaml
+++ b/tests/fio/test.yaml
@@ -1,0 +1,126 @@
+# TODO 
+# Change pod status checks to container status checks (containerStatuses)
+# O/P result
+
+- hosts: localhost
+  connection: local  
+
+  vars_files:
+    - test_vars.yaml
+ 
+  tasks:
+   - block:
+
+       ## VERIFY AVAILABILITY OF SELECTED STORAGE CLASS  
+
+       - name: Check whether the provider storageclass is applied
+         shell: kubectl get sc {{ lookup('env','PROVIDER_STORAGE_CLASS') }}
+         args:
+           executable: /bin/bash
+         register: result
+
+       ## PRE-CONDITION THE APPLICATION DEPLOYMENT SPECS WITH TEST PARAMS 
+                  
+       - name: Replace the app node placeholder with perf-intensive node
+         replace:
+           path: "{{ pod_yaml_alias }}"
+           regexp: "testNode"
+           replace: "{{ lookup('env','APP_NODE_SELECTOR') }}"
+
+       - name: Replace the pvc placeholder with test param
+         replace:
+           path: "{{ pod_yaml_alias }}"
+           regexp: "testClaim"
+           replace: "{{ test_name }}"
+          
+       - name: Replace the storageclass placeholder with provider
+         replace:
+           path: "{{ pod_yaml_alias }}"
+           regexp: "testClass"
+           replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+       # FIO-SPECIFIC PRE-CONDITIONING
+
+       - name: Replace the default fio profile with user-defined profile
+         replace: 
+           path: "{{ pod_yaml_alias }}"
+           regexp: "basic-rw"
+           replace: "{{ lookup('env','FIO_TEST_PROFILE') }}"
+
+       - name: Replace the data sample size with user-defined size
+         replace: 
+           path: "{{ pod_yaml_alias }}"
+           regexp: "256m"
+           replace: "{{ lookup('env','FIO_SAMPLE_SIZE') }}"
+
+       - name: Replace the default I/O test duration with user-defined period
+         replace: 
+           path: "{{ pod_yaml_alias }}"
+           regexp: "60"
+           replace: "{{ lookup('env','FIO_TESTRUN_PERIOD') }}"
+       
+       ## RUN FIO WORKLOAD TEST
+
+       - name: Deploy fio test job
+         shell: kubectl apply -f {{ pod_yaml_alias }} -n litmus  
+         args: 
+           executable: /bin/bash
+
+       - name: Confirm fio pod status is running
+         shell: >
+           kubectl get pods -l name=fio -n litmus 
+           --no-headers 
+         args: 
+           executable: /bin/bash
+         register: result
+         until: "'fio' and 'Running' in result.stdout" 
+         delay: 120 
+         retries: 15
+
+       - name: Obtain name of fio pod 
+         set_fact: 
+           fio_pod_name: "{{ result.stdout.split()[0] }}"
+ 
+       - name: Wait for fio pod to proceed with workload
+         wait_for:
+           timeout: 60
+
+       - name: Re-Check fio pod status 
+         shell: >
+           kubectl get pod {{ fio_pod_name }} -n litmus
+           --no-headers -o custom-columns=:status.phase
+         args: 
+           executable: /bin/bash
+         register: result 
+         failed_when: "result.stdout not in ['Running', 'Succeeded']"
+
+       - name: Confirm fio job completion status (poll & wait for upperbound of 60 min) 
+         shell: >
+           kubectl get pod {{ fio_pod_name }} -n litmus 
+           --no-headers -o custom-columns=:status.phase
+         args: 
+           executable: /bin/bash
+         register: result
+         until: "'Succeeded' in result.stdout"
+         delay: 120 
+         retries: 30
+
+       - name: Verify the fio logs to check if run is complete w/o errors
+         shell: >
+           kubectl logs {{ fio_pod_name }} -n litmus 
+           | grep -i error | cut -d ":" -f 2 
+           | sort | uniq
+         args:
+           executable: /bin/bash
+         register: result
+         failed_when: result.stdout != " 0,"
+
+       - set_fact:
+           flag: "Pass"
+
+     rescue: 
+       - set_fact: 
+           flag: "Fail"
+
+     always:
+       - include: test_cleanup.yaml

--- a/tests/fio/test_cleanup.yaml
+++ b/tests/fio/test_cleanup.yaml
@@ -1,0 +1,46 @@
+---
+- name: Get pvc name to verify successful pvc deletion
+  shell: >
+    kubectl get pvc {{ test_name }} 
+    -o custom-columns=:spec.volumeName -n litmus 
+    --no-headers
+  args:
+    executable: /bin/bash
+  register: pv
+
+- name: Delete fio job 
+  shell: >
+    source ~/.profile; kubectl delete -f {{ pod_yaml_alias }} 
+    -n litmus 
+  args:
+    executable: /bin/bash
+
+- name: Confirm fio pod has been deleted
+  shell: source ~/.profile; kubectl get pods -n litmus 
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'fio' not in result.stdout"
+  delay: 30 
+  retries: 12
+
+- block: 
+    - name: Confirm pvc pod has been deleted
+      shell: >
+        kubectl get pods -n litmus | grep {{ pv.stdout }}
+      args:
+        executable: /bin/bash
+      register: result
+      failed_when: "'pvc' and 'Running' in result.stdout"
+      delay: 30
+      retries: 12
+  when: "'openebs-standard' in lookup('env','PROVIDER_STORAGE_CLASS')"
+
+- block:
+    - name: Remove the local persistent volume 
+      shell: kubectl delete pv {{ pv.stdout }}
+      args:
+        executable: /bin/bash
+      register: result
+      failed_when: "'persistentvolume' and 'deleted' not in result.stdout"
+  when: "'local-storage' in lookup('env','PROVIDER_STORAGE_CLASS')"

--- a/tests/fio/test_vars.yaml
+++ b/tests/fio/test_vars.yaml
@@ -1,0 +1,17 @@
+---
+## TEST-SPECIFIC PARAMS
+
+test_name: fio-benchmark
+pod_yaml_alias: fio.yaml
+
+## PROVIDER-SPECIFIC PARARMS
+
+# OpenEBS
+
+openebs_operator: 
+  - maya-apiserver
+  - openebs-provisioner
+
+# Local Volume 
+
+local_pv_name: local-pv  

--- a/tests/fio/test_vars.yaml
+++ b/tests/fio/test_vars.yaml
@@ -4,14 +4,3 @@
 test_name: fio-benchmark
 pod_yaml_alias: fio.yaml
 
-## PROVIDER-SPECIFIC PARARMS
-
-# OpenEBS
-
-openebs_operator: 
-  - maya-apiserver
-  - openebs-provisioner
-
-# Local Volume 
-
-local_pv_name: local-pv  

--- a/tools/fio/templates/file/basic-rw
+++ b/tools/fio/templates/file/basic-rw
@@ -1,10 +1,8 @@
 [global]
-directory=/datadir1
-filesize=16m
-
+directory=/datadir
+filename=basic.test.file
 
 [basic-readwrite]
 rw=readwrite
 bs=4k
 time_based=1
-runtime=60

--- a/tools/fio/templates/file/standard-ssd
+++ b/tools/fio/templates/file/standard-ssd
@@ -1,0 +1,32 @@
+# Do some important numbers on SSD drives, to gauge what kind of
+# performance you might get out of them.
+#
+# Sequential read and write speeds are tested, these are expected to be
+# high. Random reads should also be fast, random writes are where crap
+# drives are usually separated from the good drives.
+#
+# This uses a queue depth of 32 (As this is more representative of mid-heavy disk use)
+
+[global]
+bs=4k
+ioengine=libaio
+iodepth=1
+direct=1
+directory=/datadir 
+filename=ssd.test.file
+
+[seq-read]
+rw=read
+stonewall
+
+[rand-read]
+rw=randread
+stonewall
+
+[seq-write]
+rw=write
+stonewall
+
+[rand-write]
+rw=randwrite
+stonewall


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Creates a litmus test for fio-based benchmarks for storage evaluation
- Updates the openebs/tests-fio workload generator container, with respect to: 
  - Additional template based on user request
  - Improvements to fio_runner bash script

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- The fio profiles checked into the tools/fio/templates are based on user definitions. While the core IO parameters are retained unchanged during a test, options have been provided in the test job to run with desired size and duration.

- The fio run has been configured to return a JSON output which can be used for further processing. 

- The test run log is attached: 

[fio-test-job-run.log](https://github.com/openebs/litmus/files/2167704/fio-test-job-run.log)
