### PR TITLE
Updates to litmus openebs installer & percona app-deployer jobs

### DIFF
--- a/apps/percona/deployers/percona-installer.yaml
+++ b/apps/percona/deployers/percona-installer.yaml
@@ -32,7 +32,8 @@
           when: namespace != 'litmus'
 
         - name: Checking the status  of test specific namespace.
-          shell: kubectl get ns -o jsonpath='{.items[?(@.metadata.name=={{ namespace }})].status.phase}'
+          #shell: kubectl get ns -o jsonpath='{.items[?(@.metadata.name=={{ namespace }})].status.phase}'
+          shell: kubectl get ns {{ namespace }} -o custom-columns=:status.phase --no-headers 
           args:
            executable: /bin/bash
           register: npstatus

--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -173,7 +173,10 @@
             failed_when: "'m-apiserver status:  running' not in result_vers.stdout"
 
           - name: Getting the number of nodes
-            shell: kubectl get nodes | grep '<none>' | wc -l
+            #shell: kubectl get nodes | grep '<none>' | wc -l
+            shell: >
+              kubectl get nodes -o custom-columns=:spec.taints[*].key 
+              --no-headers | grep -iv master | wc -l
             args:
               executable: /bin/bash
             register: node_count


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- The openebs operator installer litmusbook tries to identify node count by performing a `grep <none>` operation with reference to lack of role definitions for the nodes in the cluster. However, this behaviour may change across providers and kubernetes versions. In AWS, for 1.10.x the node roles are explicitly defined causing failure of this step. A more generic approach that checks for taints with 'master' key are used to determine the 'schedulable nodes' of the cluster - thereby getting a more realistic count.

- Simplified a namespace existence check in percona app deployer that was failing due to lack of quotes while performing a string compare within the kubectl jsonpath filter.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
