### PR TITLE
[WIP] Adds litmus and ansible books to install openebs v0.7 using litmus

### DIFF
--- a/Providers/OpenEBS/Installers/Operator/0.7/ansible/openebs.yaml
+++ b/Providers/OpenEBS/Installers/Operator/0.7/ansible/openebs.yaml
@@ -1,0 +1,31 @@
+# TODO 
+# Apply openebs operator and openebs storage class
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+  - vars.yaml
+
+  tasks:
+    - name: Applying openebs operator
+      shell: "{{ kubeapply }} apply -f {{ openebs_operator_link }}" 
+      args:
+        executable: /bin/bash
+
+    - name: Applying openebs storageclass 
+      shell: "{{ kubeapply }} apply -f {{ openebs_storageclass_link }}" 
+      args:
+        executable: /bin/bash
+
+    - name: Applying openebs storagepoolclaim 
+      shell: "{{ kubeapply }} apply -f {{ openebs_storagepoolclaim_link }}" 
+      args:
+        executable: /bin/bash
+
+    - block:
+          - set_fact:
+              flag: "Pass"
+      rescue: 
+        - set_fact: 
+            flag: "Fail"

--- a/Providers/OpenEBS/Installers/Operator/0.7/ansible/vars.yaml
+++ b/Providers/OpenEBS/Installers/Operator/0.7/ansible/vars.yaml
@@ -1,0 +1,7 @@
+---
+
+kubeapply: kubectl --kubeconfig /root/admin.conf
+namespace: openebs
+openebs_operator_link: https://raw.githubusercontent.com/AmitKumarDas/openebs/2891b35c5f381151ad870342d2674a810bb87f54/k8s/openebs-operator.yaml
+openebs_storageclass_link: https://raw.githubusercontent.com/AmitKumarDas/openebs/2891b35c5f381151ad870342d2674a810bb87f54/k8s/openebs-storageclasses.yaml
+openebs_storagepoolclaim_link: https://raw.githubusercontent.com/AmitKumarDas/openebs/2891b35c5f381151ad870342d2674a810bb87f54/k8s/openebs-storagepoolclaims.yaml

--- a/Providers/OpenEBS/Installers/Operator/0.7/litmusbook/setup_openebs.yaml
+++ b/Providers/OpenEBS/Installers/Operator/0.7/litmusbook/setup_openebs.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: litmus-openebs
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: IfNotPresent
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: actionable
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./0.7/ansible/openebs.yaml -i /etc/ansible/hosts -v; exit 0"]
+        volumeMounts:
+          - name: kubeconfig 
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /var/log/ansible 
+      volumes: 
+        - name: kubeconfig
+          configMap: 
+            name: kubeconfig 
+        - name: logs 
+          hostPath:
+            path: /mnt/openebs
+            type: ""

--- a/tools/ansible-runner/Dockerfile
+++ b/tools/ansible-runner/Dockerfile
@@ -19,6 +19,6 @@ RUN echo "[local]" >> /etc/ansible/hosts && \
 
 ADD ./tests ./
 
-ADD Providers/OpenEBS/Installers/Operator/0.6/ ./
+ADD Providers/OpenEBS/Installers/Operator/ ./
 
 COPY ./executor/ansible/plugins/callback/actionable.py /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/ 


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This PR will add litmus books and ansible book for installing openebs v0.7 using litmus .
- Modifies the docker file to copy all files present under this path Providers/OpenEBS/Installers/Operator/ to ansible-runner image.

**Special notes for your reviewer**:
- This litmus book has been tested on 3 node vagrant cluster .
- Create config map with admin.conf file . If admin.conf file is not present rename config file to admin.conf and create configmap .
- Output of ```kubectl get pods,svc --all-namespaces -o wide``` : 
```NAMESPACE     NAME                                         READY     STATUS      RESTARTS   AGE       IP             NODE
kube-system   etcd-kubemaster-01                           1/1       Running     0          2h        172.28.128.3   kubemaster-01
kube-system   kube-apiserver-kubemaster-01                 1/1       Running     0          2h        172.28.128.3   kubemaster-01
kube-system   kube-controller-manager-kubemaster-01        1/1       Running     0          2h        172.28.128.3   kubemaster-01
kube-system   kube-dns-86f4d74b45-kvgf5                    3/3       Running     0          2h        10.1.0.3       kubemaster-01
kube-system   kube-proxy-75s5c                             1/1       Running     0          2h        172.28.128.6   kubeminion-03
kube-system   kube-proxy-m66tk                             1/1       Running     0          2h        172.28.128.5   kubeminion-02
kube-system   kube-proxy-tvfsw                             1/1       Running     0          2h        172.28.128.3   kubemaster-01
kube-system   kube-proxy-v5ktj                             1/1       Running     0          2h        172.28.128.4   kubeminion-01
kube-system   kube-router-8hmrp                            1/1       Running     0          2h        172.28.128.5   kubeminion-02
kube-system   kube-router-lcj7z                            1/1       Running     0          2h        172.28.128.6   kubeminion-03
kube-system   kube-router-qzm6r                            1/1       Running     0          2h        172.28.128.3   kubemaster-01
kube-system   kube-router-wrwv2                            1/1       Running     0          2h        172.28.128.4   kubeminion-01
kube-system   kube-scheduler-kubemaster-01                 1/1       Running     0          2h        172.28.128.3   kubemaster-01
kube-system   kubernetes-dashboard-75d647ffd9-n9rf9        1/1       Running     0          2h        10.1.0.2       kubemaster-01
litmus        litmus-openebs-rzwjv                         0/1       Completed   0          2m        10.1.1.4       kubeminion-01
openebs       maya-apiserver-5df8bfb4bc-jzdnk              1/1       Running     0          1m        10.1.3.5       kubeminion-03
openebs       node-disk-manager-4wtnv                      1/1       Running     0          1m        172.28.128.5   kubeminion-02
openebs       node-disk-manager-nh4ks                      1/1       Running     0          1m        172.28.128.6   kubeminion-03
openebs       node-disk-manager-sdr84                      1/1       Running     0          1m        172.28.128.4   kubeminion-01
openebs       openebs-provisioner-5d4b8c968b-shpdt         1/1       Running     0          1m        10.1.2.5       kubeminion-02
openebs       openebs-snapshot-operator-745d9c945d-ljwbx   2/2       Running     0          1m        10.1.1.5       kubeminion-01

NAMESPACE     NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)         AGE       SELECTOR
default       kubernetes               ClusterIP   10.96.0.1        <none>        443/TCP         2h        <none>
kube-system   kube-dns                 ClusterIP   10.96.0.10       <none>        53/UDP,53/TCP   2h        k8s-app=kube-dns
kube-system   kubernetes-dashboard     ClusterIP   10.111.152.109   <none>        80/TCP          2h        k8s-app=kubernetes-dashboard
openebs       maya-apiserver-service   ClusterIP   10.111.68.55     <none>        5656/TCP        1m        name=maya-apiserver