### PR TITLE
Initial commit for Litmus result CRD & CR spec 

### DIFF
--- a/hack/litmus-result.yaml
+++ b/hack/litmus-result.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: litmus.io/v1alpha1
+kind: LitmusResult
+metadata:
+
+  # name of the litmus testcase
+  name: @test # mysql_data_persistence
+spec:
+
+  # holds information on the testcase
+  test-metadata:
+    app: @app # percona-mysql 
+    chaostype: @chaos # APP_POD_KILL/PUMBA
+
+  # holds the state of testcase,  manually updated by json merge patch
+  # result is the useful value today, but anticipate phase use in future 
+  test-status: 
+    phase: @phase # completed 
+    result: @result # pass 
+

--- a/hack/rbac.yaml
+++ b/hack/rbac.yaml
@@ -37,3 +37,26 @@ subjects:
 - kind: ServiceAccount
   name: litmus
   namespace: litmus
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: litmusresults.litmus.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: litmus.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: litmusresults
+    # singular name to be used as an alias on the CLI and for display
+    singular: litmusresult
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: LitmusResult
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - lr

--- a/tools/ansible-runner/Dockerfile
+++ b/tools/ansible-runner/Dockerfile
@@ -22,3 +22,5 @@ ADD ./tests ./
 ADD providers/openebs/installers/operator/ ./
 
 COPY ./executor/ansible/plugins/callback/actionable.py /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/ 
+
+COPY ./hack/litmus-result.yaml ./


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- The litmus test results are currently maintained in a result.json file that is stored inside the "logdir" specified in the litmus job, which is a host path on the node. For any CI system, executing the litmus tests, extracting the test results would mean fetching the file content from the node OR parsing the ansible runner pod logs to the result strings.  It would be desirable to have a better/simpler means of getting the results. This PR addresses this need, and makes a provision for the test status  to be stored in a custom resource  (thanks @kmova ). This way the test results can also be obtained via a kubectl command (the CI stage/job executing the test can perform this step) 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- The initial expectation is to have the test auto-generate the result CR spec from a template burned into the ansible-runner, with necessary test metadata & status/phase as *running*, with the spec updated upon test completion with appropriate values for status (*completed*) & result (*pass/fail*).

- CRDs do not support strategic merge patch, thereby making updates of specific field alone. The updates need to be made by a re-apply of the spec (acts as a JSON merge patch) 

- At this point, these custom resources are all *statically provisioned/maintained*, i.e., just structured data with no custom controllers, watchers etc., though it is expected to evolve as such in the coming days. 

- Example CRD/CR are provided below: 

(Litmus Result CRD)

```
ubuntu@kubemaster-01:~$ kubectl get crd litmusresults.litmus.io -o yaml
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apiextensions.k8s.io/v1beta1","kind":"CustomResourceDefinition","metadata":{"annotations":{},"name":"litmusresults.litmus.io","namespace":""},"spec":{"group":"litmus.io","names":{"kind":"LitmusResult","plural":"litmusresults","shortNames":["lr"],"singular":"litmusresult"},"scope":"Namespaced","version":"v1alpha1"}}
  creationTimestamp: 2018-08-08T09:57:55Z
  generation: 1
  name: litmusresults.litmus.io
  resourceVersion: "3415619"
  selfLink: /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/litmusresults.litmus.io
  uid: 85c84fc0-9af1-11e8-83d8-02b983f0a4db
spec:
  group: litmus.io
  names:
    kind: LitmusResult
    listKind: LitmusResultList
    plural: litmusresults
    shortNames:
    - lr
    singular: litmusresult
  scope: Namespaced
  version: v1alpha1
status:
  acceptedNames:
    kind: LitmusResult
    listKind: LitmusResultList
    plural: litmusresults
    shortNames:
    - lr
    singular: litmusresult
  conditions:
  - lastTransitionTime: 2018-08-08T09:57:55Z
    message: no conflicts found
    reason: NoConflicts
    status: "True"
    type: NamesAccepted
  - lastTransitionTime: 2018-08-08T09:57:55Z
    message: the initial names have been accepted
    reason: InitialNamesAccepted
    status: "True"
    type: Established
```

(Litmus Result CR)

```
ubuntu@kubemaster-01:~$ kubectl get lr litmus-test-1 -o yaml
apiVersion: litmus.io/v1alpha1
kind: LitmusResult
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"litmus.io/v1alpha1","kind":"LitmusResult","metadata":{"annotations":{},"name":"litmus-test-1","namespace":"default"},"spec":{"test-metadata":{"app":null,"type":null},"test-status":{"phase":"completed","result":"pass"}}}
  clusterName: ""
  creationTimestamp: 2018-08-08T10:43:49Z
  generation: 1
  name: litmus-test-1
  namespace: default
  resourceVersion: "3421577"
  selfLink: /apis/litmus.io/v1alpha1/namespaces/default/litmusresults/litmus-test-1
  uid: eef544e7-9af7-11e8-83d8-02b983f0a4db
spec:
  test-metadata:
    app: null
    type: null
  test-status:
    phase: completed
    result: pass
```