### PR TITLE
Update label for fetching jiva controller and replica pods

### DIFF
--- a/chaoslib/openebs/jiva_controller_network_delay.yaml
+++ b/chaoslib/openebs/jiva_controller_network_delay.yaml
@@ -29,7 +29,7 @@
 
 - name: Identify the jiva controller pod belonging to the PV
   shell: > 
-    kubectl get pods -l openebs/controller=jiva-controller
+    kubectl get pods -l openebs.io/controller=jiva-controller
     -n {{ app_ns }} --no-headers | grep {{ pv.stdout }} 
     | awk '{print $1}'
   args:

--- a/chaoslib/openebs/jiva_replica_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_replica_pod_failure.yaml
@@ -22,7 +22,7 @@
 
 - name: Randomly pick a jiva replica pod belonging to the PV
   shell: > 
-    kubectl get pods -l openebs/replica=jiva-replica
+    kubectl get pods -l openebs.io/replica=jiva-replica
     -n {{ app_ns }} --no-headers | grep {{ pv.stdout }} 
     | shuf -n1 | awk '{print $1}'
   args:


### PR DESCRIPTION
**What this PR does / why we need it**:
Change label from `openebs/replica=jiva-replica` to `openebs.io/replica=jiva-replica`
Change label from `openebs/controller` to `openebs.io/controller`

Signed-off-by: Akash Srivastava <akash.srivastava@openebs.io>