### PR TITLE
Obtain node count w/o master across kubernetes distros 

### DIFF
--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -173,10 +173,9 @@
             failed_when: "'m-apiserver status:  running' not in result_vers.stdout"
 
           - name: Getting the number of nodes
-            #shell: kubectl get nodes | grep '<none>' | wc -l
-            shell: >
-              kubectl get nodes -o custom-columns=:spec.taints[*].key 
-              --no-headers | grep -iv master | wc -l
+            shell: kubectl get nodes --no-headers | grep -v master | wc -l
+            #  kubectl get nodes -o custom-columns=:spec.taints[*].key 
+            #  --no-headers | grep -iv master | wc -l
             args:
               executable: /bin/bash
             register: node_count


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**: 

- Refer #124 (The taint based check to discount the master during a node count, while being a good method is seen to fail when executed over a kubeconfig from inside a pod). 

- Using a simpler check involving `grep -v master` directly from the `kubectl get nodes` o/p. This is seen to work from pods mounted w/ kubeconfig - and is verified on vagrant, GKE and kops-based AWS clusters. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
