### PR TITLE
Adds litmus book to install openebs 0.6

### DIFF
--- a/Providers/OpenEBS/Installers/Operator/0.6/ansible/openebs.yaml
+++ b/Providers/OpenEBS/Installers/Operator/0.6/ansible/openebs.yaml
@@ -2,35 +2,72 @@
 # Apply openebs operator and openebs storage class
 
 - hosts: localhost
-  connection: local  
+  connection: local
+
+  vars_files:
+  - vars.yaml
+
   tasks:
-   - name: Applying openebs operator
-     shell: kubectl --kubeconfig /root/admin.conf apply -f https://raw.githubusercontent.com/openebs/openebs/v0.6/k8s/openebs-operator.yaml 
-     args:
-       executable: /bin/bash
+    - name: Applying openebs operator
+      shell: \{{ kubeapply }} apply -f {{ openebsOperatorLink }} 
+      args:
+        executable: /bin/bash
 
-   - name: Applying openebs storageclass 
-     shell: kubectl --kubeconfig /root/admin.conf apply -f https://raw.githubusercontent.com/openebs/openebs/v0.6/k8s/openebs-storageclasses.yaml 
-     args:
-       executable: /bin/bash
+    - name: Applying openebs storageclass 
+      shell: \{{ kubeapply }} apply -f {{ openebsStorageclassLink }} 
+      args:
+        executable: /bin/bash
 
-   - name: Checking Maya-API-Server is running
-     shell: kubectl get po --all-namespaces | grep maya-apiserver | awk '{print $4}'
-     register: maya_api
-     until: "'Running' in maya_api.stdout"
-     delay: 30
-     retries: 100
+    - block:
+          - name: Checking Maya-API-Server is running
+            shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.labels.name=="maya-apiserver")].status.phase}'
+            register: maya_api
+            until: "'Running' in maya_api.stdout"
+            delay: 30
+            retries: 100
 
-   - name: Checking OpenEBS-provisioner is running
-     shell: kubectl get po --all-namespaces | grep openebs-provisioner | awk '{print $4}'
-     register: openebs_prob
-     until: "'Running' in openebs_prob.stdout"
-     delay: 30
-     retries: 100
+          - name: Checking OpenEBS-provisioner is running
+            shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.labels.name=="openebs-provisioner")].status.phase}'
+            register: openebs_prob
+            until: "'Running' in openebs_prob.stdout"
+            delay: 30
+            retries: 100
 
-   - name: Checking OpenEBS-Snapshot-Operator is running
-     shell: kubectl get po --all-namespaces | grep openebs-snapshot-operator | awk '{print $4}'
-     register: oso
-     until: "'Running' in oso.stdout"
-     delay: 30
-     retries: 100
+          - name: Get maya-apiserver pod name
+            shell: kubectl get pods -n {{ namespace }} --selector=name=maya-apiserver
+            args:
+              executable: /bin/bash
+            register: result_name
+
+          - name: Create fact for pod name
+            set_fact: 
+              pod_name: "{{ result_name.stdout_lines[1].split()[0] }}"
+
+          - name: Checking OpenEBS-Snapshot-Operator is running
+            shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.labels.name=="openebs-snapshot-operator")].status.phase}'
+            register: oso
+            until: "'Running' in oso.stdout"
+            delay: 30
+            retries: 100
+
+          - name: Confirm that maya-cli is available in the maya-apiserver pod
+            shell: kubectl exec {{pod_name}} -c maya-apiserver -n {{ namespace }} -- mayactl version
+            args:
+              executable: /bin/bash
+            register: result_vers
+            failed_when: "'m-apiserver status:  running' not in result_vers.stdout"
+
+          - name: Confirm that openebs storage classes are created
+            shell: kubectl get sc
+            args:
+              executable: /bin/bash
+            register: result_sc
+            until: "'openebs.io/provisioner-iscsi' in result_sc.stdout"
+            delay: 30 
+            retries: 100
+          
+          - set_fact:
+              flag: "Pass"
+      rescue: 
+        - set_fact: 
+            flag: "Fail"

--- a/Providers/OpenEBS/Installers/Operator/0.6/ansible/openebs.yaml
+++ b/Providers/OpenEBS/Installers/Operator/0.6/ansible/openebs.yaml
@@ -1,0 +1,36 @@
+# TODO 
+# Apply openebs operator and openebs storage class
+
+- hosts: localhost
+  connection: local  
+  tasks:
+   - name: Applying openebs operator
+     shell: kubectl --kubeconfig /root/admin.conf apply -f https://raw.githubusercontent.com/openebs/openebs/v0.6/k8s/openebs-operator.yaml 
+     args:
+       executable: /bin/bash
+
+   - name: Applying openebs storageclass 
+     shell: kubectl --kubeconfig /root/admin.conf apply -f https://raw.githubusercontent.com/openebs/openebs/v0.6/k8s/openebs-storageclasses.yaml 
+     args:
+       executable: /bin/bash
+
+   - name: Checking Maya-API-Server is running
+     shell: kubectl get po --all-namespaces | grep maya-apiserver | awk '{print $4}'
+     register: maya_api
+     until: "'Running' in maya_api.stdout"
+     delay: 30
+     retries: 100
+
+   - name: Checking OpenEBS-provisioner is running
+     shell: kubectl get po --all-namespaces | grep openebs-provisioner | awk '{print $4}'
+     register: openebs_prob
+     until: "'Running' in openebs_prob.stdout"
+     delay: 30
+     retries: 100
+
+   - name: Checking OpenEBS-Snapshot-Operator is running
+     shell: kubectl get po --all-namespaces | grep openebs-snapshot-operator | awk '{print $4}'
+     register: oso
+     until: "'Running' in oso.stdout"
+     delay: 30
+     retries: 100

--- a/Providers/OpenEBS/Installers/Operator/0.6/ansible/vars.yaml
+++ b/Providers/OpenEBS/Installers/Operator/0.6/ansible/vars.yaml
@@ -1,0 +1,6 @@
+---
+
+kubeapply: kubectl --kubeconfig /root/admin.conf
+namespace: openebs
+openebsOperatorLink: https://raw.githubusercontent.com/openebs/openebs/v0.6/k8s/openebs-operator.yaml
+openebsStorageclassLink: https://raw.githubusercontent.com/openebs/openebs/v0.6/k8s/openebs-storageclasses.yaml

--- a/Providers/OpenEBS/Installers/Operator/0.6/litmusbook/setup_openebs.yaml
+++ b/Providers/OpenEBS/Installers/Operator/0.6/litmusbook/setup_openebs.yaml
@@ -19,7 +19,7 @@ spec:
           - name: ANSIBLE_STDOUT_CALLBACK
             value: actionable
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./openebs/openebs.yaml -i /etc/ansible/hosts -v; exit 0"]
+        args: ["-c", "ansible-playbook ./ansible/openebs.yaml -i /etc/ansible/hosts -v; exit 0"]
         volumeMounts:
           - name: kubeconfig 
             mountPath: /root/admin.conf

--- a/Providers/OpenEBS/Installers/Operator/0.6/litmusbook/setup_openebs.yaml
+++ b/Providers/OpenEBS/Installers/Operator/0.6/litmusbook/setup_openebs.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: litmus-openebs
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: actionable
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./openebs/openebs.yaml -i /etc/ansible/hosts -v; exit 0"]
+        volumeMounts:
+          - name: kubeconfig 
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /var/log/ansible 
+      volumes: 
+        - name: kubeconfig
+          configMap: 
+            name: kubeconfig 
+        - name: logs 
+          hostPath:
+            path: /mnt/openebs
+            type: ""

--- a/tools/ansible-runner/Dockerfile
+++ b/tools/ansible-runner/Dockerfile
@@ -19,8 +19,6 @@ RUN echo "[local]" >> /etc/ansible/hosts && \
 
 ADD ./tests ./
 
-RUN mkdir -p ./openebs
-
-ADD Providers/OpenEBS/Installers/Operator/0.6/ansible/openebs.yaml ./openebs/openebs.yaml
+ADD Providers/OpenEBS/Installers/Operator/0.6/ ./
 
 COPY ./executor/ansible/plugins/callback/actionable.py /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/ 

--- a/tools/ansible-runner/Dockerfile
+++ b/tools/ansible-runner/Dockerfile
@@ -19,4 +19,8 @@ RUN echo "[local]" >> /etc/ansible/hosts && \
 
 ADD ./tests ./
 
+RUN mkdir -p ./openebs
+
+ADD Providers/OpenEBS/Installers/Operator/0.6/ansible/openebs.yaml ./openebs/openebs.yaml
+
 COPY ./executor/ansible/plugins/callback/actionable.py /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/ 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This PR adds litmusbook for installing openebs v0.6 in kubernetes cluster .
- This book has been tested on both AWS and GCP cluster .

**Special notes for your reviewer**:

- Logs for litmus pod running this book in GCP cluster :
```
kubectl log -n litmus litmus-openebs-qk9bd
log is DEPRECATED and will be removed in a future version. Use logs instead.
No config file found; using defaults

PLAY [localhost] ***************************************************************

TASK [Applying openebs operator] ***********************************************

TASK [Applying openebs storageclass] *******************************************
FAILED - RETRYING: Checking Maya-API-Server is running (100 retries left).

TASK [Checking Maya-API-Server is running] *************************************

TASK [Checking OpenEBS-provisioner is running] *********************************

TASK [Checking OpenEBS-Snapshot-Operator is running] ***************************

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=6    changed=5    unreachable=0    failed=0 

```
- Ansible Runner image has to be updated with openebs ansible playbook present in this PR .