### PR TITLE
Updates to logger spec to capture logs for duration of litmus test container

### DIFF
--- a/apps/percona/chaos/openebs_target_network_delay/run_litmus_test.yaml
+++ b/apps/percona/chaos/openebs_target_network_delay/run_litmus_test.yaml
@@ -44,8 +44,20 @@ spec:
         tty: true
       - name: logger
         image: openebs/logger
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # spec.volumes is not supported by downward API
+          - name: MY_POD_HOSTPATH
+            value: /mnt/chaos/openebs_target_network_delay
         command: ["/bin/bash"]
-        args: ["-c", "./logger.sh -d 10 -r maya,openebs,pvc,percona; exit 0"] 
+        args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,percona; exit 0"] 
         volumeMounts:
           - name: kubeconfig 
             mountPath: /root/admin.conf

--- a/apps/percona/chaos/openebs_volume_replica_failure/run_litmus_test.yaml
+++ b/apps/percona/chaos/openebs_volume_replica_failure/run_litmus_test.yaml
@@ -38,8 +38,20 @@ spec:
         tty: true
       - name: logger
         image: openebs/logger
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # spec.volumes is not supported via downward API 
+          - name: MY_POD_HOSTPATH
+            value: /mnt/chaos/openebs-volume-replica-failure
         command: ["/bin/bash"]
-        args: ["-c", "./logger.sh -d 10 -r maya,openebs,pvc,percona; exit 0"] 
+        args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,percona; exit 0"] 
         volumeMounts:
           - name: kubeconfig 
             mountPath: /root/admin.conf


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Currently, the stern-based logger runs for a pre-defined period, regardless of completion of the test container execution, thereby keeping the test job alive for much longer than necessary. The other case, i.e., completion of log collection before test end (esp on slower systems where image pulls take a long time) is also observed

- This PR fixes the above behaviour by running the log collection process until the test container is terminated. The logger waits upon test completion, following which the node (systemd) logs are collected & test job ends

- This involves passing the test container name in the logger's command along with certain cluster data (pod name, namespace) to the logger in the form of ENV (derived by downward API)

- The PR also ensures that the node/kubelet logs are placed in the test-specific log dir on the nodes as against a previously hard-coded location of /mnt (currently, only pod logs are placed in a test-specific dir). The fix involves passing the hostPath from the litmus job to the nodelogger daemonset.  


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #71 

**Special notes for your reviewer**:

- The duration flag takes both kind of args - a integer value indicating actual minutes for which logger will run, as also a string to indicate container name for whose duration logger will run. Currently , the logger container has some inbuilt validation for the values, but this needs the container names to include at-least one non-int character, failing which the logger may interpret this as minute count. This check will be further enhanced. 