### PR TITLE
Add dedicated log directory to each test

### DIFF
--- a/tests/fio/run_litmus_test.yaml
+++ b/tests/fio/run_litmus_test.yaml
@@ -57,6 +57,6 @@ spec:
             name: kubeconfig 
         - name: logs 
           hostPath:
-            path: /mnt
-            type: Directory 
+            path: /mnt/fio
+            type: "" 
 

--- a/tests/mysql/mysql_persistence_on_pod_eviction/README.md
+++ b/tests/mysql/mysql_persistence_on_pod_eviction/README.md
@@ -7,14 +7,16 @@ reschedule operation caused by immediate eviction effected by the Kubernetes nod
 
 ### Considerations
 
-- This test simulates one type of graceful node loss (other means include cordon+drain operations) 
+- This test requires a multi-node Kubernetes cluster 
+  *Note:* The min. count depends on individual storage solution's HA policies. For example OpenEBS needs 3-node cluster
+- This test simulates one type of graceful node loss (other means include cordon+drain operations)
 - The application reschedule time is also impacted by the amount of delay between disk attach and mount attempts by Kubernetes
 
 ### Steps to Run
 
-- Apply the litmus/hack/rbac.yaml to setup the Litmus namespace, service account, clusterrole and clusterrolebinding 
-- Create a configmap with content of kubernetes config file (needs to be named "admin.conf") 
-- Run the litmus test job 
+- Apply the litmus/hack/rbac.yaml to setup the Litmus namespace, service account, clusterrole and clusterrolebinding
+- Create a configmap with content of kubernetes config file (needs to be named "admin.conf")
+- Run the litmus test job
 - View the test run & pod logs on the litmus node at /mnt
 
 

--- a/tests/mysql/mysql_persistence_on_pod_eviction/run_litmus_test.yaml
+++ b/tests/mysql/mysql_persistence_on_pod_eviction/run_litmus_test.yaml
@@ -47,6 +47,6 @@ spec:
             name: kubeconfig 
         - name: logs 
           hostPath:
-            path: /mnt
-            type: Directory 
+            path: /mnt/mysql_persistence_on_pod_eviction
+            type: ""
 

--- a/tests/mysql/mysql_storage_benchmark/run_litmus_test.yaml
+++ b/tests/mysql/mysql_storage_benchmark/run_litmus_test.yaml
@@ -48,6 +48,6 @@ spec:
             name: kubeconfig 
         - name: logs 
           hostPath:
-            path: /mnt
-            type: Directory 
+            path: /mnt/mysql_storage_benchmark
+            type: ""
 


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- The current litmus test jobs uses "/mnt" as the log-location for placing the pod, cluster and ansible playbook logs. The tarball created after compression is based on timestamp and not intuitive for user to relate to test executed. This PR adds a log directory named after the test in /mnt to store the same logs. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- Until a better log visualization approach is identified, the following steps will have to be performed: 
  - Append test-name to hostPath volume.
  - Obtain the logs from *wherever* (node) litmus pod runs.

- The hostPath volume supports a "type" flag which can specify the nature of the mount. An empty string `""` creates the directory if not present before mounting into pod.