### PR TITLE
Seperate Cluster availability check playbook

### DIFF
--- a/k8s/gcp/k8s-installer/check-cluster-availability.yml
+++ b/k8s/gcp/k8s-installer/check-cluster-availability.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  tasks:
+    - name: Checking Cluster availability
+      shell: python ../../utils/health/cluster_health_check.py -n {{ nodes | int + 1 }}

--- a/k8s/gcp/k8s-installer/create-k8s-cluster.yml
+++ b/k8s/gcp/k8s-installer/create-k8s-cluster.yml
@@ -1,5 +1,5 @@
-# Description:  Generates a random name, & creates a bucket, InstanceGroup object and Initializes 
-# VMs running Kubernetes, in accordance to the node_count specified using kops in Google Cloud 
+# Description:  Generates a random name, & creates a bucket, InstanceGroup object and Initializes
+# VMs running Kubernetes, in accordance to the node_count specified using kops in Google Cloud
 # Author: Harshvardhan Karn
 ###############################################################################################
 #Steps:
@@ -12,37 +12,34 @@
 
 ---
 - hosts: localhost
-  vars:
-    cluster_name:
+  vars: cluster_name
   tasks:
-   - name: Generating Random Cluster Name
-     shell: python ../../utils/name_generator/namesgenerator.py
-     register: cluster_name
-     when: not cluster_name
-   - set_fact:
-       cluster_name: "{{ cluster_name.stdout }}"
-     when: cluster_name.stdout is defined
-   - name: Creating Bucket
-     shell: gsutil mb gs://{{ cluster_name }}/
-   - name: Creating the Cluster & InstanceGroup objects in our state store
-     shell: |
-       export KOPS_FEATURE_FLAGS=AlphaAllowGCE
-       kops create cluster {{ cluster_name }}.k8s.local --kubernetes-version {{ k8s_version }} --zones us-central1-a --state gs://{{ cluster_name }}/ --project {{ project }} --node-count {{ nodes }} --networking kubenet --image "ubuntu-os-cloud/ubuntu-1604-xenial-v20170202" --vpc {{ vpc_name }}
-   - name: Creating K8s Cluster
-     shell: |
-       export KOPS_FEATURE_FLAGS=AlphaAllowGCE
-       kops update cluster {{ cluster_name }}.k8s.local --state gs://{{ cluster_name }}/ --yes
-   - name: Logging Cluster Name inside
-     shell: mkdir -p ~/logs/ && touch ~/logs/clusters
-     
-   - lineinfile: 
-       create: yes
-       state: present
-       path: '~/logs/clusters'
-       line: '{{ cluster_name }}'
-   - name: Checking Cluster availability
-     shell: python ../../utils/health/cluster_health_check.py -n {{ nodes | int + 1 }}
-     
-   - name: Test Passed
-     set_fact:
-       flag: "Test Passed"
+    - name: Generating Random Cluster Name
+      shell: python ../../utils/name_generator/namesgenerator.py
+      register: cluster_name
+      when: not cluster_name
+    - set_fact:
+        cluster_name: "{{ cluster_name.stdout }}"
+      when: cluster_name.stdout is defined
+    - name: Creating Bucket
+      shell: gsutil mb gs://{{ cluster_name }}/
+    - name: Creating the Cluster & InstanceGroup objects in our state store
+      shell: |
+        export KOPS_FEATURE_FLAGS=AlphaAllowGCE
+        kops create cluster {{ cluster_name }}.k8s.local --kubernetes-version {{ k8s_version }} --zones us-central1-a --state gs://{{ cluster_name }}/ --project {{ project }} --node-count {{ nodes }} --networking kubenet --image "ubuntu-os-cloud/ubuntu-1604-xenial-v20170202" --vpc {{ vpc_name }}
+    - name: Creating K8s Cluster
+      shell: |
+        export KOPS_FEATURE_FLAGS=AlphaAllowGCE
+        kops update cluster {{ cluster_name }}.k8s.local --state gs://{{ cluster_name }}/ --yes
+    - name: Logging Cluster Name inside
+      shell: mkdir -p ~/logs/ && touch ~/logs/clusters
+
+    - lineinfile:
+        create: yes
+        state: present
+        path: '~/logs/clusters'
+        line: '{{ cluster_name }}'
+
+    - name: Test Passed
+      set_fact:
+        flag: "Test Passed"

--- a/k8s/utils/health/cluster_health_check.py
+++ b/k8s/utils/health/cluster_health_check.py
@@ -25,15 +25,16 @@ import time
 import argparse
 import sys
 
+
 def create_api():
     while True:
         try:
-            v1=client.CoreV1Api()
+            v1 = client.CoreV1Api()
             break
         except Exception :
             time.sleep(30)
-            continue
     return v1
+
 
 def get_nodes(node_count):
     v1 = create_api()
@@ -44,7 +45,7 @@ def get_nodes(node_count):
                 return getNodes.items
         except Exception :
             time.sleep(30)
-            continue
+
 
 def get_node_status(node_count):
     count = 0
@@ -56,6 +57,7 @@ def get_node_status(node_count):
                 count = count + 1
     return count
 
+
 def checkCluster(node_count):
     while True:
         try:
@@ -64,8 +66,8 @@ def checkCluster(node_count):
                 break
         except Exception :
             time.sleep(30)
-            continue
     print('Cluster is Up and Running')
+
 
 def get_kube_config():
     while True:
@@ -74,7 +76,7 @@ def get_kube_config():
             break
         except Exception :
             time.sleep(30)
-            continue
+
 
 def get_args():
     parser = argparse.ArgumentParser()
@@ -82,6 +84,7 @@ def get_args():
     parser.add_argument('-n', '--nodes', help='Node or Size of cluster', required=True)
     args = parser.parse_args()
     return args.nodes
+
 
 def init():
     nodes = get_args()
@@ -92,7 +95,7 @@ def init():
             return exit
         except Exception :
             time.sleep(30)
-            continue
+
 
 if __name__ == '__main__':
     p = multiprocessing.Process(target=init, name="main")


### PR DESCRIPTION
**What this PR does / why we need it**:
- Separate cluster availability check from `create-k8s-cluster.yml`
  playbook for GCP
- Add `check-cluster-availability.yml` playbook, that runs independently
  and checks for readiness of cluster
- Separating these playbooks helps in calling cleanup/rollback process, in case of
  non-availability/failure of the cluster due to any reason

Signed-off-by: harshvkarn <harshvkarn54@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->



**Special notes for your reviewer**:
