### PR TITLE
Update tests to generate unique test-specific job names

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ constituting a separate test. Select a workload and follow the instructions unde
   For example, to run a MySQL benchmarking test:
 
 ```
-cd tests/mysql/mysql_storage_benchmark/
+cd apps/percona/tests/mysql_storage_benchmark/
 <Modify the PROVIDER_STORAGE_CLASS in run_litmus_test.yaml>
 kubectl create -f run_litmus_test.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ constituting a separate test. Select a workload and follow the instructions unde
 ```
 cd tests/mysql/mysql_storage_benchmark/
 <Modify the PROVIDER_STORAGE_CLASS in run_litmus_test.yaml>
-kubectl apply -f run_litmus_test.yaml
+kubectl create -f run_litmus_test.yaml
 ```
 
   The above test runs a Kubernetes job that:
@@ -73,6 +73,13 @@ kubectl apply -f run_litmus_test.yaml
 As the test ends, the logs of the various storage pods, including the test results of this Kubernetes job are 
 collected and saved in a temporary location. The `run_litmus_test.yaml` can be customized for the location for 
 saving the logs, type of storage (StorageClass) to be used, etc..  This type of deployment test can be used to accelerate the feedback loop when deploying new pieces of a stack, whether underlying cloud or hardware, network, storage, or other.
+
+- Notes: 
+
+  - To run the test, please ensure *kubectl create* is used as against *kubectl apply* as the test job uses the `generateName` API to autogenerate the
+  job name. This is to ensure a re-run of the job w/o deleting the previous instance doesn't throw an error. 
+
+  - To delete the job, use the `kubectl delete job <jobname>`. Deletion using *-f spec* can complain about non-matching name resources. 
 
 ## Ways to Contribute
 

--- a/apps/fio/tests/run_litmus_test.yaml
+++ b/apps/fio/tests/run_litmus_test.yaml
@@ -2,12 +2,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: litmus
+  generateName: litmus-fio-
   namespace: litmus 
 spec:
   template:
     metadata:
-      name: litmus
+      labels:
+        name: litmus
     spec:
       serviceAccountName: litmus
       restartPolicy: Never

--- a/apps/percona/tests/mysql_data_persistence/run_litmus_test.yaml
+++ b/apps/percona/tests/mysql_data_persistence/run_litmus_test.yaml
@@ -2,12 +2,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: litmus
+  generateName: litmus-mysql-data-persistence-
   namespace: litmus 
 spec:
   template:
     metadata:
-      name: litmus
       labels:
         name: litmus 
     spec:

--- a/apps/percona/tests/mysql_storage_benchmark/README.md
+++ b/apps/percona/tests/mysql_storage_benchmark/README.md
@@ -37,8 +37,7 @@ as described above in order to aid batch runs of all the litmus tests by the exe
 
 The test can be run using the following command:
 
-`kubectl apply -f run_litmus_test.yaml` 
-
+`kubectl create -f run_litmus_test.yaml` 
 
 ### Viewing test results & logs 
 
@@ -53,5 +52,3 @@ the test result, pod logs, playbook logs & node's systemd (kubelet) logs if avai
 All the litmus tests harness the enormous potential of `kubectl` which we believe is more than just a CLI tool
 
 
-
-  

--- a/apps/percona/tests/mysql_storage_benchmark/run_litmus_test.yaml
+++ b/apps/percona/tests/mysql_storage_benchmark/run_litmus_test.yaml
@@ -2,12 +2,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: litmus
+  generateName: litmus-mysql-storage-benchmark-
   namespace: litmus 
 spec:
   template:
     metadata:
-      name: litmus
+      labels:
+        name: litmus
     spec:
       serviceAccountName: litmus
       restartPolicy: Never
@@ -16,7 +17,8 @@ spec:
         image: openebs/ansible-runner
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK
-            value: log_plays
+            #value: log_plays
+            value: actionable
  
           - name: PROVIDER_STORAGE_CLASS
             value: openebs-standard


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Currently, all tests have job name as "litmus"  (The tests cleanup all the resources created as part of the test, with the litmus job itself stays behind). 

  - The job does not identify with the test being performed
  - Re-running these tests errors out & can be executed only if the completed job instance is removed/deleted. It is possible for users to forget this step. 
  - CI systems using litmus jobs in their pipelines will have the additional step of deletion of completed job in each stage, whereas a bulk removal at the end of the pipeline may be more desirable. 

- This PR addresses the above issue by : 

  a) Prefixing test names to litmus test jobs (`litmus-<test-name>`)
  b) Adding metadata.generateName as against metadata.name to make the name unique (hash appended to (a)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- The above changes mandate that the litmus job should be deployed via `kubectl create -f` as against `kubectl apply`. As apply doesn't support the generateName API

- The job removal should be performed via `kubectl delete job <job>` as against a `delete -f <spec>` as the latter cannot resolve/find the unique name 
