### PR TITLE
Include custom ansible stdout callback plugin "actionable"

### DIFF
--- a/executor/ansible/plugins/callback/actionable.py
+++ b/executor/ansible/plugins/callback/actionable.py
@@ -1,0 +1,94 @@
+# (c) 2015, Andrew Gaffney <andrew@agaffney.org>
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    callback: actionable
+    type: stdout
+    short_description: shows only items that need attention
+    description:
+      - Use this callback when you dont care about OK nor Skipped.
+      - This callback suppresses any non Failed or Changed status.
+    version_added: "2.1"
+    extends_documentation_fragment:
+      - default_callback
+    requirements:
+      - set as stdout callback in configuration
+'''
+
+from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
+
+
+class CallbackModule(CallbackModule_default):
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'actionable'
+
+    def __init__(self):
+        self.super_ref = super(CallbackModule, self)
+        self.super_ref.__init__()
+        self.last_task = None
+        self.shown_title = False
+
+    def v2_playbook_on_handler_task_start(self, task):
+        self.super_ref.v2_playbook_on_handler_task_start(task)
+        self.shown_title = True
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        self.last_task = task
+        self.shown_title = False
+
+    def display_task_banner(self):
+        if not self.shown_title:
+            self.super_ref.v2_playbook_on_task_start(self.last_task, None)
+            self.shown_title = True
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        self.display_task_banner()
+        self.super_ref.v2_runner_on_failed(result, ignore_errors)
+
+    def v2_runner_on_ok(self, result):
+        if result._result.get('changed', False):
+            self.display_task_banner()
+            #self.super_ref.v2_runner_on_ok(result)
+
+    def v2_runner_on_unreachable(self, result):
+        self.display_task_banner()
+        self.super_ref.v2_runner_on_unreachable(result)
+
+    def v2_runner_on_skipped(self, result):
+        pass
+
+    def v2_playbook_on_include(self, included_file):
+        pass
+
+    def v2_runner_item_on_ok(self, result):
+        if result._result.get('changed', False):
+            self.display_task_banner()
+            #self.super_ref.v2_runner_item_on_ok(result)
+
+    def v2_runner_item_on_skipped(self, result):
+        pass
+
+    def v2_runner_item_on_failed(self, result):
+        self.display_task_banner()
+        self.super_ref.v2_runner_item_on_failed(result)
+
+    def v2_runner_retry(self, result):
+        task_name = result.task_name or result._task
+        final_result = result._result['retries'] - result._result['attempts']
+        msg = "FAILED - RETRYING: %s (%d retries left)." % (task_name,
+                                                            final_result)
+        display_verbosity = self._display.verbosity
+        required_result = '_ansible_verbose_always'
+        if (display_verbosity > 2 or required_result in result._result):
+            if required_result not in result._result:
+                msg += "Result was: %s" % self._dump_results(result._result)
+        self._display.v('%s' % (msg))
+
+

--- a/tests/mysql/mysql_data_persistence/chaos/pumba/pod_failure_by_sigkill.yaml
+++ b/tests/mysql/mysql_data_persistence/chaos/pumba/pod_failure_by_sigkill.yaml
@@ -51,7 +51,7 @@
 - name: Force kill the application pod using pumba 
   shell: >
     kubectl exec {{ pumba_pod.stdout}} -n litmus
-    -- timeout -t 120 pumba --interval 15s kill
+    -- timeout -t 40 pumba --interval 15s kill
     --signal SIGKILL re2:k8s_{{ app_container.stdout }};
   args:
     executable: /bin/bash

--- a/tests/mysql/mysql_data_persistence/run_litmus_test.yaml
+++ b/tests/mysql/mysql_data_persistence/run_litmus_test.yaml
@@ -18,7 +18,8 @@ spec:
         image: openebs/ansible-runner
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK
-            value: log_plays
+            #value: log_plays
+            value: actionable
  
           - name: PROVIDER_STORAGE_CLASS
             # Supported values: openebs-standard, local-storage
@@ -26,7 +27,7 @@ spec:
 
           - name: CHAOS_TYPE
             # Supported values : APP_POD_EVICT/KUBECTL, APP_NODE_DRAIN/KUBECTL, APP_POD_KILL/PUMBA
-            value: "APP_POD_EVICT/KUBECTL"
+            value: "APP_POD_KILL/PUMBA"
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./mysql/mysql_data_persistence/test.yaml -i /etc/ansible/hosts -v; exit 0"]

--- a/tools/ansible-runner/Dockerfile
+++ b/tools/ansible-runner/Dockerfile
@@ -17,4 +17,6 @@ RUN mkdir /etc/ansible/ /ansible
 RUN echo "[local]" >> /etc/ansible/hosts && \
     echo "127.0.0.1" >> /etc/ansible/hosts
 
-ADD ./tests ./ 
+ADD ./tests ./
+
+COPY ./executor/ansible/plugins/callback/actionable.py /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/ 


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Include custom ansible stdout callback plugin "actionable"
- Minor updates to chaos type and duration for MySQL data persistence test

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

The callback plugin displays the test playbook run output similar to the following : 

```
PLAY [localhost] ***************************************************************
TASK [Check whether the provider storageclass is applied] **********************
TASK [Replace the pvc placeholder with test param] *****************************
TASK [Replace the storageclass placeholder with provider] **********************
TASK [Deploy percona mysql pod] ************************************************
TASK [Confirm mysql pod status is running] *************************************
TASK [Check for successful database init] **************************************
TASK [Create some test data in the mysql database] *****************************
TASK [Setup pumba chaos infrastructure] ****************************************
TASK [Confirm that the pumba ds is running on all nodes] ***********************
TASK [Identify the application node] *******************************************
TASK [Record the application container] ****************************************
TASK [Record the pumba pod on app node] ****************************************
TASK [Force kill the application pod using pumba] ******************************
TASK [Delete the pumba daemonset] **********************************************
TASK [Confirm that the pumba ds is deleted successfully] ***********************
TASK [Confirm mysql pod status is running] *************************************
TASK [Verify mysql data persistence] *******************************************
TASK [Create results file] *****************************************************
TASK [Get pvc name to verify successful pvc deletion] **************************
TASK [Delete percona mysql pod] ************************************************
TASK [Confirm percona pod has been deleted] ************************************
TASK [Confirm pvc pod has been deleted] ****************************************
PLAY RECAP *********************************************************************
127.0.0.1                  : ok=29   changed=22   unreachable=0    failed=0
```