### PR TITLE
Fixes docker error of no test directory present

### DIFF
--- a/tools/ansible-runner/Dockerfile
+++ b/tools/ansible-runner/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu
+
 LABEL maintainer="OpenEBS"
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get clean && \
@@ -17,9 +18,7 @@ RUN mkdir /etc/ansible/ /ansible
 RUN echo "[local]" >> /etc/ansible/hosts && \
     echo "127.0.0.1" >> /etc/ansible/hosts
 
-ADD ./tests ./
-
-ADD providers/openebs/installers/operator/ ./
+ADD providers/openebs/installers/ ./
 
 COPY ./executor/ansible/plugins/callback/actionable.py /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/ 
 


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
-> This PR removes add test operation from tools/docker file as there is no more test directory present.
-> Changed  ADD **providers/openebs/installers/operator/** to  ADD **providers/openebs/installers/operator/** so that storageclass litmus job can also get packed to the ansible runner image .


**Special notes for your reviewer**:
-> New expected directory structure:
```
providers
└── openebs
    └── installers
        ├── operator
        │   └── 0.6
        │       ├── ansible
        │       └── litmusbook
        └── storageclass
            └── 0.6
                ├── ansible
                └── litmusbook
```
