### PR TITLE
Add cleanup code for removal of openebs v0.6 and exposes more environment variable

### DIFF
--- a/providers/openebs/installers/operator/0.6/README.md
+++ b/providers/openebs/installers/operator/0.6/README.md
@@ -9,18 +9,22 @@ This litmus job installs OpenEBS v0.6 on a litmus enabled cluster. This job firs
 
 ### Installing
 
-This job can be easily started by just applying ```kubectl apply -f litmusbook/setup_openebs.yaml```.
+-> Starting the openebs setup job :```kubectl apply -f litmusbook/openebs_setup.yaml```.
+-> Deleting the setup job :```kubectl delete -f litmusbook/setup_setup.yaml```.
+-> Starting the openebs cleanup job :```kubectl apply -f litmusbook/openebs_cleanup.yaml```.
+-> Deleting the openebs cleanup job :```kubectl delete -f litmusbook/openebs_cleanup.yaml```.
 
 ### Note:
 
-Image names for openebs-operator can be explicitly passed by environment variable in the setup_openebs.yaml .
+Image names for openebs-operator can be explicitly passed by environment variable in the setup_openebs.yaml.
+
 Example:
 ```
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: litmus-openebs
+  name: litmus-openebs-setup
   namespace: litmus 
 spec:
   template:
@@ -39,9 +43,23 @@ spec:
           - name: ANSIBLE_STDOUT_CALLBACK
             value: actionable
           - name: MAYA_APISERVER_IMAGE
-            value: * image name *
+            value: * Enter the image name here *
+          - name: OPENEBS_PROVISIONER_IMAGE
+            value: * Enter the image name here *
+          - name: OPENEBS_SNAPSHOT_CONTROLLER_IMAGE
+            value: * Enter the image name here *
+          - name: OPENEBS_SNAPSHOT_PROVISIONER_IMAGE
+            value: * Enter the image name here *
+          - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
+            value: * Enter the image name here *
+          - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
+            value: * Enter the image name here *
+          - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
+            value: * Enter the image name here *
+          - name: OPENEBS_IO_JIVA_REPLICA_COUNT
+            value: * Enter the image name here *
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./operator/0.6/ansible/openebs.yaml -i /etc/ansible/hosts -vvv; exit 0"]
+        args: ["-c", "ansible-playbook ./operator/0.6/cleanup/ansible/openebs_cleanup.yaml -i /etc/ansible/hosts -vvv; exit 0"]
         volumeMounts:
           - name: kubeconfig 
             mountPath: /root/admin.conf
@@ -65,3 +83,7 @@ spec:
 -> OPENEBS_PROVISIONER_IMAGE  
 -> OPENEBS_SNAPSHOT_CONTROLLER_IMAGE  
 -> OPENEBS_SNAPSHOT_PROVISIONER_IMAGE  
+-> OPENEBS_IO_JIVA_CONTROLLER_IMAGE  
+-> OPENEBS_IO_JIVA_REPLICA_IMAGE  
+-> OPENEBS_IO_VOLUME_MONITOR_IMAGE  
+-> OPENEBS_IO_JIVA_REPLICA_COUNT    

--- a/providers/openebs/installers/operator/0.6/ansible/openebs_cleanup.yaml
+++ b/providers/openebs/installers/operator/0.6/ansible/openebs_cleanup.yaml
@@ -1,0 +1,31 @@
+# TODO 
+# Delete openebs operator
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+  - vars.yaml
+
+  tasks:
+    - block:
+          - name: Cleaning openebs operator
+            shell: "{{ kubeapply }} delete -f {{ openebs_operator_link }}" 
+            args:
+              executable: /bin/bash
+            ignore_errors: True
+
+          - name: Confirm pods has been deleted
+            shell: kubectl get pods --all-namespaces 
+            args:
+              executable: /bin/bash
+            register: result
+            until: '"maya-apiserver" and "openebs-provisioner" and "openebs-snapshot-operator" not in result.stdout'
+            delay: 30
+            retries: 100
+
+          - set_fact:
+              flag: "Pass"
+      rescue: 
+        - set_fact: 
+            flag: "Fail"

--- a/providers/openebs/installers/operator/0.6/ansible/openebs_cleanup.yaml
+++ b/providers/openebs/installers/operator/0.6/ansible/openebs_cleanup.yaml
@@ -16,11 +16,11 @@
             ignore_errors: True
 
           - name: Confirm pods has been deleted
-            shell: "kubectl get pods --all-namespaces"
+            shell: kubectl get pods --all-namespaces
             args:
               executable: /bin/bash
             register: result
-            until: ' item not in result.stdout'
+            until: "item not in result.stdout"
             with_items:
               - "maya-apiserver"
               - "openebs-provisioner"
@@ -29,11 +29,11 @@
             retries: 100
 
           - name: Confirm that namspace has been deleted
-            shell: 'kubectl get namespaces'
+            shell: kubectl get namespaces
             args:
               executable: /bin/bash
             register: result
-            until: '"namespace" not in result.stdout'
+            until: "namespace not in result.stdout"
             delay: 30
             retries: 100
 

--- a/providers/openebs/installers/operator/0.6/ansible/openebs_cleanup.yaml
+++ b/providers/openebs/installers/operator/0.6/ansible/openebs_cleanup.yaml
@@ -16,11 +16,24 @@
             ignore_errors: True
 
           - name: Confirm pods has been deleted
-            shell: kubectl get pods --all-namespaces 
+            shell: "kubectl get pods --all-namespaces"
             args:
               executable: /bin/bash
             register: result
-            until: '"maya-apiserver" and "openebs-provisioner" and "openebs-snapshot-operator" not in result.stdout'
+            until: ' item not in result.stdout'
+            with_items:
+              - "maya-apiserver"
+              - "openebs-provisioner"
+              - "openebs-snapshot-operator"
+            delay: 30
+            retries: 100
+
+          - name: Confirm that namspace has been deleted
+            shell: 'kubectl get namespaces'
+            args:
+              executable: /bin/bash
+            register: result
+            until: '"namespace" not in result.stdout'
             delay: 30
             retries: 100
 

--- a/providers/openebs/installers/operator/0.6/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/0.6/ansible/openebs_setup.yaml
@@ -9,12 +9,10 @@
 
   tasks:
     - block:
-
           - name: Downloading openebs-operator.yaml
             get_url:
               url: "{{ openebs_operator_link }}"
               dest: "{{ playbook_dir }}/openebs-operator.yaml"
-
 
           - name: Updating maya api server image
             replace:
@@ -43,6 +41,34 @@
               regexp: "image: openebs/snapshot-provisioner.*"
               replace: "image: {{ lookup('env','OPENEBS_SNAPSHOT_PROVISIONER_IMAGE') }}"
             when: lookup('env','OPENEBS_SNAPSHOT_PROVISIONER_IMAGE') | length > 0
+
+          - name: Updating openebs jiva controller image
+            replace:
+              path: "openebs-operator.yaml"
+              regexp: "        - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE\n          value: \"openebs/jiva.*"
+              replace: "        - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE\n          value: \"{{ lookup('env','OPENEBS_IO_JIVA_CONTROLLER_IMAGE') }}\""
+            when: lookup('env','OPENEBS_IO_JIVA_CONTROLLER_IMAGE') | length > 0
+
+          - name: Updating openebs jiva replica image
+            replace:
+              path: "openebs-operator.yaml"
+              regexp: "        - name: OPENEBS_IO_JIVA_REPLICA_IMAGE\n          value: \"openebs/jiva.*"
+              replace: "        - name: OPENEBS_IO_JIVA_REPLICA_IMAGE\n          value: \"{{ lookup('env','OPENEBS_IO_JIVA_REPLICA_IMAGE') }}\""
+            when: lookup('env','OPENEBS_IO_JIVA_REPLICA_IMAGE') | length > 0
+
+          - name: Updating openebs io volume monitor image
+            replace:
+              path: "openebs-operator.yaml"
+              regexp: "        - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE\n          value: \"openebs/m-exporter.*"
+              replace: "        - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE\n          value: \"{{ lookup('env','OPENEBS_IO_VOLUME_MONITOR_IMAGE') }}\""
+            when: lookup('env','OPENEBS_IO_VOLUME_MONITOR_IMAGE') | length > 0
+
+          - name: Updating jiva replica count
+            replace:
+              path: "openebs-operator.yaml"
+              regexp: "        - name: OPENEBS_IO_JIVA_REPLICA_COUNT\n          value: \"3\""
+              replace: "        - name: OPENEBS_IO_JIVA_REPLICA_COUNT\n          value: \"{{ lookup('env','OPENEBS_IO_JIVA_REPLICA_COUNT') }}\""
+            when: lookup('env','OPENEBS_IO_JIVA_REPLICA_COUNT') | length > 0
 
           - name: Applying openebs operator
             shell: "{{ kubeapply }} apply -f {{ openebs_operator }}" 

--- a/providers/openebs/installers/operator/0.6/litmusbook/openebs_cleanup.yaml
+++ b/providers/openebs/installers/operator/0.6/litmusbook/openebs_cleanup.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: litmus-openebs-cleanup
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: mountPath
+            value: /mnt/openebs
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: actionable
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./operator/0.6/ansible/openebs_cleanup.yaml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+          - name: kubeconfig 
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /var/log/ansible 
+      volumes: 
+        - name: kubeconfig
+          configMap: 
+            name: kubeconfig 
+        - name: logs 
+          hostPath:
+            path: /mnt/openebs
+            type: ""

--- a/providers/openebs/installers/operator/0.6/litmusbook/openebs_cleanup.yaml
+++ b/providers/openebs/installers/operator/0.6/litmusbook/openebs_cleanup.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: litmus-openebs-cleanup
+  name: litmus-openebs-cleanup-v0.6
   namespace: litmus 
 spec:
   template:

--- a/providers/openebs/installers/operator/0.6/litmusbook/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/0.6/litmusbook/openebs_setup.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: litmus-openebs-setup
+  name: litmus-openebs-setup-v0.6
   namespace: litmus 
 spec:
   template:

--- a/providers/openebs/installers/operator/0.6/litmusbook/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/0.6/litmusbook/openebs_setup.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: litmus-openebs
+  name: litmus-openebs-setup
   namespace: litmus 
 spec:
   template:
@@ -20,8 +20,24 @@ spec:
             value: /mnt/openebs
           - name: ANSIBLE_STDOUT_CALLBACK
             value: actionable
+          - name: MAYA_APISERVER_IMAGE
+            value:
+          - name: OPENEBS_PROVISIONER_IMAGE
+            value:
+          - name: OPENEBS_SNAPSHOT_CONTROLLER_IMAGE
+            value:
+          - name: OPENEBS_SNAPSHOT_PROVISIONER_IMAGE
+            value:
+          - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
+            value:
+          - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
+            value:
+          - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
+            value:
+          - name: OPENEBS_IO_JIVA_REPLICA_COUNT
+            value:
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./operator/0.6/ansible/openebs.yaml -i /etc/ansible/hosts -vvv; exit 0"]
+        args: ["-c", "ansible-playbook ./operator/0.6/ansible/openebs_setup.yaml -i /etc/ansible/hosts -vv; exit 0"]
         volumeMounts:
           - name: kubeconfig 
             mountPath: /root/admin.conf


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
-> This PR adds cleanup code for openebs.
-> Applying cleanup code will perform ```kubectl delete -f openebs-oprator.yaml```
-> Adds following environment variable to pass image name explicitly.
```
- OPENEBS_IO_JIVA_CONTROLLER_IMAGE  
- OPENEBS_IO_JIVA_REPLICA_IMAGE  
- OPENEBS_IO_VOLUME_MONITOR_IMAGE  
- OPENEBS_IO_JIVA_REPLICA_COUNT 
```
**Special notes for your reviewer**:
-> This PR has been tested on a GCP cluster anf found working .