### PR TITLE
Update cassandra litmus book to verify successful creation of statefulset replicas.

### DIFF
--- a/apps/cassandra/deployers/cassandra-installer.yml
+++ b/apps/cassandra/deployers/cassandra-installer.yml
@@ -44,6 +44,12 @@
             regexp: "testclass"
             replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
 
+        - name: 2c) Replace the default namespace in cassandra statefulset yaml
+          replace:
+            path: "{{ cassandra_deployment }}"
+            regexp: 'cassandra-0.cassandra.default.svc.cluster.local'
+            replace: 'cassandra-0.cassandra.{{ namespace }}.svc.cluster.local'
+
         - name: Create test specific namespace.
           shell: kubectl create ns {{ namespace }}
           args:
@@ -59,15 +65,30 @@
           delay: 30
           retries: 10
         
-        - name: Deploying Cassendra
+        - name: Deploying Cassandra statefulset
           shell: kubectl apply -f {{ cassandra_deployment }} -n {{ namespace }} 
 
-        - name: Checking Cassendra is in running state
-          shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.generateName=="cassandra-")].status.phase}'
-          register: result
-          until: "((result.stdout_lines|unique)|length) == 1 and 'Running' in result.stdout"
-          delay: 10
-          retries: 100
+        - block:
+
+            - name: Obtain the number of replicas.
+              shell: kubectl get statefulset -n {{ namespace }} -l app=cassandra -o custom-columns=:spec.replicas
+              args:
+                executable: /bin/bash
+              register: rep_count
+              until: "rep_count.rc == 0"
+              delay: 60
+              retries: 15
+
+            - name: Obtain the ready replica count and compare with the replica count.
+              shell: kubectl get statefulset -n {{ namespace }} -l app=cassandra -o custom-columns=:..readyReplicas
+              args:
+                executable: /bin/bash
+              register: ready_rep
+              until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
+              delay: 60
+              retries: 15
+
+          when: lookup('env','DEPLOY_TYPE') == 'statefulset'
 
         - set_fact:
             flag: "Pass"

--- a/apps/cassandra/deployers/cassandra-installer.yml
+++ b/apps/cassandra/deployers/cassandra-installer.yml
@@ -44,7 +44,7 @@
             regexp: "testclass"
             replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
 
-        - name: 2c) Replace the default namespace in cassandra statefulset yaml
+        - name: Replace the default namespace in cassandra statefulset yaml
           replace:
             path: "{{ cassandra_deployment }}"
             regexp: 'cassandra-0.cassandra.default.svc.cluster.local'

--- a/apps/cassandra/deployers/cassandra_vars.yml
+++ b/apps/cassandra/deployers/cassandra_vars.yml
@@ -1,3 +1,3 @@
 cassandra_deployment: cassandra-statefulset.yml
 namespace: litmus
-test_name: Cassandra_Deployment
+test_name: cassandra-deployment

--- a/apps/cassandra/deployers/deploy_cassandra_litmus.yml
+++ b/apps/cassandra/deployers/deploy_cassandra_litmus.yml
@@ -24,11 +24,14 @@ spec:
 
           - name: PROVIDER_STORAGE_CLASS
             # Supported values: openebs-standard, local-storage
-            value: openebs-cassandra
+            value: openebs-standard
 
           - name: PROVIDER_PVC
             value: openebs-cassandra
- 
+
+          - name: DEPLOY_TYPE
+            value: statefulset
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./cassandra/deployers/cassandra-installer.yml -i /etc/ansible/hosts -v; exit 0"]
         


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->
- Update litmus job to refer to openebs-standard storage class by default.
- Fix litmus cr result job to use test name (lower case alphanumeric characters, '-' or '.')
- Added a check to verify successful creation of statefulset replicas as specified in statefulset spec.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
@shashank855 Can you review this PR?