### PR TITLE
Add litmus test to check mysql data persistence upon forced reschedule (via pod evictions)

### DIFF
--- a/tests/mysql/mysql_persistence_on_pod_eviction/README.md
+++ b/tests/mysql/mysql_persistence_on_pod_eviction/README.md
@@ -1,0 +1,20 @@
+## Checking MySQL data persistence upon forced reschedule (eviction) 
+
+### Objective  
+
+- This test checks MySQL data persistence with a specified storage solution by verifying table content post a forced
+reschedule operation caused by immediate eviction effected by the Kubernetes node-controller manager. 
+
+### Considerations
+
+- This test simulates one type of graceful node loss (other means include cordon+drain operations) 
+- The application reschedule time is also impacted by the amount of delay between disk attach and mount attempts by Kubernetes
+
+### Steps to Run
+
+- Apply the litmus/hack/rbac.yaml to setup the Litmus namespace, service account, clusterrole and clusterrolebinding 
+- Create a configmap with content of kubernetes config file (needs to be named "admin.conf") 
+- Run the litmus test job 
+- View the test run & pod logs on the litmus node at /mnt
+
+

--- a/tests/mysql/mysql_persistence_on_pod_eviction/mysql.yaml
+++ b/tests/mysql/mysql_persistence_on_pod_eviction/mysql.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: percona
+  labels:
+    name: percona
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      name: percona 
+  template: 
+    metadata:
+      labels: 
+        name: percona
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                name: litmus
+            topologyKey: kubernetes.io/hostname
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: percona
+          image: percona
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: data-vol
+      volumes:
+        - name: data-vol
+          persistentVolumeClaim:
+            claimName: testClaim 
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testClaim
+spec:
+  storageClassName: testClass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: percona-mysql
+  labels:
+    name: percona-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: percona
+

--- a/tests/mysql/mysql_persistence_on_pod_eviction/run_litmus_test.yaml
+++ b/tests/mysql/mysql_persistence_on_pod_eviction/run_litmus_test.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: litmus
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        name: litmus 
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: log_plays
+ 
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-standard
+            #value: local-storage
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./mysql/mysql_persistence_on_pod_eviction/test.yaml -i /etc/ansible/hosts -v; exit 0"]
+        volumeMounts:
+          - name: logs 
+            mountPath: /var/log/ansible 
+        tty: true
+      - name: logger
+        image: openebs/logger
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d 10 -r maya,openebs,pvc,percona; exit 0"] 
+        volumeMounts:
+          - name: kubeconfig 
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt 
+        tty: true 
+      volumes: 
+        - name: kubeconfig
+          configMap: 
+            name: kubeconfig 
+        - name: logs 
+          hostPath:
+            path: /mnt
+            type: Directory 
+

--- a/tests/mysql/mysql_persistence_on_pod_eviction/test.yaml
+++ b/tests/mysql/mysql_persistence_on_pod_eviction/test.yaml
@@ -1,0 +1,141 @@
+# TODO 
+# Change pod status checks to container status checks (containerStatuses)
+# O/P result
+
+- hosts: localhost
+  connection: local  
+
+  vars_files:
+    - test_vars.yaml
+ 
+  tasks:
+   - block:
+
+       ## VERIFY AVAILABILITY OF SELECTED STORAGE CLASS  
+
+       - name: Check whether the provider storageclass is applied
+         shell: kubectl get sc {{ lookup('env','PROVIDER_STORAGE_CLASS') }}
+         args:
+           executable: /bin/bash
+         register: result
+
+       ## PRE-CONDITION THE APPLICATION DEPLOYMENT SPECS WITH TEST PARAMS 
+                  
+       - name: Replace the pvc placeholder with test param
+         replace:
+           path: "{{ pod_yaml_alias }}"
+           regexp: "testClaim"
+           replace: "{{ test_name }}"
+          
+       - name: Replace the storageclass placeholder with provider
+         replace:
+           path: "{{ pod_yaml_alias }}"
+           regexp: "testClass"
+           replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+       
+       ## RUN APPLICATION PERSISTENCE TEST
+
+       - name: Deploy percona mysql pod
+         shell: kubectl apply -f {{ pod_yaml_alias }} -n litmus  
+         args: 
+           executable: /bin/bash
+
+       - name: Confirm mysql pod status is running
+         shell: >
+           kubectl get pods -l name=percona -n litmus 
+           --no-headers 
+         args: 
+           executable: /bin/bash
+         register: result
+         until: "'percona' and 'Running' in result.stdout"
+         delay: 60
+         retries: 15
+
+       - name: Obtain name of mysql pod 
+         set_fact: 
+           percona_pod_name: "{{ result.stdout.split()[0] }}"
+
+       - name: Check for successful database init
+         shell: > 
+           kubectl logs {{ percona_pod_name }} -n litmus 
+           | grep 'ready for connections' | wc -l
+         args:
+           executable: /bin/bash
+         register: result
+         until: result.stdout == "2"
+         delay: 10
+         retries: 18
+
+       - name: Create some test data in the mysql database
+         shell: >
+           kubectl exec {{ percona_pod_name }} -n litmus 
+           -- {{ item }}
+         args:
+           executable: /bin/bash
+         register: result
+         failed_when: "result.rc != 0"
+         with_items:
+           - mysql -uroot -pk8sDem0 -e 'create database tdb;'
+           - mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb
+           - mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb 
+
+       - name: Identify the mysql application node
+         shell: >
+           kubectl get pod {{ percona_pod_name }} -n litmus 
+           --no-headers -o custom-columns=:spec.nodeName
+         args: 
+           executable: /bin/bash
+         register: result 
+           
+       - name: Record the application node name 
+         set_fact:
+           percona_node: "{{ result.stdout }}"
+
+       - name: Force eviction of pods by tainting the app node
+         shell: >
+           kubectl taint node {{ percona_node }} 
+           {{ taint }}=:NoExecute
+         args:
+           executable: /bin/bash
+         register: result
+         until: "'tainted' in result.stdout"
+         delay: 20
+         retries: 12
+         
+       - name: Wait for mysql pod reschedule    
+         wait_for:
+           timeout: 30
+
+       - name: Confirm mysql pod status is running
+         shell: >
+           kubectl get pods -l name=percona -n litmus 
+           --no-headers 
+         args: 
+           executable: /bin/bash
+         register: result
+         until: "'percona' and 'Running' in result.stdout"
+         delay: 60
+         retries: 15
+
+       - name: Obtain name of mysql pod 
+         set_fact: 
+           percona_pod_name: "{{ result.stdout.split()[0] }}"
+       
+       - name: Verify mysql data persistence  
+         shell: > 
+           kubectl exec {{ percona_pod_name }} -n litmus
+           -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' tdb;
+         args:
+           executable: /bin/bash
+         register: result 
+         failed_when: "'tdata' not in result.stdout"
+
+       - set_fact:
+           flag: "Pass"
+
+     rescue: 
+       - set_fact: 
+           flag: "Fail"
+
+     always:
+       - include: test_cleanup.yaml

--- a/tests/mysql/mysql_persistence_on_pod_eviction/test_cleanup.yaml
+++ b/tests/mysql/mysql_persistence_on_pod_eviction/test_cleanup.yaml
@@ -1,0 +1,63 @@
+---
+
+- block: 
+    - name: Verify if node taints are present 
+      shell: >
+        kubectl describe node 
+        {{ percona_node }}
+        | grep {{ taint }}
+      args:
+        executable: /bin/bash
+      register: output 
+      ignore_errors: true 
+
+    - name: Untaint the node if taints are present
+      shell: >
+        kubectl taint node 
+        {{ percona_node }}
+        {{ taint }}:NoExecute-
+      args:
+        executable: /bin/bash
+      register: result
+      failed_when: "'untainted' not in result.stdout"
+      when: output.rc == 0 
+
+  when: percona_node is defined
+
+- name: Get pvc name to verify successful pvc deletion
+  shell: >
+    kubectl get pvc {{ test_name }} 
+    -o custom-columns=:spec.volumeName -n litmus 
+    --no-headers
+  args:
+    executable: /bin/bash
+  register: pv
+
+- name: Delete percona mysql pod 
+  shell: >
+    source ~/.profile; kubectl delete -f {{ pod_yaml_alias }} 
+    -n litmus 
+  args:
+    executable: /bin/bash
+
+- name: Confirm percona pod has been deleted
+  shell: source ~/.profile; kubectl get pods -n litmus 
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'percona' not in result.stdout"
+  delay: 30 
+  retries: 12
+
+- block: 
+    - name: Confirm pvc pod has been deleted
+      shell: >
+        kubectl get pods -n litmus | grep {{ pv.stdout }}
+      args:
+        executable: /bin/bash
+      register: result
+      failed_when: "'pvc' and 'Running' in result.stdout"
+      delay: 30
+      retries: 12
+  when: "'openebs-standard' in lookup('env','PROVIDER_STORAGE_CLASS')"
+

--- a/tests/mysql/mysql_persistence_on_pod_eviction/test_vars.yaml
+++ b/tests/mysql/mysql_persistence_on_pod_eviction/test_vars.yaml
@@ -1,0 +1,6 @@
+---
+## TEST-SPECIFIC PARAMS
+
+test_name: mysql-persistence
+pod_yaml_alias: mysql.yaml
+taint: "node.kubernetes.io/out-of-disk"


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This litmus test verifies persistence of MySQL data upon forced reschedule of all pods on the application node due to resource constraints (disk-pressure) 
- The eviction/resource constraint is applied by the test on the application node via a kubernetes node taint `node.kubernetes.io/out-of-disk` with action `NoExecute`. This belongs to a group of taints for which the `tolerationSeconds` is 0, i.e., the pods are immediately evicted. Typically, these are applied by node-controller when certain system conditions are true.
- The data persistence is checked by validating the presence of table content written prior to the reschedule

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- This test simulates a *graceful* node loss, i.e., as the tear-down process as part reschedule is handled while the kubelet is still running/alive on the test node.
- One of  the requirements for the chaos tests involving node is that the litmus test pod itself should bot be rescheduled/restarted as that interrupts the test-code execution. To account for this, the application pod is built with `anti-pod affinity` towards the litmus pod, which ensures that the node being taken down is not the one running the test pod.

The test playbook run logs are available below: 

[mysql_persistence_test_log.log](https://github.com/openebs/litmus/files/2178864/mysql_persistence_test_log.log)