### PR TITLE
Add playbook to mount and delete GPD disks

### DIFF
--- a/k8s/gcp/gpd-disks/README.md
+++ b/k8s/gcp/gpd-disks/README.md
@@ -1,0 +1,27 @@
+
+# GCE platform specific code and scripts
+
+## Attaching and Mounting Google Persistent Disks to Cluster's Nodes
+
+### Pre-requisites
+
+- Cluster in GCE is up, running and accesible.
+- Service account JSON and email with sufficient privilege to Disks and Compute Engine access
+
+
+### Creating, attaching and mounting GPDs in worker nodes
+
+- `create-gpd.yml`, will create, attach and mount the GPD to each worker node of given cluster, sequentially.
+
+```bash
+ansible-playbook create-gpd.yml --extra-vars "cluster_name=<cluster-name> json=<credential-file> email=<service-email> project=<project-name>"
+```
+** If you don't specify the cluster name, it will by read the `~logs/cluster` to get the name by default.
+
+### Unmount, Detach and delete GPDs in worker nodes
+
+- `delete-gpd.yml`, will unmount, detach and delete disks from each worker node of specified cluster.
+
+```bash
+ansible-playbook delete-gpd.yml --extra-vars "cluster_name=<cluster-name> json=<credential-file> email=<service-email> project=<project-name>"
+```

--- a/k8s/gcp/gpd-disks/create-gpd.yml
+++ b/k8s/gcp/gpd-disks/create-gpd.yml
@@ -1,0 +1,53 @@
+# create-gpd.yml
+# Description:  This Ansible playbook will create, attach, and mount the GPDs to the specified
+# Cluster
+# Author: Harshvardhan Karn
+###############################################################################################
+#Test Steps:
+#
+# 1. Get Cluster name, if not provided
+# 2. Get the nodes name from the specified cluster
+# 3. Attach a disk of size 20 GBs on each worker nodes
+# 4. Format the disks into ext4 format and mount on each worker nodes 
+###############################################################################################
+
+---
+- hosts: localhost
+  vars:
+    json: 
+    email: 
+    project: 
+    cluster_name:
+
+  tasks:
+    - name: Fetching Cluster Name
+      shell: cat ~/logs/clusters
+      register: cluster_name
+      when: not cluster_name
+
+    - set_fact:
+        cluster_name: "{{ cluster_name.stdout }}"
+      when: cluster_name.stdout is defined
+
+    - name: get nodes
+      command:  gcloud compute instances list --filter="metadata.items.key['cluster-name']['value']~'{{cluster_name}}' name~'nodes'" --format json
+      register: response
+
+    - set_fact:
+        data: "{{ response.stdout }}"
+
+    - local_action:
+        module: gce_pd
+        credentials_file: "{{ json }}"
+        service_account_email: "{{ email }}"
+        project_id: "{{ project }}"
+        instance_name: "{{item.name}}"
+        size_gb: 20
+        zone: us-central1-a
+        mode: READ_WRITE
+        name: "{{item.name + '-' + 'gpd'}}"
+      with_items: "{{ data }}"
+
+    - name: Mount Disks to the Instances
+      shell: gcloud compute --project openebs-ci ssh --zone us-central1-a {{ item.name }} --command "sudo mkfs.ext4 /dev/sdb && sudo mkdir -p /mnt/openebs && sudo mount -o discard,defaults /dev/sdb /mnt/openebs && sudo chmod a+w /mnt/openebs"
+      with_items: "{{ data }}"

--- a/k8s/gcp/gpd-disks/delete-gpd.yml
+++ b/k8s/gcp/gpd-disks/delete-gpd.yml
@@ -1,0 +1,46 @@
+# delete-gpd.yml
+# Description:  This Ansible playbook will remove the previously attached GPDs to the Cluster
+# Author: Harshvardhan Karn
+###############################################################################################
+#Test Steps:
+#
+# 1. Get Cluster name, if not provided
+# 2. Get the nodes name from the specified cluster
+# 3. Use the fetched node to get the GPDs, then detach and delete
+#
+###############################################################################################
+---
+- hosts: localhost
+  vars:
+    files: 
+    email: 
+    project: 
+    cluster_name:
+  tasks:
+    - name: Fetching Cluster Name
+      shell: cat ~/logs/clusters
+      register: cluster_name
+      when: not cluster_name
+
+    - set_fact:
+        cluster_name: "{{ cluster_name.stdout }}"
+      when: cluster_name.stdout is defined
+
+    - name: Get nodes
+      command:  gcloud compute instances list --filter="metadata.items.key['cluster-name']['value']~'{{cluster_name}}' name~'nodes'" --format json
+      register: response
+      
+    - set_fact:
+        data: "{{ response.stdout }}"
+
+    - local_action:
+        module: gce_pd
+        state: deleted
+        credentials_file: "{{ files }}"
+        service_account_email: "{{ email }}"
+        project_id: "{{ project }}"
+        instance_name: "{{item.name }}"
+        zone: us-central1-a
+        name: "{{ item.name + '-' + 'gpd' }}"
+      with_items: "{{ data }}"
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Add Ansible Playbook to create, attach and mount the disks on each worker node of k8s cluster.
- Add ansible playbook to detach all the persistent disks from worker node and delete the disks
- Intialize README with all pre-requisites and steps to execute playbooks

**Special notes for your reviewer**:
### LOGS
#### create-gpd.yml 
```bash
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] ******************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************
ok: [localhost]

TASK [Fetching Cluster Name] ******************************************************************************************************************
changed: [localhost]

TASK [set_fact] *******************************************************************************************************************************
ok: [localhost]

TASK [get nodes] ******************************************************************************************************************************
changed: [localhost]

TASK [set_fact] *******************************************************************************************************************************
ok: [localhost]

TASK [gce_pd] *********************************************************************************************************************************
changed: [localhost -> localhost] => (item={'cpuPlatform': u'Intel Sandy Bridge', 'deletionProtection': False, 'kind': u'compute#instance', 'canIpForward': True, 'name': u'nodes-4c71', 'zone': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a', 'tags': {'items': [u'jovial-babbage-k8s-local-k8s-io-role-node'], 'fingerprint': u'-bY-exg4scA='}, 'labelFingerprint': u'42WmSpB8rSM=', 'disks': [{'deviceName': u'persistent-disks-0', 'kind': u'compute#attachedDisk', 'autoDelete': True, 'index': 0, 'boot': True, 'licenses': [u'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1604-xenial'], 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT', 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-4c71'}], 'id': u'8674947076663567873', 'status': u'RUNNING', 'scheduling': {'automaticRestart': True, 'preemptible': False, 'onHostMaintenance': u'MIGRATE'}, 'machineType': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/machineTypes/n1-standard-2', 'serviceAccounts': [{'scopes': [u'https://www.googleapis.com/auth/compute', u'https://www.googleapis.com/auth/monitoring', u'https://www.googleapis.com/auth/logging.write', u'https://www.googleapis.com/auth/devstorage.read_only'], 'email': u'863768743956-compute@developer.gserviceaccount.com'}], 'metadata': {'items': [{'key': u'instance-template', 'value': u'projects/863768743956/global/instanceTemplates/nodes-jovial-babbage-k8s-local-1534449849'}, {'key': u'created-by', 'value': u'projects/863768743956/zones/us-central1-a/instanceGroupManagers/a-nodes-jovial-babbage-k8s-local'}, {'key': u'startup-script', 'value': u'#!/bin/bash\n# Copyright 2016 The Kubernetes Authors All rights reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/nodeup\nNODEUP_HASH=b85aba5d8c4a8821d0d452e9f1961e511eb35377\n\n\n\n\n\n\n\n\nfunction ensure-install-dir() {\n  INSTALL_DIR="/var/cache/kubernetes-install"\n  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)\n  if [[ -d /var/lib/toolbox ]]; then\n    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"\n  fi\n  mkdir -p ${INSTALL_DIR}\n  cd ${INSTALL_DIR}\n}\n\n# Retry a download until we get it. Takes a hash and a set of URLs.\n#\n# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.\n# $2+ are the URLs to download.\ndownload-or-bust() {\n  local -r hash="$1"\n  shift 1\n\n  urls=( $* )\n  while true; do\n    for url in "${urls[@]}"; do\n      local file="${url##*/}"\n      rm -f "${file}"\n\n      if [[ $(which curl) ]]; then\n        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then\n          echo "== Failed to curl ${url}. Retrying. =="\n          break\n        fi\n      elif [[ $(which wget ) ]]; then\n        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then\n          echo "== Failed to wget ${url}. Retrying. =="\n          break\n        fi\n      else\n        echo "== Could not find curl or wget. Retrying. =="\n        break\n      fi\n\n      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then\n        echo "== Hash validation of ${url} failed. Retrying. =="\n      else\n        if [[ -n "${hash}" ]]; then\n          echo "== Downloaded ${url} (SHA1 = ${hash}) =="\n        else\n          echo "== Downloaded ${url} =="\n        fi\n        return\n      fi\n    done\n\n    echo "All downloads failed; sleeping before retrying"\n    sleep 60\n  done\n}\n\nvalidate-hash() {\n  local -r file="$1"\n  local -r expected="$2"\n  local actual\n\n  actual=$(sha1sum ${file} | awk \'{ print $1 }\') || true\n  if [[ "${actual}" != "${expected}" ]]; then\n    echo "== ${file} corrupted, sha1 ${actual} doesn\'t match expected ${expected} =="\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1 | tr "," "\\n"\n}\n\nfunction try-download-release() {\n  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot\n  # optimization.\n\n  local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )\n  local -r nodeup_filename="${nodeup_urls[0]##*/}"\n  if [[ -n "${NODEUP_HASH:-}" ]]; then\n    local -r nodeup_hash="${NODEUP_HASH}"\n  else\n  # TODO: Remove?\n    echo "Downloading sha1 (not found in env)"\n    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"\n    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")\n  fi\n\n  echo "Downloading nodeup (${nodeup_urls[@]})"\n  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"\n\n  chmod +x nodeup\n}\n\nfunction download-release() {\n  # In case of failure checking integrity of release, retry.\n  until try-download-release; do\n    sleep 15\n    echo "Couldn\'t download release. Retrying..."\n  done\n\n  echo "Running nodeup"\n  # We can\'t run in the foreground because of https://github.com/docker/docker/issues/23793\n  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"\n\necho "== nodeup node config starting =="\nensure-install-dir\n\ncat > cluster_spec.yaml << \'__EOF_CLUSTER_SPEC\'\ncloudConfig:\n  multizone: true\n  nodeTags: jovial-babbage-k8s-local-k8s-io-role-node\ndocker:\n  bridge: ""\n  ipMasq: false\n  ipTables: false\n  logDriver: json-file\n  logLevel: warn\n  logOpt:\n  - max-size=10m\n  - max-file=5\n  storage: overlay,aufs\n  version: 17.03.2\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: k8s.gcr.io/kube-proxy:v1.11.1\n  logLevel: 2\nkubelet:\n  allowPrivileged: true\n  cgroupRoot: /\n  cloudProvider: gce\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n  featureGates:\n    ExperimentalCriticalPodAnnotation: "true"\n  hairpinMode: promiscuous-bridge\n  kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginMTU: 9001\n  networkPluginName: kubenet\n  nonMasqueradeCIDR: 100.64.0.0/10\n  podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0\n  podManifestPath: /etc/kubernetes/manifests\n\n__EOF_CLUSTER_SPEC\n\ncat > ig_spec.yaml << \'__EOF_IG_SPEC\'\nkubelet: null\nnodeLabels:\n  kops.k8s.io/instancegroup: nodes\nsuspendProcesses: null\ntaints: null\n\n__EOF_IG_SPEC\n\ncat > kube_env.yaml << \'__EOF_KUBE_ENV\'\nAssets:\n- 503d54f3273518993d450767ce8051b98d9e435a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubelet\n- 29e6ae2db5969445a23012be7406626ede57450a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl\n- 967945b674b1272ca100c397e3a56f089a444365@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/mounter\n- d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz\n- aad29883ed2ad2288f708487e1217c079604e9ef@https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/utils.tar.gz\nClusterName: jovial-babbage.k8s.local\nConfigBase: gs://jovial-babbage/jovial-babbage.k8s.local\nInstanceGroupName: nodes\nTags:\n- _automatic_upgrades\n- _gce\nchannels:\n- gs://jovial-babbage/jovial-babbage.k8s.local/addons/bootstrap-channel.yaml\nprotokubeImage:\n  hash: 439b34ab45d5dbe309c7235890ec753e1f6bd9a1\n  name: protokube:1.9.1\n  source: https://kubeupv2.s3.amazonaws.com/kops/1.9.1/images/protokube.tar.gz\n\n__EOF_KUBE_ENV\n\ndownload-release\necho "== nodeup node config done =="\n'}, {'key': u'cluster-name', 'value': u'jovial-babbage.k8s.local'}], 'kind': u'compute#metadata', 'fingerprint': u'h_q5DW39C0w='}, 'creationTimestamp': u'2018-08-16T13:05:03.061-07:00', 'startRestricted': False, 'selfLink': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/instances/nodes-4c71', 'networkInterfaces': [{'kind': u'compute#networkInterface', 'network': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/global/networks/openebs-e2e', 'accessConfigs': [{'networkTier': u'PREMIUM', 'kind': u'compute#accessConfig', 'type': u'ONE_TO_ONE_NAT', 'name': u'external-nat', 'natIP': u'35.225.248.56'}], 'networkIP': u'10.128.0.3', 'fingerprint': u'fl2PlEScxNg=', 'subnetwork': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/regions/us-central1/subnetworks/openebs-e2e', 'name': u'nic0'}]})
changed: [localhost -> localhost] => (item={'cpuPlatform': u'Intel Sandy Bridge', 'deletionProtection': False, 'kind': u'compute#instance', 'canIpForward': True, 'name': u'nodes-7v1r', 'zone': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a', 'tags': {'items': [u'jovial-babbage-k8s-local-k8s-io-role-node'], 'fingerprint': u'-bY-exg4scA='}, 'labelFingerprint': u'42WmSpB8rSM=', 'disks': [{'deviceName': u'persistent-disks-0', 'kind': u'compute#attachedDisk', 'autoDelete': True, 'index': 0, 'boot': True, 'licenses': [u'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1604-xenial'], 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT', 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-7v1r'}], 'id': u'8424667976432117249', 'status': u'RUNNING', 'scheduling': {'automaticRestart': True, 'preemptible': False, 'onHostMaintenance': u'MIGRATE'}, 'machineType': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/machineTypes/n1-standard-2', 'serviceAccounts': [{'scopes': [u'https://www.googleapis.com/auth/compute', u'https://www.googleapis.com/auth/monitoring', u'https://www.googleapis.com/auth/logging.write', u'https://www.googleapis.com/auth/devstorage.read_only'], 'email': u'863768743956-compute@developer.gserviceaccount.com'}], 'metadata': {'items': [{'key': u'instance-template', 'value': u'projects/863768743956/global/instanceTemplates/nodes-jovial-babbage-k8s-local-1534449849'}, {'key': u'created-by', 'value': u'projects/863768743956/zones/us-central1-a/instanceGroupManagers/a-nodes-jovial-babbage-k8s-local'}, {'key': u'startup-script', 'value': u'#!/bin/bash\n# Copyright 2016 The Kubernetes Authors All rights reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/nodeup\nNODEUP_HASH=b85aba5d8c4a8821d0d452e9f1961e511eb35377\n\n\n\n\n\n\n\n\nfunction ensure-install-dir() {\n  INSTALL_DIR="/var/cache/kubernetes-install"\n  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)\n  if [[ -d /var/lib/toolbox ]]; then\n    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"\n  fi\n  mkdir -p ${INSTALL_DIR}\n  cd ${INSTALL_DIR}\n}\n\n# Retry a download until we get it. Takes a hash and a set of URLs.\n#\n# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.\n# $2+ are the URLs to download.\ndownload-or-bust() {\n  local -r hash="$1"\n  shift 1\n\n  urls=( $* )\n  while true; do\n    for url in "${urls[@]}"; do\n      local file="${url##*/}"\n      rm -f "${file}"\n\n      if [[ $(which curl) ]]; then\n        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then\n          echo "== Failed to curl ${url}. Retrying. =="\n          break\n        fi\n      elif [[ $(which wget ) ]]; then\n        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then\n          echo "== Failed to wget ${url}. Retrying. =="\n          break\n        fi\n      else\n        echo "== Could not find curl or wget. Retrying. =="\n        break\n      fi\n\n      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then\n        echo "== Hash validation of ${url} failed. Retrying. =="\n      else\n        if [[ -n "${hash}" ]]; then\n          echo "== Downloaded ${url} (SHA1 = ${hash}) =="\n        else\n          echo "== Downloaded ${url} =="\n        fi\n        return\n      fi\n    done\n\n    echo "All downloads failed; sleeping before retrying"\n    sleep 60\n  done\n}\n\nvalidate-hash() {\n  local -r file="$1"\n  local -r expected="$2"\n  local actual\n\n  actual=$(sha1sum ${file} | awk \'{ print $1 }\') || true\n  if [[ "${actual}" != "${expected}" ]]; then\n    echo "== ${file} corrupted, sha1 ${actual} doesn\'t match expected ${expected} =="\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1 | tr "," "\\n"\n}\n\nfunction try-download-release() {\n  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot\n  # optimization.\n\n  local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )\n  local -r nodeup_filename="${nodeup_urls[0]##*/}"\n  if [[ -n "${NODEUP_HASH:-}" ]]; then\n    local -r nodeup_hash="${NODEUP_HASH}"\n  else\n  # TODO: Remove?\n    echo "Downloading sha1 (not found in env)"\n    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"\n    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")\n  fi\n\n  echo "Downloading nodeup (${nodeup_urls[@]})"\n  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"\n\n  chmod +x nodeup\n}\n\nfunction download-release() {\n  # In case of failure checking integrity of release, retry.\n  until try-download-release; do\n    sleep 15\n    echo "Couldn\'t download release. Retrying..."\n  done\n\n  echo "Running nodeup"\n  # We can\'t run in the foreground because of https://github.com/docker/docker/issues/23793\n  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"\n\necho "== nodeup node config starting =="\nensure-install-dir\n\ncat > cluster_spec.yaml << \'__EOF_CLUSTER_SPEC\'\ncloudConfig:\n  multizone: true\n  nodeTags: jovial-babbage-k8s-local-k8s-io-role-node\ndocker:\n  bridge: ""\n  ipMasq: false\n  ipTables: false\n  logDriver: json-file\n  logLevel: warn\n  logOpt:\n  - max-size=10m\n  - max-file=5\n  storage: overlay,aufs\n  version: 17.03.2\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: k8s.gcr.io/kube-proxy:v1.11.1\n  logLevel: 2\nkubelet:\n  allowPrivileged: true\n  cgroupRoot: /\n  cloudProvider: gce\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n  featureGates:\n    ExperimentalCriticalPodAnnotation: "true"\n  hairpinMode: promiscuous-bridge\n  kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginMTU: 9001\n  networkPluginName: kubenet\n  nonMasqueradeCIDR: 100.64.0.0/10\n  podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0\n  podManifestPath: /etc/kubernetes/manifests\n\n__EOF_CLUSTER_SPEC\n\ncat > ig_spec.yaml << \'__EOF_IG_SPEC\'\nkubelet: null\nnodeLabels:\n  kops.k8s.io/instancegroup: nodes\nsuspendProcesses: null\ntaints: null\n\n__EOF_IG_SPEC\n\ncat > kube_env.yaml << \'__EOF_KUBE_ENV\'\nAssets:\n- 503d54f3273518993d450767ce8051b98d9e435a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubelet\n- 29e6ae2db5969445a23012be7406626ede57450a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl\n- 967945b674b1272ca100c397e3a56f089a444365@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/mounter\n- d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz\n- aad29883ed2ad2288f708487e1217c079604e9ef@https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/utils.tar.gz\nClusterName: jovial-babbage.k8s.local\nConfigBase: gs://jovial-babbage/jovial-babbage.k8s.local\nInstanceGroupName: nodes\nTags:\n- _automatic_upgrades\n- _gce\nchannels:\n- gs://jovial-babbage/jovial-babbage.k8s.local/addons/bootstrap-channel.yaml\nprotokubeImage:\n  hash: 439b34ab45d5dbe309c7235890ec753e1f6bd9a1\n  name: protokube:1.9.1\n  source: https://kubeupv2.s3.amazonaws.com/kops/1.9.1/images/protokube.tar.gz\n\n__EOF_KUBE_ENV\n\ndownload-release\necho "== nodeup node config done =="\n'}, {'key': u'cluster-name', 'value': u'jovial-babbage.k8s.local'}], 'kind': u'compute#metadata', 'fingerprint': u'h_q5DW39C0w='}, 'creationTimestamp': u'2018-08-16T13:05:03.356-07:00', 'startRestricted': False, 'selfLink': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/instances/nodes-7v1r', 'networkInterfaces': [{'kind': u'compute#networkInterface', 'network': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/global/networks/openebs-e2e', 'accessConfigs': [{'networkTier': u'PREMIUM', 'kind': u'compute#accessConfig', 'type': u'ONE_TO_ONE_NAT', 'name': u'external-nat', 'natIP': u'104.198.180.79'}], 'networkIP': u'10.128.0.5', 'fingerprint': u'9JaR26AlOiY=', 'subnetwork': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/regions/us-central1/subnetworks/openebs-e2e', 'name': u'nic0'}]})
changed: [localhost -> localhost] => (item={'cpuPlatform': u'Intel Sandy Bridge', 'deletionProtection': False, 'kind': u'compute#instance', 'canIpForward': True, 'name': u'nodes-hsnx', 'zone': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a', 'tags': {'items': [u'jovial-babbage-k8s-local-k8s-io-role-node'], 'fingerprint': u'-bY-exg4scA='}, 'labelFingerprint': u'42WmSpB8rSM=', 'disks': [{'deviceName': u'persistent-disks-0', 'kind': u'compute#attachedDisk', 'autoDelete': True, 'index': 0, 'boot': True, 'licenses': [u'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1604-xenial'], 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT', 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-hsnx'}], 'id': u'4808194252072314369', 'status': u'RUNNING', 'scheduling': {'automaticRestart': True, 'preemptible': False, 'onHostMaintenance': u'MIGRATE'}, 'machineType': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/machineTypes/n1-standard-2', 'serviceAccounts': [{'scopes': [u'https://www.googleapis.com/auth/compute', u'https://www.googleapis.com/auth/monitoring', u'https://www.googleapis.com/auth/logging.write', u'https://www.googleapis.com/auth/devstorage.read_only'], 'email': u'863768743956-compute@developer.gserviceaccount.com'}], 'metadata': {'items': [{'key': u'instance-template', 'value': u'projects/863768743956/global/instanceTemplates/nodes-jovial-babbage-k8s-local-1534449849'}, {'key': u'created-by', 'value': u'projects/863768743956/zones/us-central1-a/instanceGroupManagers/a-nodes-jovial-babbage-k8s-local'}, {'key': u'startup-script', 'value': u'#!/bin/bash\n# Copyright 2016 The Kubernetes Authors All rights reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/nodeup\nNODEUP_HASH=b85aba5d8c4a8821d0d452e9f1961e511eb35377\n\n\n\n\n\n\n\n\nfunction ensure-install-dir() {\n  INSTALL_DIR="/var/cache/kubernetes-install"\n  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)\n  if [[ -d /var/lib/toolbox ]]; then\n    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"\n  fi\n  mkdir -p ${INSTALL_DIR}\n  cd ${INSTALL_DIR}\n}\n\n# Retry a download until we get it. Takes a hash and a set of URLs.\n#\n# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.\n# $2+ are the URLs to download.\ndownload-or-bust() {\n  local -r hash="$1"\n  shift 1\n\n  urls=( $* )\n  while true; do\n    for url in "${urls[@]}"; do\n      local file="${url##*/}"\n      rm -f "${file}"\n\n      if [[ $(which curl) ]]; then\n        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then\n          echo "== Failed to curl ${url}. Retrying. =="\n          break\n        fi\n      elif [[ $(which wget ) ]]; then\n        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then\n          echo "== Failed to wget ${url}. Retrying. =="\n          break\n        fi\n      else\n        echo "== Could not find curl or wget. Retrying. =="\n        break\n      fi\n\n      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then\n        echo "== Hash validation of ${url} failed. Retrying. =="\n      else\n        if [[ -n "${hash}" ]]; then\n          echo "== Downloaded ${url} (SHA1 = ${hash}) =="\n        else\n          echo "== Downloaded ${url} =="\n        fi\n        return\n      fi\n    done\n\n    echo "All downloads failed; sleeping before retrying"\n    sleep 60\n  done\n}\n\nvalidate-hash() {\n  local -r file="$1"\n  local -r expected="$2"\n  local actual\n\n  actual=$(sha1sum ${file} | awk \'{ print $1 }\') || true\n  if [[ "${actual}" != "${expected}" ]]; then\n    echo "== ${file} corrupted, sha1 ${actual} doesn\'t match expected ${expected} =="\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1 | tr "," "\\n"\n}\n\nfunction try-download-release() {\n  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot\n  # optimization.\n\n  local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )\n  local -r nodeup_filename="${nodeup_urls[0]##*/}"\n  if [[ -n "${NODEUP_HASH:-}" ]]; then\n    local -r nodeup_hash="${NODEUP_HASH}"\n  else\n  # TODO: Remove?\n    echo "Downloading sha1 (not found in env)"\n    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"\n    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")\n  fi\n\n  echo "Downloading nodeup (${nodeup_urls[@]})"\n  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"\n\n  chmod +x nodeup\n}\n\nfunction download-release() {\n  # In case of failure checking integrity of release, retry.\n  until try-download-release; do\n    sleep 15\n    echo "Couldn\'t download release. Retrying..."\n  done\n\n  echo "Running nodeup"\n  # We can\'t run in the foreground because of https://github.com/docker/docker/issues/23793\n  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"\n\necho "== nodeup node config starting =="\nensure-install-dir\n\ncat > cluster_spec.yaml << \'__EOF_CLUSTER_SPEC\'\ncloudConfig:\n  multizone: true\n  nodeTags: jovial-babbage-k8s-local-k8s-io-role-node\ndocker:\n  bridge: ""\n  ipMasq: false\n  ipTables: false\n  logDriver: json-file\n  logLevel: warn\n  logOpt:\n  - max-size=10m\n  - max-file=5\n  storage: overlay,aufs\n  version: 17.03.2\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: k8s.gcr.io/kube-proxy:v1.11.1\n  logLevel: 2\nkubelet:\n  allowPrivileged: true\n  cgroupRoot: /\n  cloudProvider: gce\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n  featureGates:\n    ExperimentalCriticalPodAnnotation: "true"\n  hairpinMode: promiscuous-bridge\n  kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginMTU: 9001\n  networkPluginName: kubenet\n  nonMasqueradeCIDR: 100.64.0.0/10\n  podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0\n  podManifestPath: /etc/kubernetes/manifests\n\n__EOF_CLUSTER_SPEC\n\ncat > ig_spec.yaml << \'__EOF_IG_SPEC\'\nkubelet: null\nnodeLabels:\n  kops.k8s.io/instancegroup: nodes\nsuspendProcesses: null\ntaints: null\n\n__EOF_IG_SPEC\n\ncat > kube_env.yaml << \'__EOF_KUBE_ENV\'\nAssets:\n- 503d54f3273518993d450767ce8051b98d9e435a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubelet\n- 29e6ae2db5969445a23012be7406626ede57450a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl\n- 967945b674b1272ca100c397e3a56f089a444365@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/mounter\n- d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz\n- aad29883ed2ad2288f708487e1217c079604e9ef@https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/utils.tar.gz\nClusterName: jovial-babbage.k8s.local\nConfigBase: gs://jovial-babbage/jovial-babbage.k8s.local\nInstanceGroupName: nodes\nTags:\n- _automatic_upgrades\n- _gce\nchannels:\n- gs://jovial-babbage/jovial-babbage.k8s.local/addons/bootstrap-channel.yaml\nprotokubeImage:\n  hash: 439b34ab45d5dbe309c7235890ec753e1f6bd9a1\n  name: protokube:1.9.1\n  source: https://kubeupv2.s3.amazonaws.com/kops/1.9.1/images/protokube.tar.gz\n\n__EOF_KUBE_ENV\n\ndownload-release\necho "== nodeup node config done =="\n'}, {'key': u'cluster-name', 'value': u'jovial-babbage.k8s.local'}], 'kind': u'compute#metadata', 'fingerprint': u'h_q5DW39C0w='}, 'creationTimestamp': u'2018-08-16T13:05:03.053-07:00', 'startRestricted': False, 'selfLink': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/instances/nodes-hsnx', 'networkInterfaces': [{'kind': u'compute#networkInterface', 'network': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/global/networks/openebs-e2e', 'accessConfigs': [{'networkTier': u'PREMIUM', 'kind': u'compute#accessConfig', 'type': u'ONE_TO_ONE_NAT', 'name': u'external-nat', 'natIP': u'35.226.189.232'}], 'networkIP': u'10.128.0.4', 'fingerprint': u'DCy1k1MvV74=', 'subnetwork': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/regions/us-central1/subnetworks/openebs-e2e', 'name': u'nic0'}]})

TASK [Mount Disks to the Instances] ***********************************************************************************************************
changed: [localhost] => (item={'cpuPlatform': u'Intel Sandy Bridge', 'deletionProtection': False, 'kind': u'compute#instance', 'canIpForward': True, 'name': u'nodes-4c71', 'zone': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a', 'tags': {'items': [u'jovial-babbage-k8s-local-k8s-io-role-node'], 'fingerprint': u'-bY-exg4scA='}, 'labelFingerprint': u'42WmSpB8rSM=', 'disks': [{'deviceName': u'persistent-disks-0', 'kind': u'compute#attachedDisk', 'autoDelete': True, 'index': 0, 'boot': True, 'licenses': [u'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1604-xenial'], 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT', 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-4c71'}], 'id': u'8674947076663567873', 'status': u'RUNNING', 'scheduling': {'automaticRestart': True, 'preemptible': False, 'onHostMaintenance': u'MIGRATE'}, 'machineType': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/machineTypes/n1-standard-2', 'serviceAccounts': [{'scopes': [u'https://www.googleapis.com/auth/compute', u'https://www.googleapis.com/auth/monitoring', u'https://www.googleapis.com/auth/logging.write', u'https://www.googleapis.com/auth/devstorage.read_only'], 'email': u'863768743956-compute@developer.gserviceaccount.com'}], 'metadata': {'items': [{'key': u'instance-template', 'value': u'projects/863768743956/global/instanceTemplates/nodes-jovial-babbage-k8s-local-1534449849'}, {'key': u'created-by', 'value': u'projects/863768743956/zones/us-central1-a/instanceGroupManagers/a-nodes-jovial-babbage-k8s-local'}, {'key': u'startup-script', 'value': u'#!/bin/bash\n# Copyright 2016 The Kubernetes Authors All rights reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/nodeup\nNODEUP_HASH=b85aba5d8c4a8821d0d452e9f1961e511eb35377\n\n\n\n\n\n\n\n\nfunction ensure-install-dir() {\n  INSTALL_DIR="/var/cache/kubernetes-install"\n  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)\n  if [[ -d /var/lib/toolbox ]]; then\n    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"\n  fi\n  mkdir -p ${INSTALL_DIR}\n  cd ${INSTALL_DIR}\n}\n\n# Retry a download until we get it. Takes a hash and a set of URLs.\n#\n# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.\n# $2+ are the URLs to download.\ndownload-or-bust() {\n  local -r hash="$1"\n  shift 1\n\n  urls=( $* )\n  while true; do\n    for url in "${urls[@]}"; do\n      local file="${url##*/}"\n      rm -f "${file}"\n\n      if [[ $(which curl) ]]; then\n        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then\n          echo "== Failed to curl ${url}. Retrying. =="\n          break\n        fi\n      elif [[ $(which wget ) ]]; then\n        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then\n          echo "== Failed to wget ${url}. Retrying. =="\n          break\n        fi\n      else\n        echo "== Could not find curl or wget. Retrying. =="\n        break\n      fi\n\n      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then\n        echo "== Hash validation of ${url} failed. Retrying. =="\n      else\n        if [[ -n "${hash}" ]]; then\n          echo "== Downloaded ${url} (SHA1 = ${hash}) =="\n        else\n          echo "== Downloaded ${url} =="\n        fi\n        return\n      fi\n    done\n\n    echo "All downloads failed; sleeping before retrying"\n    sleep 60\n  done\n}\n\nvalidate-hash() {\n  local -r file="$1"\n  local -r expected="$2"\n  local actual\n\n  actual=$(sha1sum ${file} | awk \'{ print $1 }\') || true\n  if [[ "${actual}" != "${expected}" ]]; then\n    echo "== ${file} corrupted, sha1 ${actual} doesn\'t match expected ${expected} =="\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1 | tr "," "\\n"\n}\n\nfunction try-download-release() {\n  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot\n  # optimization.\n\n  local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )\n  local -r nodeup_filename="${nodeup_urls[0]##*/}"\n  if [[ -n "${NODEUP_HASH:-}" ]]; then\n    local -r nodeup_hash="${NODEUP_HASH}"\n  else\n  # TODO: Remove?\n    echo "Downloading sha1 (not found in env)"\n    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"\n    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")\n  fi\n\n  echo "Downloading nodeup (${nodeup_urls[@]})"\n  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"\n\n  chmod +x nodeup\n}\n\nfunction download-release() {\n  # In case of failure checking integrity of release, retry.\n  until try-download-release; do\n    sleep 15\n    echo "Couldn\'t download release. Retrying..."\n  done\n\n  echo "Running nodeup"\n  # We can\'t run in the foreground because of https://github.com/docker/docker/issues/23793\n  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"\n\necho "== nodeup node config starting =="\nensure-install-dir\n\ncat > cluster_spec.yaml << \'__EOF_CLUSTER_SPEC\'\ncloudConfig:\n  multizone: true\n  nodeTags: jovial-babbage-k8s-local-k8s-io-role-node\ndocker:\n  bridge: ""\n  ipMasq: false\n  ipTables: false\n  logDriver: json-file\n  logLevel: warn\n  logOpt:\n  - max-size=10m\n  - max-file=5\n  storage: overlay,aufs\n  version: 17.03.2\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: k8s.gcr.io/kube-proxy:v1.11.1\n  logLevel: 2\nkubelet:\n  allowPrivileged: true\n  cgroupRoot: /\n  cloudProvider: gce\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n  featureGates:\n    ExperimentalCriticalPodAnnotation: "true"\n  hairpinMode: promiscuous-bridge\n  kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginMTU: 9001\n  networkPluginName: kubenet\n  nonMasqueradeCIDR: 100.64.0.0/10\n  podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0\n  podManifestPath: /etc/kubernetes/manifests\n\n__EOF_CLUSTER_SPEC\n\ncat > ig_spec.yaml << \'__EOF_IG_SPEC\'\nkubelet: null\nnodeLabels:\n  kops.k8s.io/instancegroup: nodes\nsuspendProcesses: null\ntaints: null\n\n__EOF_IG_SPEC\n\ncat > kube_env.yaml << \'__EOF_KUBE_ENV\'\nAssets:\n- 503d54f3273518993d450767ce8051b98d9e435a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubelet\n- 29e6ae2db5969445a23012be7406626ede57450a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl\n- 967945b674b1272ca100c397e3a56f089a444365@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/mounter\n- d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz\n- aad29883ed2ad2288f708487e1217c079604e9ef@https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/utils.tar.gz\nClusterName: jovial-babbage.k8s.local\nConfigBase: gs://jovial-babbage/jovial-babbage.k8s.local\nInstanceGroupName: nodes\nTags:\n- _automatic_upgrades\n- _gce\nchannels:\n- gs://jovial-babbage/jovial-babbage.k8s.local/addons/bootstrap-channel.yaml\nprotokubeImage:\n  hash: 439b34ab45d5dbe309c7235890ec753e1f6bd9a1\n  name: protokube:1.9.1\n  source: https://kubeupv2.s3.amazonaws.com/kops/1.9.1/images/protokube.tar.gz\n\n__EOF_KUBE_ENV\n\ndownload-release\necho "== nodeup node config done =="\n'}, {'key': u'cluster-name', 'value': u'jovial-babbage.k8s.local'}], 'kind': u'compute#metadata', 'fingerprint': u'h_q5DW39C0w='}, 'creationTimestamp': u'2018-08-16T13:05:03.061-07:00', 'startRestricted': False, 'selfLink': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/instances/nodes-4c71', 'networkInterfaces': [{'kind': u'compute#networkInterface', 'network': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/global/networks/openebs-e2e', 'accessConfigs': [{'networkTier': u'PREMIUM', 'kind': u'compute#accessConfig', 'type': u'ONE_TO_ONE_NAT', 'name': u'external-nat', 'natIP': u'35.225.248.56'}], 'networkIP': u'10.128.0.3', 'fingerprint': u'fl2PlEScxNg=', 'subnetwork': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/regions/us-central1/subnetworks/openebs-e2e', 'name': u'nic0'}]})
changed: [localhost] => (item={'cpuPlatform': u'Intel Sandy Bridge', 'deletionProtection': False, 'kind': u'compute#instance', 'canIpForward': True, 'name': u'nodes-7v1r', 'zone': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a', 'tags': {'items': [u'jovial-babbage-k8s-local-k8s-io-role-node'], 'fingerprint': u'-bY-exg4scA='}, 'labelFingerprint': u'42WmSpB8rSM=', 'disks': [{'deviceName': u'persistent-disks-0', 'kind': u'compute#attachedDisk', 'autoDelete': True, 'index': 0, 'boot': True, 'licenses': [u'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1604-xenial'], 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT', 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-7v1r'}], 'id': u'8424667976432117249', 'status': u'RUNNING', 'scheduling': {'automaticRestart': True, 'preemptible': False, 'onHostMaintenance': u'MIGRATE'}, 'machineType': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/machineTypes/n1-standard-2', 'serviceAccounts': [{'scopes': [u'https://www.googleapis.com/auth/compute', u'https://www.googleapis.com/auth/monitoring', u'https://www.googleapis.com/auth/logging.write', u'https://www.googleapis.com/auth/devstorage.read_only'], 'email': u'863768743956-compute@developer.gserviceaccount.com'}], 'metadata': {'items': [{'key': u'instance-template', 'value': u'projects/863768743956/global/instanceTemplates/nodes-jovial-babbage-k8s-local-1534449849'}, {'key': u'created-by', 'value': u'projects/863768743956/zones/us-central1-a/instanceGroupManagers/a-nodes-jovial-babbage-k8s-local'}, {'key': u'startup-script', 'value': u'#!/bin/bash\n# Copyright 2016 The Kubernetes Authors All rights reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/nodeup\nNODEUP_HASH=b85aba5d8c4a8821d0d452e9f1961e511eb35377\n\n\n\n\n\n\n\n\nfunction ensure-install-dir() {\n  INSTALL_DIR="/var/cache/kubernetes-install"\n  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)\n  if [[ -d /var/lib/toolbox ]]; then\n    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"\n  fi\n  mkdir -p ${INSTALL_DIR}\n  cd ${INSTALL_DIR}\n}\n\n# Retry a download until we get it. Takes a hash and a set of URLs.\n#\n# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.\n# $2+ are the URLs to download.\ndownload-or-bust() {\n  local -r hash="$1"\n  shift 1\n\n  urls=( $* )\n  while true; do\n    for url in "${urls[@]}"; do\n      local file="${url##*/}"\n      rm -f "${file}"\n\n      if [[ $(which curl) ]]; then\n        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then\n          echo "== Failed to curl ${url}. Retrying. =="\n          break\n        fi\n      elif [[ $(which wget ) ]]; then\n        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then\n          echo "== Failed to wget ${url}. Retrying. =="\n          break\n        fi\n      else\n        echo "== Could not find curl or wget. Retrying. =="\n        break\n      fi\n\n      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then\n        echo "== Hash validation of ${url} failed. Retrying. =="\n      else\n        if [[ -n "${hash}" ]]; then\n          echo "== Downloaded ${url} (SHA1 = ${hash}) =="\n        else\n          echo "== Downloaded ${url} =="\n        fi\n        return\n      fi\n    done\n\n    echo "All downloads failed; sleeping before retrying"\n    sleep 60\n  done\n}\n\nvalidate-hash() {\n  local -r file="$1"\n  local -r expected="$2"\n  local actual\n\n  actual=$(sha1sum ${file} | awk \'{ print $1 }\') || true\n  if [[ "${actual}" != "${expected}" ]]; then\n    echo "== ${file} corrupted, sha1 ${actual} doesn\'t match expected ${expected} =="\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1 | tr "," "\\n"\n}\n\nfunction try-download-release() {\n  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot\n  # optimization.\n\n  local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )\n  local -r nodeup_filename="${nodeup_urls[0]##*/}"\n  if [[ -n "${NODEUP_HASH:-}" ]]; then\n    local -r nodeup_hash="${NODEUP_HASH}"\n  else\n  # TODO: Remove?\n    echo "Downloading sha1 (not found in env)"\n    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"\n    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")\n  fi\n\n  echo "Downloading nodeup (${nodeup_urls[@]})"\n  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"\n\n  chmod +x nodeup\n}\n\nfunction download-release() {\n  # In case of failure checking integrity of release, retry.\n  until try-download-release; do\n    sleep 15\n    echo "Couldn\'t download release. Retrying..."\n  done\n\n  echo "Running nodeup"\n  # We can\'t run in the foreground because of https://github.com/docker/docker/issues/23793\n  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"\n\necho "== nodeup node config starting =="\nensure-install-dir\n\ncat > cluster_spec.yaml << \'__EOF_CLUSTER_SPEC\'\ncloudConfig:\n  multizone: true\n  nodeTags: jovial-babbage-k8s-local-k8s-io-role-node\ndocker:\n  bridge: ""\n  ipMasq: false\n  ipTables: false\n  logDriver: json-file\n  logLevel: warn\n  logOpt:\n  - max-size=10m\n  - max-file=5\n  storage: overlay,aufs\n  version: 17.03.2\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: k8s.gcr.io/kube-proxy:v1.11.1\n  logLevel: 2\nkubelet:\n  allowPrivileged: true\n  cgroupRoot: /\n  cloudProvider: gce\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n  featureGates:\n    ExperimentalCriticalPodAnnotation: "true"\n  hairpinMode: promiscuous-bridge\n  kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginMTU: 9001\n  networkPluginName: kubenet\n  nonMasqueradeCIDR: 100.64.0.0/10\n  podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0\n  podManifestPath: /etc/kubernetes/manifests\n\n__EOF_CLUSTER_SPEC\n\ncat > ig_spec.yaml << \'__EOF_IG_SPEC\'\nkubelet: null\nnodeLabels:\n  kops.k8s.io/instancegroup: nodes\nsuspendProcesses: null\ntaints: null\n\n__EOF_IG_SPEC\n\ncat > kube_env.yaml << \'__EOF_KUBE_ENV\'\nAssets:\n- 503d54f3273518993d450767ce8051b98d9e435a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubelet\n- 29e6ae2db5969445a23012be7406626ede57450a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl\n- 967945b674b1272ca100c397e3a56f089a444365@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/mounter\n- d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz\n- aad29883ed2ad2288f708487e1217c079604e9ef@https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/utils.tar.gz\nClusterName: jovial-babbage.k8s.local\nConfigBase: gs://jovial-babbage/jovial-babbage.k8s.local\nInstanceGroupName: nodes\nTags:\n- _automatic_upgrades\n- _gce\nchannels:\n- gs://jovial-babbage/jovial-babbage.k8s.local/addons/bootstrap-channel.yaml\nprotokubeImage:\n  hash: 439b34ab45d5dbe309c7235890ec753e1f6bd9a1\n  name: protokube:1.9.1\n  source: https://kubeupv2.s3.amazonaws.com/kops/1.9.1/images/protokube.tar.gz\n\n__EOF_KUBE_ENV\n\ndownload-release\necho "== nodeup node config done =="\n'}, {'key': u'cluster-name', 'value': u'jovial-babbage.k8s.local'}], 'kind': u'compute#metadata', 'fingerprint': u'h_q5DW39C0w='}, 'creationTimestamp': u'2018-08-16T13:05:03.356-07:00', 'startRestricted': False, 'selfLink': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/instances/nodes-7v1r', 'networkInterfaces': [{'kind': u'compute#networkInterface', 'network': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/global/networks/openebs-e2e', 'accessConfigs': [{'networkTier': u'PREMIUM', 'kind': u'compute#accessConfig', 'type': u'ONE_TO_ONE_NAT', 'name': u'external-nat', 'natIP': u'104.198.180.79'}], 'networkIP': u'10.128.0.5', 'fingerprint': u'9JaR26AlOiY=', 'subnetwork': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/regions/us-central1/subnetworks/openebs-e2e', 'name': u'nic0'}]})
changed: [localhost] => (item={'cpuPlatform': u'Intel Sandy Bridge', 'deletionProtection': False, 'kind': u'compute#instance', 'canIpForward': True, 'name': u'nodes-hsnx', 'zone': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a', 'tags': {'items': [u'jovial-babbage-k8s-local-k8s-io-role-node'], 'fingerprint': u'-bY-exg4scA='}, 'labelFingerprint': u'42WmSpB8rSM=', 'disks': [{'deviceName': u'persistent-disks-0', 'kind': u'compute#attachedDisk', 'autoDelete': True, 'index': 0, 'boot': True, 'licenses': [u'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1604-xenial'], 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT', 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-hsnx'}], 'id': u'4808194252072314369', 'status': u'RUNNING', 'scheduling': {'automaticRestart': True, 'preemptible': False, 'onHostMaintenance': u'MIGRATE'}, 'machineType': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/machineTypes/n1-standard-2', 'serviceAccounts': [{'scopes': [u'https://www.googleapis.com/auth/compute', u'https://www.googleapis.com/auth/monitoring', u'https://www.googleapis.com/auth/logging.write', u'https://www.googleapis.com/auth/devstorage.read_only'], 'email': u'863768743956-compute@developer.gserviceaccount.com'}], 'metadata': {'items': [{'key': u'instance-template', 'value': u'projects/863768743956/global/instanceTemplates/nodes-jovial-babbage-k8s-local-1534449849'}, {'key': u'created-by', 'value': u'projects/863768743956/zones/us-central1-a/instanceGroupManagers/a-nodes-jovial-babbage-k8s-local'}, {'key': u'startup-script', 'value': u'#!/bin/bash\n# Copyright 2016 The Kubernetes Authors All rights reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/nodeup\nNODEUP_HASH=b85aba5d8c4a8821d0d452e9f1961e511eb35377\n\n\n\n\n\n\n\n\nfunction ensure-install-dir() {\n  INSTALL_DIR="/var/cache/kubernetes-install"\n  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)\n  if [[ -d /var/lib/toolbox ]]; then\n    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"\n  fi\n  mkdir -p ${INSTALL_DIR}\n  cd ${INSTALL_DIR}\n}\n\n# Retry a download until we get it. Takes a hash and a set of URLs.\n#\n# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.\n# $2+ are the URLs to download.\ndownload-or-bust() {\n  local -r hash="$1"\n  shift 1\n\n  urls=( $* )\n  while true; do\n    for url in "${urls[@]}"; do\n      local file="${url##*/}"\n      rm -f "${file}"\n\n      if [[ $(which curl) ]]; then\n        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then\n          echo "== Failed to curl ${url}. Retrying. =="\n          break\n        fi\n      elif [[ $(which wget ) ]]; then\n        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then\n          echo "== Failed to wget ${url}. Retrying. =="\n          break\n        fi\n      else\n        echo "== Could not find curl or wget. Retrying. =="\n        break\n      fi\n\n      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then\n        echo "== Hash validation of ${url} failed. Retrying. =="\n      else\n        if [[ -n "${hash}" ]]; then\n          echo "== Downloaded ${url} (SHA1 = ${hash}) =="\n        else\n          echo "== Downloaded ${url} =="\n        fi\n        return\n      fi\n    done\n\n    echo "All downloads failed; sleeping before retrying"\n    sleep 60\n  done\n}\n\nvalidate-hash() {\n  local -r file="$1"\n  local -r expected="$2"\n  local actual\n\n  actual=$(sha1sum ${file} | awk \'{ print $1 }\') || true\n  if [[ "${actual}" != "${expected}" ]]; then\n    echo "== ${file} corrupted, sha1 ${actual} doesn\'t match expected ${expected} =="\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1 | tr "," "\\n"\n}\n\nfunction try-download-release() {\n  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot\n  # optimization.\n\n  local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )\n  local -r nodeup_filename="${nodeup_urls[0]##*/}"\n  if [[ -n "${NODEUP_HASH:-}" ]]; then\n    local -r nodeup_hash="${NODEUP_HASH}"\n  else\n  # TODO: Remove?\n    echo "Downloading sha1 (not found in env)"\n    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"\n    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")\n  fi\n\n  echo "Downloading nodeup (${nodeup_urls[@]})"\n  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"\n\n  chmod +x nodeup\n}\n\nfunction download-release() {\n  # In case of failure checking integrity of release, retry.\n  until try-download-release; do\n    sleep 15\n    echo "Couldn\'t download release. Retrying..."\n  done\n\n  echo "Running nodeup"\n  # We can\'t run in the foreground because of https://github.com/docker/docker/issues/23793\n  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"\n\necho "== nodeup node config starting =="\nensure-install-dir\n\ncat > cluster_spec.yaml << \'__EOF_CLUSTER_SPEC\'\ncloudConfig:\n  multizone: true\n  nodeTags: jovial-babbage-k8s-local-k8s-io-role-node\ndocker:\n  bridge: ""\n  ipMasq: false\n  ipTables: false\n  logDriver: json-file\n  logLevel: warn\n  logOpt:\n  - max-size=10m\n  - max-file=5\n  storage: overlay,aufs\n  version: 17.03.2\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: k8s.gcr.io/kube-proxy:v1.11.1\n  logLevel: 2\nkubelet:\n  allowPrivileged: true\n  cgroupRoot: /\n  cloudProvider: gce\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n  featureGates:\n    ExperimentalCriticalPodAnnotation: "true"\n  hairpinMode: promiscuous-bridge\n  kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginMTU: 9001\n  networkPluginName: kubenet\n  nonMasqueradeCIDR: 100.64.0.0/10\n  podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0\n  podManifestPath: /etc/kubernetes/manifests\n\n__EOF_CLUSTER_SPEC\n\ncat > ig_spec.yaml << \'__EOF_IG_SPEC\'\nkubelet: null\nnodeLabels:\n  kops.k8s.io/instancegroup: nodes\nsuspendProcesses: null\ntaints: null\n\n__EOF_IG_SPEC\n\ncat > kube_env.yaml << \'__EOF_KUBE_ENV\'\nAssets:\n- 503d54f3273518993d450767ce8051b98d9e435a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubelet\n- 29e6ae2db5969445a23012be7406626ede57450a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl\n- 967945b674b1272ca100c397e3a56f089a444365@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/mounter\n- d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz\n- aad29883ed2ad2288f708487e1217c079604e9ef@https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/utils.tar.gz\nClusterName: jovial-babbage.k8s.local\nConfigBase: gs://jovial-babbage/jovial-babbage.k8s.local\nInstanceGroupName: nodes\nTags:\n- _automatic_upgrades\n- _gce\nchannels:\n- gs://jovial-babbage/jovial-babbage.k8s.local/addons/bootstrap-channel.yaml\nprotokubeImage:\n  hash: 439b34ab45d5dbe309c7235890ec753e1f6bd9a1\n  name: protokube:1.9.1\n  source: https://kubeupv2.s3.amazonaws.com/kops/1.9.1/images/protokube.tar.gz\n\n__EOF_KUBE_ENV\n\ndownload-release\necho "== nodeup node config done =="\n'}, {'key': u'cluster-name', 'value': u'jovial-babbage.k8s.local'}], 'kind': u'compute#metadata', 'fingerprint': u'h_q5DW39C0w='}, 'creationTimestamp': u'2018-08-16T13:05:03.053-07:00', 'startRestricted': False, 'selfLink': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/instances/nodes-hsnx', 'networkInterfaces': [{'kind': u'compute#networkInterface', 'network': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/global/networks/openebs-e2e', 'accessConfigs': [{'networkTier': u'PREMIUM', 'kind': u'compute#accessConfig', 'type': u'ONE_TO_ONE_NAT', 'name': u'external-nat', 'natIP': u'35.226.189.232'}], 'networkIP': u'10.128.0.4', 'fingerprint': u'DCy1k1MvV74=', 'subnetwork': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/regions/us-central1/subnetworks/openebs-e2e', 'name': u'nic0'}]})

PLAY RECAP ************************************************************************************************************************************
localhost                  : ok=7    changed=4    unreachable=0    failed=0   
```
#### delete-gpd.yml
```bash
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'


PLAY [localhost] ******************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************
ok: [localhost]

TASK [Fetching Cluster Name] ******************************************************************************************************************
changed: [localhost]

TASK [set_fact] *******************************************************************************************************************************
ok: [localhost]

TASK [get nodes] ******************************************************************************************************************************
changed: [localhost]

TASK [set_fact] *******************************************************************************************************************************
ok: [localhost]

TASK [gce_pd] *********************************************************************************************************************************
changed: [localhost -> localhost] => (item={'cpuPlatform': u'Intel Sandy Bridge', 'deletionProtection': False, 'kind': u'compute#instance', 'canIpForward': True, 'name': u'nodes-4c71', 'zone': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a', 'tags': {'items': [u'jovial-babbage-k8s-local-k8s-io-role-node'], 'fingerprint': u'-bY-exg4scA='}, 'labelFingerprint': u'42WmSpB8rSM=', 'disks': [{'deviceName': u'persistent-disks-0', 'kind': u'compute#attachedDisk', 'autoDelete': True, 'index': 0, 'boot': True, 'licenses': [u'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1604-xenial'], 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT', 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-4c71'}, {'deviceName': u'nodes-4c71-gpd', 'kind': u'compute#attachedDisk', 'autoDelete': False, 'index': 1, 'boot': False, 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-4c71-gpd', 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT'}], 'id': u'8674947076663567873', 'status': u'RUNNING', 'scheduling': {'automaticRestart': True, 'preemptible': False, 'onHostMaintenance': u'MIGRATE'}, 'machineType': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/machineTypes/n1-standard-2', 'serviceAccounts': [{'scopes': [u'https://www.googleapis.com/auth/compute', u'https://www.googleapis.com/auth/monitoring', u'https://www.googleapis.com/auth/logging.write', u'https://www.googleapis.com/auth/devstorage.read_only'], 'email': u'863768743956-compute@developer.gserviceaccount.com'}], 'metadata': {'items': [{'key': u'instance-template', 'value': u'projects/863768743956/global/instanceTemplates/nodes-jovial-babbage-k8s-local-1534449849'}, {'key': u'created-by', 'value': u'projects/863768743956/zones/us-central1-a/instanceGroupManagers/a-nodes-jovial-babbage-k8s-local'}, {'key': u'startup-script', 'value': u'#!/bin/bash\n# Copyright 2016 The Kubernetes Authors All rights reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/nodeup\nNODEUP_HASH=b85aba5d8c4a8821d0d452e9f1961e511eb35377\n\n\n\n\n\n\n\n\nfunction ensure-install-dir() {\n  INSTALL_DIR="/var/cache/kubernetes-install"\n  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)\n  if [[ -d /var/lib/toolbox ]]; then\n    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"\n  fi\n  mkdir -p ${INSTALL_DIR}\n  cd ${INSTALL_DIR}\n}\n\n# Retry a download until we get it. Takes a hash and a set of URLs.\n#\n# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.\n# $2+ are the URLs to download.\ndownload-or-bust() {\n  local -r hash="$1"\n  shift 1\n\n  urls=( $* )\n  while true; do\n    for url in "${urls[@]}"; do\n      local file="${url##*/}"\n      rm -f "${file}"\n\n      if [[ $(which curl) ]]; then\n        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then\n          echo "== Failed to curl ${url}. Retrying. =="\n          break\n        fi\n      elif [[ $(which wget ) ]]; then\n        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then\n          echo "== Failed to wget ${url}. Retrying. =="\n          break\n        fi\n      else\n        echo "== Could not find curl or wget. Retrying. =="\n        break\n      fi\n\n      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then\n        echo "== Hash validation of ${url} failed. Retrying. =="\n      else\n        if [[ -n "${hash}" ]]; then\n          echo "== Downloaded ${url} (SHA1 = ${hash}) =="\n        else\n          echo "== Downloaded ${url} =="\n        fi\n        return\n      fi\n    done\n\n    echo "All downloads failed; sleeping before retrying"\n    sleep 60\n  done\n}\n\nvalidate-hash() {\n  local -r file="$1"\n  local -r expected="$2"\n  local actual\n\n  actual=$(sha1sum ${file} | awk \'{ print $1 }\') || true\n  if [[ "${actual}" != "${expected}" ]]; then\n    echo "== ${file} corrupted, sha1 ${actual} doesn\'t match expected ${expected} =="\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1 | tr "," "\\n"\n}\n\nfunction try-download-release() {\n  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot\n  # optimization.\n\n  local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )\n  local -r nodeup_filename="${nodeup_urls[0]##*/}"\n  if [[ -n "${NODEUP_HASH:-}" ]]; then\n    local -r nodeup_hash="${NODEUP_HASH}"\n  else\n  # TODO: Remove?\n    echo "Downloading sha1 (not found in env)"\n    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"\n    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")\n  fi\n\n  echo "Downloading nodeup (${nodeup_urls[@]})"\n  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"\n\n  chmod +x nodeup\n}\n\nfunction download-release() {\n  # In case of failure checking integrity of release, retry.\n  until try-download-release; do\n    sleep 15\n    echo "Couldn\'t download release. Retrying..."\n  done\n\n  echo "Running nodeup"\n  # We can\'t run in the foreground because of https://github.com/docker/docker/issues/23793\n  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"\n\necho "== nodeup node config starting =="\nensure-install-dir\n\ncat > cluster_spec.yaml << \'__EOF_CLUSTER_SPEC\'\ncloudConfig:\n  multizone: true\n  nodeTags: jovial-babbage-k8s-local-k8s-io-role-node\ndocker:\n  bridge: ""\n  ipMasq: false\n  ipTables: false\n  logDriver: json-file\n  logLevel: warn\n  logOpt:\n  - max-size=10m\n  - max-file=5\n  storage: overlay,aufs\n  version: 17.03.2\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: k8s.gcr.io/kube-proxy:v1.11.1\n  logLevel: 2\nkubelet:\n  allowPrivileged: true\n  cgroupRoot: /\n  cloudProvider: gce\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n  featureGates:\n    ExperimentalCriticalPodAnnotation: "true"\n  hairpinMode: promiscuous-bridge\n  kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginMTU: 9001\n  networkPluginName: kubenet\n  nonMasqueradeCIDR: 100.64.0.0/10\n  podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0\n  podManifestPath: /etc/kubernetes/manifests\n\n__EOF_CLUSTER_SPEC\n\ncat > ig_spec.yaml << \'__EOF_IG_SPEC\'\nkubelet: null\nnodeLabels:\n  kops.k8s.io/instancegroup: nodes\nsuspendProcesses: null\ntaints: null\n\n__EOF_IG_SPEC\n\ncat > kube_env.yaml << \'__EOF_KUBE_ENV\'\nAssets:\n- 503d54f3273518993d450767ce8051b98d9e435a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubelet\n- 29e6ae2db5969445a23012be7406626ede57450a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl\n- 967945b674b1272ca100c397e3a56f089a444365@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/mounter\n- d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz\n- aad29883ed2ad2288f708487e1217c079604e9ef@https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/utils.tar.gz\nClusterName: jovial-babbage.k8s.local\nConfigBase: gs://jovial-babbage/jovial-babbage.k8s.local\nInstanceGroupName: nodes\nTags:\n- _automatic_upgrades\n- _gce\nchannels:\n- gs://jovial-babbage/jovial-babbage.k8s.local/addons/bootstrap-channel.yaml\nprotokubeImage:\n  hash: 439b34ab45d5dbe309c7235890ec753e1f6bd9a1\n  name: protokube:1.9.1\n  source: https://kubeupv2.s3.amazonaws.com/kops/1.9.1/images/protokube.tar.gz\n\n__EOF_KUBE_ENV\n\ndownload-release\necho "== nodeup node config done =="\n'}, {'key': u'cluster-name', 'value': u'jovial-babbage.k8s.local'}], 'kind': u'compute#metadata', 'fingerprint': u'h_q5DW39C0w='}, 'creationTimestamp': u'2018-08-16T13:05:03.061-07:00', 'startRestricted': False, 'selfLink': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/instances/nodes-4c71', 'networkInterfaces': [{'kind': u'compute#networkInterface', 'network': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/global/networks/openebs-e2e', 'accessConfigs': [{'networkTier': u'PREMIUM', 'kind': u'compute#accessConfig', 'type': u'ONE_TO_ONE_NAT', 'name': u'external-nat', 'natIP': u'35.225.248.56'}], 'networkIP': u'10.128.0.3', 'fingerprint': u'fl2PlEScxNg=', 'subnetwork': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/regions/us-central1/subnetworks/openebs-e2e', 'name': u'nic0'}]})
changed: [localhost -> localhost] => (item={'cpuPlatform': u'Intel Sandy Bridge', 'deletionProtection': False, 'kind': u'compute#instance', 'canIpForward': True, 'name': u'nodes-7v1r', 'zone': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a', 'tags': {'items': [u'jovial-babbage-k8s-local-k8s-io-role-node'], 'fingerprint': u'-bY-exg4scA='}, 'labelFingerprint': u'42WmSpB8rSM=', 'disks': [{'deviceName': u'persistent-disks-0', 'kind': u'compute#attachedDisk', 'autoDelete': True, 'index': 0, 'boot': True, 'licenses': [u'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1604-xenial'], 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT', 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-7v1r'}, {'deviceName': u'nodes-7v1r-gpd', 'kind': u'compute#attachedDisk', 'autoDelete': False, 'index': 1, 'boot': False, 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-7v1r-gpd', 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT'}], 'id': u'8424667976432117249', 'status': u'RUNNING', 'scheduling': {'automaticRestart': True, 'preemptible': False, 'onHostMaintenance': u'MIGRATE'}, 'machineType': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/machineTypes/n1-standard-2', 'serviceAccounts': [{'scopes': [u'https://www.googleapis.com/auth/compute', u'https://www.googleapis.com/auth/monitoring', u'https://www.googleapis.com/auth/logging.write', u'https://www.googleapis.com/auth/devstorage.read_only'], 'email': u'863768743956-compute@developer.gserviceaccount.com'}], 'metadata': {'items': [{'key': u'instance-template', 'value': u'projects/863768743956/global/instanceTemplates/nodes-jovial-babbage-k8s-local-1534449849'}, {'key': u'created-by', 'value': u'projects/863768743956/zones/us-central1-a/instanceGroupManagers/a-nodes-jovial-babbage-k8s-local'}, {'key': u'startup-script', 'value': u'#!/bin/bash\n# Copyright 2016 The Kubernetes Authors All rights reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/nodeup\nNODEUP_HASH=b85aba5d8c4a8821d0d452e9f1961e511eb35377\n\n\n\n\n\n\n\n\nfunction ensure-install-dir() {\n  INSTALL_DIR="/var/cache/kubernetes-install"\n  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)\n  if [[ -d /var/lib/toolbox ]]; then\n    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"\n  fi\n  mkdir -p ${INSTALL_DIR}\n  cd ${INSTALL_DIR}\n}\n\n# Retry a download until we get it. Takes a hash and a set of URLs.\n#\n# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.\n# $2+ are the URLs to download.\ndownload-or-bust() {\n  local -r hash="$1"\n  shift 1\n\n  urls=( $* )\n  while true; do\n    for url in "${urls[@]}"; do\n      local file="${url##*/}"\n      rm -f "${file}"\n\n      if [[ $(which curl) ]]; then\n        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then\n          echo "== Failed to curl ${url}. Retrying. =="\n          break\n        fi\n      elif [[ $(which wget ) ]]; then\n        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then\n          echo "== Failed to wget ${url}. Retrying. =="\n          break\n        fi\n      else\n        echo "== Could not find curl or wget. Retrying. =="\n        break\n      fi\n\n      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then\n        echo "== Hash validation of ${url} failed. Retrying. =="\n      else\n        if [[ -n "${hash}" ]]; then\n          echo "== Downloaded ${url} (SHA1 = ${hash}) =="\n        else\n          echo "== Downloaded ${url} =="\n        fi\n        return\n      fi\n    done\n\n    echo "All downloads failed; sleeping before retrying"\n    sleep 60\n  done\n}\n\nvalidate-hash() {\n  local -r file="$1"\n  local -r expected="$2"\n  local actual\n\n  actual=$(sha1sum ${file} | awk \'{ print $1 }\') || true\n  if [[ "${actual}" != "${expected}" ]]; then\n    echo "== ${file} corrupted, sha1 ${actual} doesn\'t match expected ${expected} =="\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1 | tr "," "\\n"\n}\n\nfunction try-download-release() {\n  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot\n  # optimization.\n\n  local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )\n  local -r nodeup_filename="${nodeup_urls[0]##*/}"\n  if [[ -n "${NODEUP_HASH:-}" ]]; then\n    local -r nodeup_hash="${NODEUP_HASH}"\n  else\n  # TODO: Remove?\n    echo "Downloading sha1 (not found in env)"\n    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"\n    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")\n  fi\n\n  echo "Downloading nodeup (${nodeup_urls[@]})"\n  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"\n\n  chmod +x nodeup\n}\n\nfunction download-release() {\n  # In case of failure checking integrity of release, retry.\n  until try-download-release; do\n    sleep 15\n    echo "Couldn\'t download release. Retrying..."\n  done\n\n  echo "Running nodeup"\n  # We can\'t run in the foreground because of https://github.com/docker/docker/issues/23793\n  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"\n\necho "== nodeup node config starting =="\nensure-install-dir\n\ncat > cluster_spec.yaml << \'__EOF_CLUSTER_SPEC\'\ncloudConfig:\n  multizone: true\n  nodeTags: jovial-babbage-k8s-local-k8s-io-role-node\ndocker:\n  bridge: ""\n  ipMasq: false\n  ipTables: false\n  logDriver: json-file\n  logLevel: warn\n  logOpt:\n  - max-size=10m\n  - max-file=5\n  storage: overlay,aufs\n  version: 17.03.2\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: k8s.gcr.io/kube-proxy:v1.11.1\n  logLevel: 2\nkubelet:\n  allowPrivileged: true\n  cgroupRoot: /\n  cloudProvider: gce\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n  featureGates:\n    ExperimentalCriticalPodAnnotation: "true"\n  hairpinMode: promiscuous-bridge\n  kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginMTU: 9001\n  networkPluginName: kubenet\n  nonMasqueradeCIDR: 100.64.0.0/10\n  podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0\n  podManifestPath: /etc/kubernetes/manifests\n\n__EOF_CLUSTER_SPEC\n\ncat > ig_spec.yaml << \'__EOF_IG_SPEC\'\nkubelet: null\nnodeLabels:\n  kops.k8s.io/instancegroup: nodes\nsuspendProcesses: null\ntaints: null\n\n__EOF_IG_SPEC\n\ncat > kube_env.yaml << \'__EOF_KUBE_ENV\'\nAssets:\n- 503d54f3273518993d450767ce8051b98d9e435a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubelet\n- 29e6ae2db5969445a23012be7406626ede57450a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl\n- 967945b674b1272ca100c397e3a56f089a444365@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/mounter\n- d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz\n- aad29883ed2ad2288f708487e1217c079604e9ef@https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/utils.tar.gz\nClusterName: jovial-babbage.k8s.local\nConfigBase: gs://jovial-babbage/jovial-babbage.k8s.local\nInstanceGroupName: nodes\nTags:\n- _automatic_upgrades\n- _gce\nchannels:\n- gs://jovial-babbage/jovial-babbage.k8s.local/addons/bootstrap-channel.yaml\nprotokubeImage:\n  hash: 439b34ab45d5dbe309c7235890ec753e1f6bd9a1\n  name: protokube:1.9.1\n  source: https://kubeupv2.s3.amazonaws.com/kops/1.9.1/images/protokube.tar.gz\n\n__EOF_KUBE_ENV\n\ndownload-release\necho "== nodeup node config done =="\n'}, {'key': u'cluster-name', 'value': u'jovial-babbage.k8s.local'}], 'kind': u'compute#metadata', 'fingerprint': u'h_q5DW39C0w='}, 'creationTimestamp': u'2018-08-16T13:05:03.356-07:00', 'startRestricted': False, 'selfLink': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/instances/nodes-7v1r', 'networkInterfaces': [{'kind': u'compute#networkInterface', 'network': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/global/networks/openebs-e2e', 'accessConfigs': [{'networkTier': u'PREMIUM', 'kind': u'compute#accessConfig', 'type': u'ONE_TO_ONE_NAT', 'name': u'external-nat', 'natIP': u'104.198.180.79'}], 'networkIP': u'10.128.0.5', 'fingerprint': u'9JaR26AlOiY=', 'subnetwork': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/regions/us-central1/subnetworks/openebs-e2e', 'name': u'nic0'}]})
changed: [localhost -> localhost] => (item={'cpuPlatform': u'Intel Sandy Bridge', 'deletionProtection': False, 'kind': u'compute#instance', 'canIpForward': True, 'name': u'nodes-hsnx', 'zone': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a', 'tags': {'items': [u'jovial-babbage-k8s-local-k8s-io-role-node'], 'fingerprint': u'-bY-exg4scA='}, 'labelFingerprint': u'42WmSpB8rSM=', 'disks': [{'deviceName': u'persistent-disks-0', 'kind': u'compute#attachedDisk', 'autoDelete': True, 'index': 0, 'boot': True, 'licenses': [u'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/licenses/ubuntu-1604-xenial'], 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT', 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-hsnx'}, {'deviceName': u'nodes-hsnx-gpd', 'kind': u'compute#attachedDisk', 'autoDelete': False, 'index': 1, 'boot': False, 'source': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/disks/nodes-hsnx-gpd', 'mode': u'READ_WRITE', 'interface': u'SCSI', 'type': u'PERSISTENT'}], 'id': u'4808194252072314369', 'status': u'RUNNING', 'scheduling': {'automaticRestart': True, 'preemptible': False, 'onHostMaintenance': u'MIGRATE'}, 'machineType': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/machineTypes/n1-standard-2', 'serviceAccounts': [{'scopes': [u'https://www.googleapis.com/auth/compute', u'https://www.googleapis.com/auth/monitoring', u'https://www.googleapis.com/auth/logging.write', u'https://www.googleapis.com/auth/devstorage.read_only'], 'email': u'863768743956-compute@developer.gserviceaccount.com'}], 'metadata': {'items': [{'key': u'instance-template', 'value': u'projects/863768743956/global/instanceTemplates/nodes-jovial-babbage-k8s-local-1534449849'}, {'key': u'created-by', 'value': u'projects/863768743956/zones/us-central1-a/instanceGroupManagers/a-nodes-jovial-babbage-k8s-local'}, {'key': u'startup-script', 'value': u'#!/bin/bash\n# Copyright 2016 The Kubernetes Authors All rights reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the "License");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nset -o errexit\nset -o nounset\nset -o pipefail\n\nNODEUP_URL=https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/nodeup\nNODEUP_HASH=b85aba5d8c4a8821d0d452e9f1961e511eb35377\n\n\n\n\n\n\n\n\nfunction ensure-install-dir() {\n  INSTALL_DIR="/var/cache/kubernetes-install"\n  # On ContainerOS, we install to /var/lib/toolbox install (because of noexec)\n  if [[ -d /var/lib/toolbox ]]; then\n    INSTALL_DIR="/var/lib/toolbox/kubernetes-install"\n  fi\n  mkdir -p ${INSTALL_DIR}\n  cd ${INSTALL_DIR}\n}\n\n# Retry a download until we get it. Takes a hash and a set of URLs.\n#\n# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.\n# $2+ are the URLs to download.\ndownload-or-bust() {\n  local -r hash="$1"\n  shift 1\n\n  urls=( $* )\n  while true; do\n    for url in "${urls[@]}"; do\n      local file="${url##*/}"\n      rm -f "${file}"\n\n      if [[ $(which curl) ]]; then\n        if ! curl -f --ipv4 -Lo "${file}" --connect-timeout 20 --retry 6 --retry-delay 10 "${url}"; then\n          echo "== Failed to curl ${url}. Retrying. =="\n          break\n        fi\n      elif [[ $(which wget ) ]]; then\n        if ! wget --inet4-only -O "${file}" --connect-timeout=20 --tries=6 --wait=10 "${url}"; then\n          echo "== Failed to wget ${url}. Retrying. =="\n          break\n        fi\n      else\n        echo "== Could not find curl or wget. Retrying. =="\n        break\n      fi\n\n      if [[ -n "${hash}" ]] && ! validate-hash "${file}" "${hash}"; then\n        echo "== Hash validation of ${url} failed. Retrying. =="\n      else\n        if [[ -n "${hash}" ]]; then\n          echo "== Downloaded ${url} (SHA1 = ${hash}) =="\n        else\n          echo "== Downloaded ${url} =="\n        fi\n        return\n      fi\n    done\n\n    echo "All downloads failed; sleeping before retrying"\n    sleep 60\n  done\n}\n\nvalidate-hash() {\n  local -r file="$1"\n  local -r expected="$2"\n  local actual\n\n  actual=$(sha1sum ${file} | awk \'{ print $1 }\') || true\n  if [[ "${actual}" != "${expected}" ]]; then\n    echo "== ${file} corrupted, sha1 ${actual} doesn\'t match expected ${expected} =="\n    return 1\n  fi\n}\n\nfunction split-commas() {\n  echo $1 | tr "," "\\n"\n}\n\nfunction try-download-release() {\n  # TODO(zmerlynn): Now we REALLY have no excuse not to do the reboot\n  # optimization.\n\n  local -r nodeup_urls=( $(split-commas "${NODEUP_URL}") )\n  local -r nodeup_filename="${nodeup_urls[0]##*/}"\n  if [[ -n "${NODEUP_HASH:-}" ]]; then\n    local -r nodeup_hash="${NODEUP_HASH}"\n  else\n  # TODO: Remove?\n    echo "Downloading sha1 (not found in env)"\n    download-or-bust "" "${nodeup_urls[@]/%/.sha1}"\n    local -r nodeup_hash=$(cat "${nodeup_filename}.sha1")\n  fi\n\n  echo "Downloading nodeup (${nodeup_urls[@]})"\n  download-or-bust "${nodeup_hash}" "${nodeup_urls[@]}"\n\n  chmod +x nodeup\n}\n\nfunction download-release() {\n  # In case of failure checking integrity of release, retry.\n  until try-download-release; do\n    sleep 15\n    echo "Couldn\'t download release. Retrying..."\n  done\n\n  echo "Running nodeup"\n  # We can\'t run in the foreground because of https://github.com/docker/docker/issues/23793\n  ( cd ${INSTALL_DIR}; ./nodeup --install-systemd-unit --conf=${INSTALL_DIR}/kube_env.yaml --v=8  )\n}\n\n####################################################################################\n\n/bin/systemd-machine-id-setup || echo "failed to set up ensure machine-id configured"\n\necho "== nodeup node config starting =="\nensure-install-dir\n\ncat > cluster_spec.yaml << \'__EOF_CLUSTER_SPEC\'\ncloudConfig:\n  multizone: true\n  nodeTags: jovial-babbage-k8s-local-k8s-io-role-node\ndocker:\n  bridge: ""\n  ipMasq: false\n  ipTables: false\n  logDriver: json-file\n  logLevel: warn\n  logOpt:\n  - max-size=10m\n  - max-file=5\n  storage: overlay,aufs\n  version: 17.03.2\nkubeProxy:\n  clusterCIDR: 100.96.0.0/11\n  cpuRequest: 100m\n  image: k8s.gcr.io/kube-proxy:v1.11.1\n  logLevel: 2\nkubelet:\n  allowPrivileged: true\n  cgroupRoot: /\n  cloudProvider: gce\n  clusterDNS: 100.64.0.10\n  clusterDomain: cluster.local\n  enableDebuggingHandlers: true\n  evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%\n  featureGates:\n    ExperimentalCriticalPodAnnotation: "true"\n  hairpinMode: promiscuous-bridge\n  kubeconfigPath: /var/lib/kubelet/kubeconfig\n  logLevel: 2\n  networkPluginMTU: 9001\n  networkPluginName: kubenet\n  nonMasqueradeCIDR: 100.64.0.0/10\n  podInfraContainerImage: k8s.gcr.io/pause-amd64:3.0\n  podManifestPath: /etc/kubernetes/manifests\n\n__EOF_CLUSTER_SPEC\n\ncat > ig_spec.yaml << \'__EOF_IG_SPEC\'\nkubelet: null\nnodeLabels:\n  kops.k8s.io/instancegroup: nodes\nsuspendProcesses: null\ntaints: null\n\n__EOF_IG_SPEC\n\ncat > kube_env.yaml << \'__EOF_KUBE_ENV\'\nAssets:\n- 503d54f3273518993d450767ce8051b98d9e435a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubelet\n- 29e6ae2db5969445a23012be7406626ede57450a@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl\n- 967945b674b1272ca100c397e3a56f089a444365@https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/mounter\n- d595d3ded6499a64e8dac02466e2f5f2ce257c9f@https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.6.0.tgz\n- aad29883ed2ad2288f708487e1217c079604e9ef@https://kubeupv2.s3.amazonaws.com/kops/1.9.1/linux/amd64/utils.tar.gz\nClusterName: jovial-babbage.k8s.local\nConfigBase: gs://jovial-babbage/jovial-babbage.k8s.local\nInstanceGroupName: nodes\nTags:\n- _automatic_upgrades\n- _gce\nchannels:\n- gs://jovial-babbage/jovial-babbage.k8s.local/addons/bootstrap-channel.yaml\nprotokubeImage:\n  hash: 439b34ab45d5dbe309c7235890ec753e1f6bd9a1\n  name: protokube:1.9.1\n  source: https://kubeupv2.s3.amazonaws.com/kops/1.9.1/images/protokube.tar.gz\n\n__EOF_KUBE_ENV\n\ndownload-release\necho "== nodeup node config done =="\n'}, {'key': u'cluster-name', 'value': u'jovial-babbage.k8s.local'}], 'kind': u'compute#metadata', 'fingerprint': u'h_q5DW39C0w='}, 'creationTimestamp': u'2018-08-16T13:05:03.053-07:00', 'startRestricted': False, 'selfLink': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/zones/us-central1-a/instances/nodes-hsnx', 'networkInterfaces': [{'kind': u'compute#networkInterface', 'network': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/global/networks/openebs-e2e', 'accessConfigs': [{'networkTier': u'PREMIUM', 'kind': u'compute#accessConfig', 'type': u'ONE_TO_ONE_NAT', 'name': u'external-nat', 'natIP': u'35.226.189.232'}], 'networkIP': u'10.128.0.4', 'fingerprint': u'DCy1k1MvV74=', 'subnetwork': u'https://www.googleapis.com/compute/v1/projects/openebs-ci/regions/us-central1/subnetworks/openebs-e2e', 'name': u'nic0'}]})

PLAY RECAP ************************************************************************************************************************************
localhost                  : ok=6    changed=3    unreachable=0    failed=0   
```
#### lsblk inside a node after mounting
```bash
root@nodes-4c71:~# lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
sda      8:0    0  128G  0 disk 
└─sda1   8:1    0  128G  0 part /
sdb      8:16   0    2G  0 disk /mnt/openebs
```