### PR TITLE
Generalize the chaosutil selection logic to make it provisioner-based

### DIFF
--- a/apps/percona/chaos/openebs_target_network_delay/chaosutil.j2
+++ b/apps/percona/chaos/openebs_target_network_delay/chaosutil.j2
@@ -1,5 +1,7 @@
-{% if sc is defined and sc == 'openebs-standard' %}
- chaosutil: openebs/jiva_controller_network_delay.yaml
-{% elif sc is defined and sc == 'openebs-standard-cstor' %}
- chaosutil: openebs/cstor_target_network_delay.yaml
+{% if stg_prov is defined and stg_prov == 'openebs.io/provisioner-iscsi' %}
+  {% if stg_engine is defined and stg_engine == 'cstor' %}
+    chaosutil: openebs/cstor_target_network_delay.yaml
+  {% else %}
+    chaosutil: openebs/jiva_controller_network_delay.yaml
+  {% endif %}
 {% endif %}

--- a/apps/percona/chaos/openebs_target_network_delay/test_prerequisites.yaml
+++ b/apps/percona/chaos/openebs_target_network_delay/test_prerequisites.yaml
@@ -7,9 +7,43 @@
     executable: /bin/bash
   register: storage_class
 
+- name: Identify the storage provisioner used by the SC
+  shell: >
+    kubectl get sc {{ storage_class.stdout }}
+    --no-headers -o custom-columns=:provisioner
+  args:
+    executable: /bin/bash
+  register: provisioner
+
 - name: Record the storage class name
   set_fact: 
     sc: "{{ storage_class.stdout }}"
+
+- name: Record the storage provisioner name
+  set_fact:
+    stg_prov: "{{ provisioner.stdout }}"
+
+- block:
+    - name: Derive PV name from PVC to query storage engine type (openebs)
+      shell: >
+        kubectl get pvc {{ pvc }} -n {{ namespace }}
+        --no-headers -o custom-columns=:spec.volumeName
+      args:
+        executable: /bin/bash
+      register: pv
+
+    - name: Check for presence & value of cas type annotation
+      shell: >
+        kubectl get pv {{ pv.stdout }} --no-headers
+        -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
+      args:
+        executable: /bin/bash
+      register: openebs_stg_engine
+
+    - name: Record the storage engine name
+      set_fact:
+        stg_engine: "{{ openebs_stg_engine }}"
+  when: stg_prov == "openebs.io/provisioner-iscsi"
 
 - name: Identify the chaos util to be invoked 
   template:

--- a/apps/percona/chaos/openebs_volume_replica_failure/chaosutil.j2
+++ b/apps/percona/chaos/openebs_volume_replica_failure/chaosutil.j2
@@ -1,5 +1,7 @@
-{% if sc is defined and sc == 'openebs-standard' %}
- chaosutil: openebs/jiva_replica_pod_failure.yaml
-{% elif sc is defined and sc == 'openebs-standard-cstor' %}
- chaosutil: openebs/cstor_pool_deploy_failure.yaml
+{% if stg_prov is defined and stg_prov == 'openebs.io/provisioner-iscsi' %}
+  {% if stg_engine is defined and stg_engine == 'cstor' %}
+    chaosutil: openebs/cstor_pool_deploy_failure.yaml
+  {% else %} 
+    chaosutil: openebs/jiva_replica_pod_failure.yaml
+  {% endif %}
 {% endif %}

--- a/apps/percona/chaos/openebs_volume_replica_failure/test_prerequisites.yaml
+++ b/apps/percona/chaos/openebs_volume_replica_failure/test_prerequisites.yaml
@@ -7,10 +7,44 @@
     executable: /bin/bash
   register: storage_class
 
+- name: Identify the storage provisioner used by the SC
+  shell: >
+    kubectl get sc {{ storage_class.stdout }} 
+    --no-headers -o custom-columns=:provisioner
+  args:
+    executable: /bin/bash
+  register: provisioner
+
 - name: Record the storage class name
   set_fact: 
     sc: "{{ storage_class.stdout }}"
 
+- name: Record the storage provisioner name
+  set_fact: 
+    stg_prov: "{{ provisioner.stdout }}"
+
+- block: 
+    - name: Derive PV name from PVC to query storage engine type (openebs)
+      shell: >
+        kubectl get pvc {{ pvc }} -n {{ namespace }}
+        --no-headers -o custom-columns=:spec.volumeName
+      args:
+        executable: /bin/bash
+      register: pv
+
+    - name: Check for presence & value of cas type annotation 
+      shell: > 
+        kubectl get pv {{ pv.stdout }} --no-headers 
+        -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
+      args:
+        executable: /bin/bash
+      register: openebs_stg_engine
+
+    - name: Record the storage engine name
+      set_fact:
+        stg_engine: "{{ openebs_stg_engine }}"
+  when: stg_prov == "openebs.io/provisioner-iscsi"
+          
 - name: Identify the chaos util to be invoked 
   template:
     src: chaosutil.j2


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Currently, the chaosutil selection logic is based on the storageclass names. This has been enhanced by making it more generic , by using a provisioner-based check.

- For the OpenEBS iSCSI provisioner, the storage-engine type is obtained via the PV annotation openebs.io/cas-type & appropriate jiva/cstor chaosutils are invoked.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
