### PR TITLE
Add playbooks to create and delete VPC in GCP

### DIFF
--- a/k8s/gcp/k8s-installer/create-vpc.yml
+++ b/k8s/gcp/k8s-installer/create-vpc.yml
@@ -1,0 +1,22 @@
+# Description:  Creates a Virtual Private Cloud with the name openebs-e2e, that will be specified
+# with all other clusters. Using --subnet-mode=auto will create a subnet for every zone. This file
+# is ran at the begining of e2e tests
+# Author: Harshvardhan Karn
+###############################################################################################
+#Steps:
+#1. Create a VPC, openebs-e2e in Google Cloud
+###############################################################################################
+
+---
+- hosts: localhost
+  tasks:
+       - block:
+             - name: Creating VPC 'openebs-e2e'
+               shell: gcloud compute --project=openebs-ci networks create openebs-e2e --subnet-mode=auto
+             - name: Test Passed
+               set_fact:
+                 flag: "Test Passed"
+         rescue:
+             - name: Test Failed
+               set_fact:
+                 flag: "Test Failed"

--- a/k8s/gcp/k8s-installer/delete-vpc.yml
+++ b/k8s/gcp/k8s-installer/delete-vpc.yml
@@ -1,0 +1,27 @@
+# Description:  Deletes the Virtual Private Cloud with the name openebs-e2e, runs when all e2e test
+# are finished running 
+# Author: Harshvardhan Karn
+###############################################################################################
+#Steps:
+#1. Delete the routes(if exists) and VPC , openebs-e2e in Google Cloud
+###############################################################################################
+
+---
+- hosts: localhost
+  vars_files:
+    - gcp-vars.yml
+  tasks:
+       - block:
+             - block:
+                 - name: Deleting VPC `openebs-e2e`
+                   shell: gcloud compute routes delete $(gcloud compute routes list --filter="name:openebs AND network:openebs-e2e"  --format="get(name)") -q || gcloud compute --project=openebs-ci networks delete openebs-e2e -q
+               rescue:
+                 - name: Only VPC
+                   shell: gcloud compute --project=openebs-ci networks delete openebs-e2e -q 
+             - name: Test Passed
+               set_fact:
+                 flag: "Test Passed"
+         rescue:
+             - name: Test Failed
+               set_fact:
+                 flag: "Test Failed"


### PR DESCRIPTION
- Add `create-vpc.yml`, an ansible playbook on execution will create a VPC,
openebs-ci, in Google Cloud Platform, with a subnet in every region,
 using gcloud per se
- Add `delete-vpc.yml`, an ansible playbook is responsible for deleting the VPC
openebs-ci, and also deleting the routes associated if exists

Signed-off-by: harshvkarn <harshvkarn54@gmail.com>