### PR TITLE
`master.yaml` uses JSONPointer instead of JSONPath

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -9,26 +9,42 @@
 tests:
   - name: pod_kill
     test_tags: ['mysql', 'pumba']
-    location: ./apps/percona/tests/mysql_data_persistence/run_litmus_test.yaml
-    test_params:
-      - name: DB_SERVER_IP
-        kind: env
-        type: string
+    specPath: ./apps/percona/tests/mysql_data_persistence/run_litmus_test.yaml
+    patch:
+    - name: 'Server IP'
+      desc: ''
+      kind: env
+      type: string
+      op: 'add'
+      path: '/spec/template/spec/containers/0/env/-'
+      value:
+        name: DB_SERVER_IP
         value: 10.20.10.100
-        spec: '.spec.template.spec.containers[?(@.name=="ansibletest")].env[?(@.name=="DB_SERVER_IP")].value'
-      - name: DB_USER
-        kind: env
-        type: string
+    - name: 'Username'
+      desc: ''
+      kind: env
+      type: string
+      op: 'add'
+      path: '/spec/template/spec/containers/0/env/-'
+      value:
+        name: DB_USER
         value: root
-        spec: '.spec.template.spec.containers[?(@.name=="ansibletest")].env[?(@.name=="DB_USER")].value'
-      - name: DB_PASSWORD
-        kind: env
-        type: string
+    - name: 'Password'
+      desc: ''
+      kind: env
+      type: string
+      op: 'add'
+      path: '/spec/template/spec/containers/0/env/-'
+      value:
+        name: DB_PASSWORD
         value: k8sDem0
-        spec: '.spec.template.spec.containers[?(@.name=="ansibletest")].env[?(@.name=="DB_PASSWORD")].value'
-      - name: CHAOS_DURATION
-        kind: env
-        type: integer
-        value: 120
-        spec: '.spec.template.spec.containers[?(@.name=="ansibletest")].env[?(@.name=="CHAOS_DURATION")].value'
+    - name: 'Duration of Chaos Test'
+      desc: ''
+      kind: env
+      type: string
+      op: 'add'
+      path: '/spec/template/spec/containers/0/env/-'
+      value:
+        name: CHAOS_DURATION
+        value: '120'
           # In pod spec this still needs to be quoted/taken as string (https://github.com/kubernetes/kubernetes/issues/2763) 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does**:
This PR makes it easy to marshal `master.yaml` and create patch for litmus tests.

**Special notes for your reviewer**:
`op`, `path`, `value` are the fields needed to parse JSONPointer, rest of the fields are just for informative purpose.

possible values for `op` (operation) are `"add"`, `"remove"`, `"replace"`, `"move"`, `"test"` and `"copy"`.

**Assumptions:**
- It is assumed in JSONPointer that `ansibletest` container is the first one in YAML when it is parsed.
- Parameters represented in current `master.yaml` is not already present in the litmus test spec. (since I have used `add` in `op` field of each param)

Note: All the above assumptions are met in this PR

Signed-off-by: Abhishek Kashyap <abhishek.kashyap@mayadata.io>