### PR TITLE
Fix broken travis builds/CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ metalint:
 	@echo "------------------"
 	@echo "--> Running metalinter"
 	@echo "------------------"
-	@gometalinter $(PACKAGES)
+	@gometalinter $(PACKAGES) --exclude=gosec 
 
 .PHONY: compile
 compile:


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Some recent changes to the gometalinter is seen to break the CI. This PR excludes gosec linter (suspected lint tool)

```
2.07s$ make
------------------
--> Running go fmt
------------------
------------------
--> Running metalinter
------------------
pkg/exec/exec.go:49::warning: Subprocess launched with variable,MEDIUM,HIGH (gosec)
make: *** [metalint] Error 1
```

- There is no new go-libraries being added into litmus at this point, so adding the above exclude until active go development resumes. 
