### PR TITLE
Add playbook for create ebs-volume in aws

### DIFF
--- a/k8s/aws/ebs-volumes/README.md
+++ b/k8s/aws/ebs-volumes/README.md
@@ -1,14 +1,22 @@
-# AWS platform specific code and scripts
-## Amazon web service and Attiching EBS Volume in Provided Kubernetes cluster
 
-### Prerequistes
+# AWS platform specific code and scripts
+
+## Amazon web service and Attaching EBS Volume in Provided Kubernetes cluster
+
+### Pre-requisites
 
 - AWS Cluster is up and running
 - Disable ansible host key checking `export ANSIBLE_HOST_KEY_CHECKING=False`
 
+#### Execution and Inventory Requirements
+
+- Public IPs of VMs/Nodes
+- SSH connection to VMs/Nodes
+- `delegate_to` and `with_items` ansible module use for SSH in VMs/Nodes and loop on each VMs/Nodes respectively
+
 ### Creating, attach and mount EBS Volume in AWS Cluster
 
-- Run `create-ebs-volume`, will create, attach and mount EBS volume to each node of provided cluster name.
+- `create-ebs-volume`, will create, attach and mount EBS volume to each node of provided cluster name.
 
 ```bash
 ansible-playbook create-ebs-volume.yml -vv --extra-vars "cluster_name=<aws-cluster-name>"
@@ -16,7 +24,7 @@ ansible-playbook create-ebs-volume.yml -vv --extra-vars "cluster_name=<aws-clust
 
 ### Unmount, Detach and delete EBS Volume in AWS cluster
 
-- Run `delete-ebs-volume`, will unmount, detach and delete EBS volume from the provided cluster.
+- `delete-ebs-volume`, will unmount, detach and delete EBS volume from the provided cluster.
 
 ```bash
 ansible-playbook delete-ebs-volume.yml -vv --extra-vars "cluster_name=<aws-cluster-name>"

--- a/k8s/aws/ebs-volumes/README.md
+++ b/k8s/aws/ebs-volumes/README.md
@@ -1,0 +1,23 @@
+# AWS platform specific code and scripts
+## Amazon web service and Attiching EBS Volume in Provided Kubernetes cluster
+
+### Prerequistes
+
+- AWS Cluster is up and running
+- Disable ansible host key checking `export ANSIBLE_HOST_KEY_CHECKING=False`
+
+### Creating, attach and mount EBS Volume in AWS Cluster
+
+- Run `create-ebs-volume`, will create, attach and mount EBS volume to each node of provided cluster name.
+
+```bash
+ansible-playbook create-ebs-volume.yml -vv --extra-vars "cluster_name=<aws-cluster-name>"
+```
+
+### Unmount, Detach and delete EBS Volume in AWS cluster
+
+- Run `delete-ebs-volume`, will unmount, detach and delete EBS volume from the provided cluster.
+
+```bash
+ansible-playbook delete-ebs-volume.yml -vv --extra-vars "cluster_name=<aws-cluster-name>"
+```

--- a/k8s/aws/ebs-volumes/create-ebs-volume.yml
+++ b/k8s/aws/ebs-volumes/create-ebs-volume.yml
@@ -1,0 +1,61 @@
+---
+- hosts: localhost
+
+  vars_files:
+    - vars.yml
+
+  vars:
+    cluster_name: "{{ cluster_name }}"
+
+  tasks:
+    - block:
+        - name: Gather fact about instances in AWS
+          ec2_instance_facts:
+            filters:
+              availability-zone: "{{ zone }}"
+              "tag:Name": "{{ cluster_name }}"
+          register: result
+
+        - name: Creating and attaching EBS Volume in AWS
+          ec2_vol:
+            instance: "{{item.instance_id}}"
+            device_name: "{{ device_name }}"
+            region: "{{ region }}"
+            state: present
+            volume_size: "{{ volume_size }}"
+            volume_type: "{{ volume_type }}"
+            zone: "{{ zone }}"
+          register: volumes
+          with_items: "{{result.instances}}"
+
+        - name: Creating mount directory in Nodes
+          file:
+            path: "{{ mount_path }}"
+            state: directory
+          become: true
+          delegate_to: "ubuntu@{{ item.public_ip_address }}"
+          with_items: "{{ result.instances }}"
+
+        - name: Mounting EBS Volume to Nodes 
+          shell: mkfs.ext4 {{ device_name }}; mount -o sync {{ device_name }} {{ mount_path }}
+          become: true
+          delegate_to: "ubuntu@{{ item.public_ip_address }}"
+          with_items: "{{ result.instances }}"
+
+        - name: Create a csv file for store all Ids
+          lineinfile:
+            create: yes
+            state: present
+            path: "/tmp/aws/volume-id"
+            line: '{{ item.volume_id }}'
+            mode: 0755
+          with_items: "{{volumes.results}}"
+
+        - name: Test Passed
+          set_fact:
+            flag: "Test Passed"
+
+    - rescue:
+        - name: Test Failed
+          set_fact:
+            flag: "Test Failed"

--- a/k8s/aws/ebs-volumes/create-ebs-volume.yml
+++ b/k8s/aws/ebs-volumes/create-ebs-volume.yml
@@ -1,3 +1,16 @@
+# create-ebs-volume.yml
+# Description:  This will create EBS volume in aws attach this volume to each nodes of cluster
+
+###############################################################################################
+#Test Steps:
+
+#1. Gather fact about cluster
+#2. Create and attach EBS Volume in AWS
+#3. create ext4 file system in EBS Volumes
+#4. Mount EBS Volumes to Ndoes
+#5. create a file for store volumes id
+###############################################################################################
+
 ---
 - hosts: localhost
 
@@ -28,16 +41,20 @@
           register: volumes
           with_items: "{{result.instances}}"
 
-        - name: Creating mount directory in Nodes
-          file:
-            path: "{{ mount_path }}"
-            state: directory
+        - name: Create ext4 filesystem in EBS Volumes
+          filesystem:
+            fstype: ext4
+            dev: "{{device_name}}"
           become: true
           delegate_to: "ubuntu@{{ item.public_ip_address }}"
           with_items: "{{ result.instances }}"
 
-        - name: Mounting EBS Volume to Nodes 
-          shell: mkfs.ext4 {{ device_name }}; mount -o sync {{ device_name }} {{ mount_path }}
+        - name: mounting EBS volumes to AWS Nodes
+          mount:
+            path: "{{mount_path}}"
+            src: "{{device_name}}"
+            fstype: ext4
+            state: mounted
           become: true
           delegate_to: "ubuntu@{{ item.public_ip_address }}"
           with_items: "{{ result.instances }}"

--- a/k8s/aws/ebs-volumes/delete-ebs-volume.yml
+++ b/k8s/aws/ebs-volumes/delete-ebs-volume.yml
@@ -1,0 +1,55 @@
+---
+- hosts: localhost
+  
+  vars_files:
+    - vars.yml
+
+  vars:
+    cluster_name: "{{ cluster_name }}"
+  
+  tasks:
+    - block:
+        - name: Gather fact about instances in AWS
+          ec2_instance_facts:
+            filters:
+              availability-zone: "{{ zone }}"
+              "tag:Name": "{{ cluster_name }}"
+          register: result
+
+        - name: Unmounting EBS Volume from Nodes 
+          shell: umount {{ device_name }}
+          become: true
+          delegate_to: "ubuntu@{{ item.public_ip_address }}"
+          with_items: "{{ result.instances }}"
+          ignore_errors: True
+
+        - name: Detaching EBS Volume
+          ec2_vol:
+            id: "{{ item }}"
+            instance: None
+            region: "{{ region }}"
+          with_lines: cat /tmp/aws/volume-id
+
+        - name: Deleting EBS volume in AWS
+          ec2_vol:
+            id: "{{ item }}"
+            state: absent
+            region: "{{ region }}"
+          with_lines: cat /tmp/aws/volume-id
+
+        - name: Delete csv file which store all Ids
+          lineinfile:
+            create: yes
+            state: absent
+            path: "/tmp/aws/volume-id"
+            regexp: ""
+            mode: 0755
+
+        - name: Test Passed
+          set_fact:
+            flag: "Test Passed"
+
+    - rescue:
+        - name: Test Failed
+          set_fact:
+            flag: "Test Failed"

--- a/k8s/aws/ebs-volumes/delete-ebs-volume.yml
+++ b/k8s/aws/ebs-volumes/delete-ebs-volume.yml
@@ -1,3 +1,15 @@
+# delete-ebs-volume.yml
+# Description:  This will unmount, detach and delete EBS volume from each nodes of cluster
+###############################################################################################
+#Test Steps:
+
+#1. Gather fact about cluster
+#2. Unmount EBS Volumes from Ndoes
+#3. Detach Ebs volumes from nodes in  AWS
+#4. Delete EBS volumes from Nodes in AWS
+#5. Delete file content which store the volumes id
+###############################################################################################
+
 ---
 - hosts: localhost
   
@@ -16,12 +28,15 @@
               "tag:Name": "{{ cluster_name }}"
           register: result
 
-        - name: Unmounting EBS Volume from Nodes 
-          shell: umount {{ device_name }}
+        - name: unmounting EBS volumes to AWS Nodes
+          mount:
+            path: "{{mount_path}}"
+            src: "{{device_name}}"
+            fstype: ext4
+            state: unmounted
           become: true
           delegate_to: "ubuntu@{{ item.public_ip_address }}"
           with_items: "{{ result.instances }}"
-          ignore_errors: True
 
         - name: Detaching EBS Volume
           ec2_vol:

--- a/k8s/aws/ebs-volumes/vars.yml
+++ b/k8s/aws/ebs-volumes/vars.yml
@@ -1,0 +1,7 @@
+---
+zone: eu-west-2a
+region: eu-west-2
+volume_size: 50
+volume_type: gp2
+device_name: /dev/xvdb
+mount_path: /mnt/openebs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Add `create-ebs-volume.yml` playbook will create, attach and mount ebs-volume.
- Add `delete-ebs-volume.yml` playbook will unmount, detach and delete ebs-volume.
- Add `vars.yml` will store all variable data.

**Special notes for your reviewer**:
 - O/P for create-ebs-volume.yml
```
$ ansible-playbook create-ebs-volume.yml --extra-vars "cluster_name=nodes.k8s-compassionate-babbage.k8s.local"
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] ********************************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************************
ok: [localhost]

TASK [Gather fact about instances in AWS] *******************************************************************************************************************************
ok: [localhost]

TASK [Creating and attaching EBS Volume in AWS] *************************************************************************************************************************
changed: [localhost] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'35.176.203.87', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-06755ca2083f98d87'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 2, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-15b9c141', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-015ec1e9', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.99', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:4a:86:59:25:c0', u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-03c368938e128a883', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})
changed: [localhost] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'35.177.81.12', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-01d3b88b314500ad4'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 0, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-17b9c143', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-035ec1eb', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.239', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:68:10:5d:51:20', u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-08de7cbedabbcef88', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})
changed: [localhost] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'18.130.73.200', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-0b86048bec682ac47'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 1, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-16b9c142', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-005ec1e8', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.229', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:06:e3:76:d0:66', u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-0a8f8c2df6608c733', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})

TASK [Creating mount directory in Nodes] ********************************************************************************************************************************
ok: [localhost -> ubuntu@35.176.203.87] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'35.176.203.87', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-06755ca2083f98d87'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 2, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-15b9c141', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-015ec1e9', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.99', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:4a:86:59:25:c0', u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-03c368938e128a883', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})
ok: [localhost -> ubuntu@35.177.81.12] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'35.177.81.12', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-01d3b88b314500ad4'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 0, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-17b9c143', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-035ec1eb', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.239', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:68:10:5d:51:20', u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-08de7cbedabbcef88', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})
ok: [localhost -> ubuntu@18.130.73.200] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'18.130.73.200', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-0b86048bec682ac47'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 1, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-16b9c142', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-005ec1e8', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.229', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:06:e3:76:d0:66', u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-0a8f8c2df6608c733', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})

TASK [Mounting EBS Volume to Nodes] *************************************************************************************************************************************
changed: [localhost -> ubuntu@35.176.203.87] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'35.176.203.87', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-06755ca2083f98d87'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 2, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-15b9c141', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-015ec1e9', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.99', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:4a:86:59:25:c0', u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-03c368938e128a883', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})
changed: [localhost -> ubuntu@35.177.81.12] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'35.177.81.12', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-01d3b88b314500ad4'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 0, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-17b9c143', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-035ec1eb', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.239', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:68:10:5d:51:20', u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-08de7cbedabbcef88', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})
changed: [localhost -> ubuntu@18.130.73.200] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'18.130.73.200', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-0b86048bec682ac47'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 1, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-16b9c142', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-005ec1e8', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.229', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:06:e3:76:d0:66', u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-0a8f8c2df6608c733', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})

TASK [Create a csv file for store all Ids] ******************************************************************************************************************************
changed: [localhost] => (item={'_ansible_parsed': True, u'changed': True, '_ansible_item_label': {u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'cpu_options': {u'threads_per_core': 1, u'core_count': 2}, u'hypervisor': u'xen', u'source_dest_check': False, u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'root_device_name': u'/dev/sda1', u'public_ip_address': u'35.176.203.87', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-06755ca2083f98d87'}, u'device_name': u'/dev/sda1'}], u'placement': {u'availability_zone': u'eu-west-2a', u'tenancy': u'default', u'group_name': u''}, u'ami_launch_index': 2, u'state_transition_reason': u'', u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'ipv6_addresses': [], u'network_interface_id': u'eni-15b9c141', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-015ec1e9', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.99', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:4a:86:59:25:c0', u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'source_dest_check': False, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-03c368938e128a883', u'instance_type': u't2.large', u'architecture': u'x86_64', u'ena_support': True, u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []}, 'item': {u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'cpu_options': {u'threads_per_core': 1, u'core_count': 2}, u'source_dest_check': False, u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'root_device_name': u'/dev/sda1', u'public_ip_address': u'35.176.203.87', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'ena_support': True, u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-06755ca2083f98d87'}, u'device_name': u'/dev/sda1'}], u'placement': {u'availability_zone': u'eu-west-2a', u'tenancy': u'default', u'group_name': u''}, u'ami_launch_index': 2, u'state_transition_reason': u'', u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-15b9c141', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-015ec1e9', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.99', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:4a:86:59:25:c0', u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-03c368938e128a883', u'instance_type': u't2.large', u'architecture': u'x86_64', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []}, '_ansible_item_result': True, u'volume_type': u'gp2', u'volume': {u'status': u'in-use', u'zone': u'eu-west-2a', u'tags': {}, u'encrypted': False, u'iops': 150, u'create_time': u'2018-08-10T08:54:25.646Z', u'snapshot_id': u'', u'attachment_set': {u'device': u'/dev/xvdb', u'instance_id': u'i-03c368938e128a883', u'deleteOnTermination': u'false', u'status': u'attached', u'attach_time': u'2018-08-10T08:54:29.000Z'}, u'type': u'gp2', u'id': u'vol-0245beb894f7afe16', u'size': 50}, 'failed': False, u'device': u'/dev/xvdb', u'volume_id': u'vol-0245beb894f7afe16', u'invocation': {u'module_args': {u'profile': None, u'aws_secret_key': None, u'aws_access_key': None, u'name': None, u'security_token': None, u'tags': {}, u'delete_on_termination': False, u'encrypted': False, u'region': u'eu-west-2', u'kms_key_id': None, u'volume_type': u'gp2', u'device_name': u'/dev/xvdb', u'volume_size': u'50', u'state': u'present', u'iops': None, u'instance': u'i-03c368938e128a883', u'ec2_url': None, u'snapshot': None, u'zone': u'eu-west-2a', u'validate_certs': True, u'id': None}}, '_ansible_ignore_errors': None, '_ansible_no_log': False})
changed: [localhost] => (item={'_ansible_parsed': True, u'changed': True, '_ansible_item_label': {u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'cpu_options': {u'threads_per_core': 1, u'core_count': 2}, u'hypervisor': u'xen', u'source_dest_check': False, u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'root_device_name': u'/dev/sda1', u'public_ip_address': u'35.177.81.12', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-01d3b88b314500ad4'}, u'device_name': u'/dev/sda1'}], u'placement': {u'availability_zone': u'eu-west-2a', u'tenancy': u'default', u'group_name': u''}, u'ami_launch_index': 0, u'state_transition_reason': u'', u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'ipv6_addresses': [], u'network_interface_id': u'eni-17b9c143', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-035ec1eb', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.239', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:68:10:5d:51:20', u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'source_dest_check': False, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-08de7cbedabbcef88', u'instance_type': u't2.large', u'architecture': u'x86_64', u'ena_support': True, u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []}, 'item': {u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'cpu_options': {u'threads_per_core': 1, u'core_count': 2}, u'source_dest_check': False, u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'root_device_name': u'/dev/sda1', u'public_ip_address': u'35.177.81.12', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'ena_support': True, u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-01d3b88b314500ad4'}, u'device_name': u'/dev/sda1'}], u'placement': {u'availability_zone': u'eu-west-2a', u'tenancy': u'default', u'group_name': u''}, u'ami_launch_index': 0, u'state_transition_reason': u'', u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-17b9c143', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-035ec1eb', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.239', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:68:10:5d:51:20', u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-08de7cbedabbcef88', u'instance_type': u't2.large', u'architecture': u'x86_64', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []}, '_ansible_item_result': True, u'volume_type': u'gp2', u'volume': {u'status': u'in-use', u'zone': u'eu-west-2a', u'tags': {}, u'encrypted': False, u'iops': 150, u'create_time': u'2018-08-10T08:54:34.760Z', u'snapshot_id': u'', u'attachment_set': {u'device': u'/dev/xvdb', u'instance_id': u'i-08de7cbedabbcef88', u'deleteOnTermination': u'false', u'status': u'attached', u'attach_time': u'2018-08-10T08:54:38.000Z'}, u'type': u'gp2', u'id': u'vol-0288c6db441045b19', u'size': 50}, 'failed': False, u'device': u'/dev/xvdb', u'volume_id': u'vol-0288c6db441045b19', u'invocation': {u'module_args': {u'profile': None, u'aws_secret_key': None, u'aws_access_key': None, u'name': None, u'security_token': None, u'tags': {}, u'delete_on_termination': False, u'encrypted': False, u'region': u'eu-west-2', u'kms_key_id': None, u'volume_type': u'gp2', u'device_name': u'/dev/xvdb', u'volume_size': u'50', u'state': u'present', u'iops': None, u'instance': u'i-08de7cbedabbcef88', u'ec2_url': None, u'snapshot': None, u'zone': u'eu-west-2a', u'validate_certs': True, u'id': None}}, '_ansible_ignore_errors': None, '_ansible_no_log': False})
changed: [localhost] => (item={'_ansible_parsed': True, u'changed': True, '_ansible_item_label': {u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'cpu_options': {u'threads_per_core': 1, u'core_count': 2}, u'hypervisor': u'xen', u'source_dest_check': False, u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'root_device_name': u'/dev/sda1', u'public_ip_address': u'18.130.73.200', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-0b86048bec682ac47'}, u'device_name': u'/dev/sda1'}], u'placement': {u'availability_zone': u'eu-west-2a', u'tenancy': u'default', u'group_name': u''}, u'ami_launch_index': 1, u'state_transition_reason': u'', u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'ipv6_addresses': [], u'network_interface_id': u'eni-16b9c142', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-005ec1e8', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.229', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:06:e3:76:d0:66', u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'source_dest_check': False, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-0a8f8c2df6608c733', u'instance_type': u't2.large', u'architecture': u'x86_64', u'ena_support': True, u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []}, 'item': {u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'cpu_options': {u'threads_per_core': 1, u'core_count': 2}, u'source_dest_check': False, u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'root_device_name': u'/dev/sda1', u'public_ip_address': u'18.130.73.200', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'ena_support': True, u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-0b86048bec682ac47'}, u'device_name': u'/dev/sda1'}], u'placement': {u'availability_zone': u'eu-west-2a', u'tenancy': u'default', u'group_name': u''}, u'ami_launch_index': 1, u'state_transition_reason': u'', u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-16b9c142', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-005ec1e8', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.229', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:06:e3:76:d0:66', u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-0a8f8c2df6608c733', u'instance_type': u't2.large', u'architecture': u'x86_64', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []}, '_ansible_item_result': True, u'volume_type': u'gp2', u'volume': {u'status': u'in-use', u'zone': u'eu-west-2a', u'tags': {}, u'encrypted': False, u'iops': 150, u'create_time': u'2018-08-10T08:54:43.791Z', u'snapshot_id': u'', u'attachment_set': {u'device': u'/dev/xvdb', u'instance_id': u'i-0a8f8c2df6608c733', u'deleteOnTermination': u'false', u'status': u'attached', u'attach_time': u'2018-08-10T08:54:47.000Z'}, u'type': u'gp2', u'id': u'vol-04e827cfe6c552040', u'size': 50}, 'failed': False, u'device': u'/dev/xvdb', u'volume_id': u'vol-04e827cfe6c552040', u'invocation': {u'module_args': {u'profile': None, u'aws_secret_key': None, u'aws_access_key': None, u'name': None, u'security_token': None, u'tags': {}, u'delete_on_termination': False, u'encrypted': False, u'region': u'eu-west-2', u'kms_key_id': None, u'volume_type': u'gp2', u'device_name': u'/dev/xvdb', u'volume_size': u'50', u'state': u'present', u'iops': None, u'instance': u'i-0a8f8c2df6608c733', u'ec2_url': None, u'snapshot': None, u'zone': u'eu-west-2a', u'validate_certs': True, u'id': None}}, '_ansible_ignore_errors': None, '_ansible_no_log': False})

TASK [Test Passed] ******************************************************************************************************************************************************
ok: [localhost]

PLAY RECAP **************************************************************************************************************************************************************
localhost                  : ok=7    changed=3    unreachable=0    failed=0   
```
- Mounting ebs-volume
```
$ ssh ubuntu@18.130.73.200
ubuntu@ip-10-0-1-229:~$ lsblk | grep openebs
xvdb    202:16   0   50G  0 disk /mnt/openebs
```
O/P for delete-ebs-volume.yml
```
$ ansible-playbook delete-ebs-volume.yml --extra-vars "cluster_name=nodes.k8s-compassionate-babbage.k8s.local"
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] ********************************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************************
ok: [localhost]

TASK [Gather fact about instances in AWS] *******************************************************************************************************************************
ok: [localhost]

TASK [Unmounting EBS Volume from Nodes] *********************************************************************************************************************************
changed: [localhost -> ubuntu@35.176.203.87] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'35.176.203.87', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-06755ca2083f98d87'}}, {u'device_name': u'/dev/xvdb', u'ebs': {u'status': u'attached', u'delete_on_termination': False, u'attach_time': u'2018-08-10T08:54:29+00:00', u'volume_id': u'vol-0245beb894f7afe16'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 2, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-15b9c141', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-015ec1e9', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.99', u'private_dns_name': u'ip-10-0-1-99.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:4a:86:59:25:c0', u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.176.203.87', u'public_dns_name': u'ec2-35-176-203-87.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-03c368938e128a883', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.99', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})
changed: [localhost -> ubuntu@35.177.81.12] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'35.177.81.12', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-01d3b88b314500ad4'}}, {u'device_name': u'/dev/xvdb', u'ebs': {u'status': u'attached', u'delete_on_termination': False, u'attach_time': u'2018-08-10T08:54:38+00:00', u'volume_id': u'vol-0288c6db441045b19'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 0, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-17b9c143', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-035ec1eb', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.239', u'private_dns_name': u'ip-10-0-1-239.eu-west-2.compute.internal', u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:68:10:5d:51:20', u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'35.177.81.12', u'public_dns_name': u'ec2-35-177-81-12.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-08de7cbedabbcef88', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.239', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})
changed: [localhost -> ubuntu@18.130.73.200] => (item={u'root_device_type': u'ebs', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'cpu_options': {u'core_count': 2, u'threads_per_core': 1}, u'security_groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'monitoring': {u'state': u'disabled'}, u'subnet_id': u'subnet-afbc64d5', u'ebs_optimized': False, u'iam_instance_profile': {u'id': u'AIPAINZEECVSWWV4HQXPM', u'arn': u'arn:aws:iam::936055414837:instance-profile/nodes.k8s-compassionate-babbage.k8s.local'}, u'state': {u'code': 16, u'name': u'running'}, u'source_dest_check': False, u'client_token': u'4255948a-d6cc-f6b8-c9e7-a3c1aa786aa2_subnet-afbc64d5_3', u'virtualization_type': u'hvm', u'architecture': u'x86_64', u'public_ip_address': u'18.130.73.200', u'tags': {u'k8s.io/role/node': u'1', u'KubernetesCluster': u'k8s-compassionate-babbage.k8s.local', u'k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup': u'nodes', u'Name': u'nodes.k8s-compassionate-babbage.k8s.local', u'aws:autoscaling:groupName': u'nodes.k8s-compassionate-babbage.k8s.local'}, u'key_name': u'kubernetes.k8s-compassionate-babbage.k8s.local-7d:e9:21:64:b1:cc:17:24:19:ee:b2:9d:65:2f:1b:b0', u'image_id': u'ami-6b3fd60c', u'state_transition_reason': u'', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'block_device_mappings': [{u'device_name': u'/dev/sda1', u'ebs': {u'status': u'attached', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:59+00:00', u'volume_id': u'vol-0b86048bec682ac47'}}, {u'device_name': u'/dev/xvdb', u'ebs': {u'status': u'attached', u'delete_on_termination': False, u'attach_time': u'2018-08-10T08:54:47+00:00', u'volume_id': u'vol-04e827cfe6c552040'}}], u'placement': {u'group_name': u'', u'tenancy': u'default', u'availability_zone': u'eu-west-2a'}, u'ami_launch_index': 1, u'ena_support': True, u'network_interfaces': [{u'status': u'in-use', u'description': u'', u'subnet_id': u'subnet-afbc64d5', u'source_dest_check': False, u'ipv6_addresses': [], u'network_interface_id': u'eni-16b9c142', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'attachment': {u'status': u'attached', u'device_index': 0, u'attachment_id': u'eni-attach-005ec1e8', u'delete_on_termination': True, u'attach_time': u'2018-08-10T07:20:58+00:00'}, u'private_ip_addresses': [{u'private_ip_address': u'10.0.1.229', u'private_dns_name': u'ip-10-0-1-229.eu-west-2.compute.internal', u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'primary': True}], u'mac_address': u'06:06:e3:76:d0:66', u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'groups': [{u'group_id': u'sg-2a5e5941', u'group_name': u'nodes.k8s-compassionate-babbage.k8s.local'}], u'association': {u'public_ip': u'18.130.73.200', u'public_dns_name': u'ec2-18-130-73-200.eu-west-2.compute.amazonaws.com', u'ip_owner_id': u'amazon'}, u'owner_id': u'936055414837'}], u'launch_time': u'2018-08-10T07:20:58+00:00', u'instance_id': u'i-0a8f8c2df6608c733', u'instance_type': u't2.large', u'root_device_name': u'/dev/sda1', u'hypervisor': u'xen', u'private_ip_address': u'10.0.1.229', u'vpc_id': u'vpc-d35dd6bb', u'product_codes': []})

TASK [Detaching EBS Volume] *********************************************************************************************************************************************
changed: [localhost] => (item=vol-0245beb894f7afe16)
changed: [localhost] => (item=vol-0288c6db441045b19)
changed: [localhost] => (item=vol-04e827cfe6c552040)

TASK [Deleting EBS volume in AWS] ***************************************************************************************************************************************
changed: [localhost] => (item=vol-0245beb894f7afe16)
changed: [localhost] => (item=vol-0288c6db441045b19)
changed: [localhost] => (item=vol-04e827cfe6c552040)

TASK [Delete csv file which store all Ids] ******************************************************************************************************************************
changed: [localhost]

TASK [Test Passed] ******************************************************************************************************************************************************
ok: [localhost]

PLAY RECAP **************************************************************************************************************************************************************
localhost                  : ok=7    changed=4    unreachable=0    failed=0 
```


Signed-off-by: Chandan Kumar <chandan.kr404@gmail.com>