### PR TITLE
Deploy cockroachdb as k8s statefulset

### DIFF
--- a/apps/cockroachdb/deployers/cockroachdb-installer.yaml
+++ b/apps/cockroachdb/deployers/cockroachdb-installer.yaml
@@ -75,7 +75,7 @@
         - block:
 
             - name: Obtain the number of replicas.
-              shell: kubectl get statefulset -n {{ namespace }} -o custom-columns=:spec.replicas
+              shell: kubectl get statefulset -n {{ namespace }} -l app=cockroachdb -o custom-columns=:spec.replicas
               args:
                 executable: /bin/bash
               register: rep_count
@@ -84,7 +84,7 @@
               retries: 15
 
             - name: Obtain the ready replica count and compare with the replica count.
-              shell: kubectl get sts -n {{ namespace }} -o custom-columns=:..readyReplicas
+              shell: kubectl get statefulset -n {{ namespace }} -l app=cockroachdb -o custom-columns=:..readyReplicas
               args:
                 executable: /bin/bash
               register: ready_rep

--- a/apps/cockroachdb/deployers/cockroachdb-installer.yaml
+++ b/apps/cockroachdb/deployers/cockroachdb-installer.yaml
@@ -1,0 +1,122 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - cockroachdb-vars.yaml
+
+  tasks:
+
+    - block:
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            app: ""
+            chaostype: ""
+            phase: in-progress
+            verdict: none
+        
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"
+
+         ##Actual test
+        - name: Check whether the provider storageclass was created.
+          shell: kubectl get sc {{ lookup('env','PROVIDER_STORAGE_CLASS') }}
+          args:
+            executable: /bin/bash
+          register: result
+
+        - name: Replace the pvc placeholder with provider
+          replace:
+            path: "{{ cockroachdb_deployment }}"
+            regexp: "testclaim"
+            replace: "{{ lookup('env','PROVIDER_PVC') }}"
+
+        - name: Replace the storageclass placeholder with provider
+          replace:
+            path: "{{ cockroachdb_deployment }}"
+            regexp: "testclass"
+            replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+        - name: Create test specific namespace.
+          shell: source ~/.profile;  kubectl create ns {{ namespace }}
+          args:
+           executable: /bin/bash
+          when: namespace != 'litmus'
+
+        - name: Checking the status of test specific namespace.
+          shell: kubectl get ns {{ namespace }} -o custom-columns=:status.phase --no-headers 
+          args:
+           executable: /bin/bash
+          register: npstatus
+          until: "'Active' in npstatus.stdout"
+          delay: 30
+          retries: 10
+        
+        - name: Deploying cockroachdb statefulset.
+          shell: kubectl apply -f {{ cockroachdb_deployment }} -n {{ namespace }}
+          args:
+            executable: /bin/bash
+         
+        - name: Deploying cockroachdb service
+          shell: kubectl apply -f {{ cockroachdb_svc }} -n {{ namespace }}
+          args:
+            executable: /bin/bash
+
+        - name: Check if all the replicas are started
+          shell: >
+            sleep 120;
+            replicas=`kubectl get sts -n {{ namespace }} -o custom-columns=:spec.replicas`; 
+            echo $replicas;
+            ready_replicas=`kubectl get sts -n {{ namespace }} -o custom-columns=:..readyReplicas`; 
+            echo $ready_replicas;
+          args:
+            executable: /bin/bash
+          register: rep_count
+          until: "rep_count.stdout_lines[0]|int == rep_count.stdout_lines[1]|int"
+          delay: 60
+          retries: 15
+          when: lookup('env','DEPLOY_TYPE') == 'statefulset'
+
+        - name: Check if cockroachdb replica pods are running.
+          shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.labels.app=="cockroachdb")].status.phase}'
+          register: result
+          until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
+          delay: 60
+          retries: 15
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+          
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR 
+        - name: Generate the litmus result CR to reflect EOT (End of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            app: ""
+            chaostype: ""
+            phase: completed
+            verdict: "{{ flag }}"
+           
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"

--- a/apps/cockroachdb/deployers/cockroachdb-installer.yaml
+++ b/apps/cockroachdb/deployers/cockroachdb-installer.yaml
@@ -72,19 +72,30 @@
           args:
             executable: /bin/bash
 
-        - name: Check if all the replicas are started
-          shell: >
-            sleep 120;
-            replicas=`kubectl get sts -n {{ namespace }} -o custom-columns=:spec.replicas`; 
-            echo $replicas;
-            ready_replicas=`kubectl get sts -n {{ namespace }} -o custom-columns=:..readyReplicas`; 
-            echo $ready_replicas;
-          args:
-            executable: /bin/bash
-          register: rep_count
-          until: "rep_count.stdout_lines[0]|int == rep_count.stdout_lines[1]|int"
-          delay: 60
-          retries: 15
+        - block:
+
+            - name: Obtain the number of replicas.
+              shell: >
+                replicas=`kubectl get sts -n {{ namespace }} -o custom-columns=:spec.replicas`; 
+                echo $replicas;
+              args:
+                executable: /bin/bash
+              register: rep_count
+              until: "rep_count.rc == 0"
+              delay: 60
+              retries: 15
+
+            - name: Obtain the ready replica count and compare with the replica count.
+              shell: >
+                ready_replicas=`kubectl get sts -n {{ namespace }} -o custom-columns=:..readyReplicas`;
+                echo $ready_replicas;
+              args:
+                executable: /bin/bash
+              register: ready_rep
+              until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
+              delay: 60
+              retries: 15
+
           when: lookup('env','DEPLOY_TYPE') == 'statefulset'
 
         - name: Check if cockroachdb replica pods are running.

--- a/apps/cockroachdb/deployers/cockroachdb-installer.yaml
+++ b/apps/cockroachdb/deployers/cockroachdb-installer.yaml
@@ -75,9 +75,7 @@
         - block:
 
             - name: Obtain the number of replicas.
-              shell: >
-                replicas=`kubectl get sts -n {{ namespace }} -o custom-columns=:spec.replicas`; 
-                echo $replicas;
+              shell: kubectl get statefulset -n {{ namespace }} -o custom-columns=:spec.replicas
               args:
                 executable: /bin/bash
               register: rep_count
@@ -86,9 +84,7 @@
               retries: 15
 
             - name: Obtain the ready replica count and compare with the replica count.
-              shell: >
-                ready_replicas=`kubectl get sts -n {{ namespace }} -o custom-columns=:..readyReplicas`;
-                echo $ready_replicas;
+              shell: kubectl get sts -n {{ namespace }} -o custom-columns=:..readyReplicas
               args:
                 executable: /bin/bash
               register: ready_rep

--- a/apps/cockroachdb/deployers/cockroachdb-sts.yaml
+++ b/apps/cockroachdb/deployers/cockroachdb-sts.yaml
@@ -1,0 +1,118 @@
+
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: cockroachdb-budget
+  labels:
+    app: cockroachdb
+spec:
+  selector:
+    matchLabels:
+      app: cockroachdb
+  minAvailable: 67%
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: cockroachdb
+spec:
+  serviceName: "cockroachdb"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: cockroachdb
+    spec:
+      # Init containers are run only once in the lifetime of a pod, before
+      # it's started up for the first time. It has to exit successfully
+      # before the pod's main containers are allowed to start.
+      # This particular init container does a DNS lookup for other pods in
+      # the set to help determine whether or not a cluster already exists.
+      # If any other pods exist, it creates a file in the cockroach-data
+      # directory to pass that information along to the primary container that
+      # has to decide what command-line flags to use when starting CockroachDB.
+      # This only matters when a pod's persistent volume is empty - if it has
+      # data from a previous execution, that data will always be used.
+      #
+      # If your Kubernetes cluster uses a custom DNS domain, you will have
+      # to add an additional arg to this pod: "-domain=<your-custom-domain>"
+      initContainers:
+      - name: bootstrap
+        image: cockroachdb/cockroach-k8s-init:0.2
+        imagePullPolicy: IfNotPresent
+        args:
+        - "-on-start=/on-start.sh"
+        - "-service=cockroachdb"
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: datadir
+          mountPath: /cockroach/cockroach-data
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - cockroachdb
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: cockroachdb
+        image: cockroachdb/cockroach:v1.1.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 26257
+          name: grpc
+        - containerPort: 8080
+          name: http
+        volumeMounts:
+        - name: datadir
+          mountPath: /cockroach/cockroach-data
+        command:
+          - "/bin/bash"
+          - "-ecx"
+          - |
+            # The use of qualified `hostname -f` is crucial:
+            # Other nodes aren't able to look up the unqualified hostname.
+            CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)" "--http-host" "0.0.0.0" "--cache" "25%" "--max-sql-memory" "25%")
+            # We only want to initialize a new cluster (by omitting the join flag)
+            # if we're sure that we're the first node (i.e. index 0) and that
+            # there aren't any other nodes running as part of the cluster that
+            # this is supposed to be a part of (which indicates that a cluster
+            # already exists and we should make sure not to create a new one).
+            # It's fine to run without --join on a restart if there aren't any
+            # other nodes.
+            if [ ! "$(hostname)" == "cockroachdb-0" ] || \
+               [ -e "/cockroach/cockroach-data/cluster_exists_marker" ]
+            then
+              # We don't join cockroachdb in order to avoid a node attempting
+              # to join itself, which currently doesn't work
+              # (https://github.com/cockroachdb/cockroach/issues/9625).
+              CRARGS+=("--join" "cockroachdb-public")
+            fi
+            exec /cockroach/cockroach ${CRARGS[*]}
+      # No pre-stop hook is required, a SIGTERM plus some time is all that's
+      # needed for graceful shutdown of a node.
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: testclaim
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+    spec:
+      storageClassName: testclass
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          storage: 10G

--- a/apps/cockroachdb/deployers/cockroachdb-svc.yaml
+++ b/apps/cockroachdb/deployers/cockroachdb-svc.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # This service is meant to be used by clients of the database. It exposes a ClusterIP that will
+  # automatically load balance connections to the different database pods.
+  name: cockroachdb-public
+  labels:
+    app: cockroachdb
+spec:
+  ports:
+  # The main port, served by gRPC, serves Postgres-flavor SQL, internode
+  # traffic and the cli.
+  - port: 26257
+    targetPort: 26257
+    name: grpc
+  # The secondary port serves the UI as well as health and debug endpoints.
+  - port: 8080
+    targetPort: 8080
+    name: http
+  selector:
+    app: cockroachdb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # This service only exists to create DNS entries for each pod in the stateful
+  # set such that they can resolve each other's IP addresses. It does not
+  # create a load-balanced ClusterIP and should not be used directly by clients
+  # in most circumstances.
+  name: cockroachdb
+  labels:
+    app: cockroachdb
+  annotations:
+    # This is needed to make the peer-finder work properly and to help avoid
+    # edge cases where instance 0 comes up after losing its data and needs to
+    # decide whether it should create a new cluster or try to join an existing
+    # one. If it creates a new cluster when it should have joined an existing
+    # one, we'd end up with two separate clusters listening at the same service
+    # endpoint, which would be very bad.
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "_status/vars"
+    prometheus.io/port: "8080"
+spec:
+  ports:
+  - port: 26257
+    targetPort: 26257
+    name: grpc
+  - port: 8080
+    targetPort: 8080
+    name: http
+  clusterIP: None
+  selector:
+    app: cockroachdb

--- a/apps/cockroachdb/deployers/cockroachdb-vars.yaml
+++ b/apps/cockroachdb/deployers/cockroachdb-vars.yaml
@@ -1,0 +1,10 @@
+---
+cockroachdb_deployment: cockroachdb-sts.yaml
+
+cockroachdb_svc: cockroachdb-svc.yaml 
+
+namespace: cockroachdb
+
+test_name: cockroachdb-deploy
+
+

--- a/apps/cockroachdb/deployers/deploy-app-litmus.yaml
+++ b/apps/cockroachdb/deployers/deploy-app-litmus.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: litmus-cockroachdb
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+   
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+          - name: PROVIDER_STORAGE_CLASS
+            # Supported values: openebs-standard, local-storage
+            value: openebs-standard
+
+          - name: PROVIDER_PVC
+            value: cockroachdb-claim
+
+          - name: DEPLOY_TYPE
+            value: statefulset
+ 
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./cockroachdb/deployers/cockroachdb-installer.yaml -i /etc/ansible/hosts -v; exit 0"]


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
- In K8s cluster, deploys cockroachdb application as statefulset with 3 replicas.
- Using new variable in cockroachdb litmusbook for the application deployment type(statefulset/deployment)
- If the deployment is statefulset, verifying if all the replicas are created and running.