### PR TITLE
Include litmus book to run workload on cassandra statefulset.

### DIFF
--- a/apps/cassandra/workload/cassandra-loadgen.yml
+++ b/apps/cassandra/workload/cassandra-loadgen.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cassandra-loadgen
+spec:
+  template:
+    metadata:
+      name: cassandra-loadgen
+      labels:
+        app: cassandra-loadgen
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: cassandra-loadgen
+        image: cassandra
+        command: ["/bin/bash"]
+        args: ["-c", "cassandra-stress write duration=5m no-warmup -node cassandra-0.cassandra"]
+        tty: true 
+

--- a/apps/cassandra/workload/run_cassandra_loadgen.yml
+++ b/apps/cassandra/workload/run_cassandra_loadgen.yml
@@ -1,0 +1,24 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: litmus-cassandra-loadgen
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: loadgen
+        image: openebs/ansible-runner
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: actionable
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./cassandra/workload/test.yml -i /etc/ansible/hosts -v; exit 0"]
+        

--- a/apps/cassandra/workload/test.yml
+++ b/apps/cassandra/workload/test.yml
@@ -1,0 +1,96 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            app: ""
+            chaostype: ""
+            phase: in-progress
+            verdict: none
+        
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"
+
+        - name: Create test specific namespace.
+          shell: kubectl create ns {{ namespace }}
+          args:
+           executable: /bin/bash
+          when: namespace != 'litmus'
+
+        - name: Checking the status  of test specific namespace.
+          shell: kubectl get ns {{ namespace }} -o jsonpath='{.status.phase}'
+          args:
+           executable: /bin/bash
+          register: npstatus
+          until: "'Active' in npstatus.stdout"
+          delay: 30
+          retries: 10
+        
+        - name: Create Cassandra Loadgen Job
+          shell: kubectl apply -f {{ cassandra_loadgen }} -n {{ namespace }} 
+
+        - name: Verify load is running for specified duration
+          shell: kubectl get pods -n {{ namespace }} -l app=cassandra-loadgen
+          args:
+            executable: /bin/bash
+          register: result
+          until: "'Running' in result.stdout"
+          delay: 30
+          retries: 15
+
+        - name: Wait for {{ (io_minutes) | int *60 }} secs to run load.
+          wait_for:
+            timeout: "{{ (io_minutes) | int *60 }}"
+
+        - name: Verify load by using describe keyspaces
+          shell: >
+            kubectl exec cassandra-0 -n {{ namespace }} 
+            -- cqlsh --execute "describe keyspaces;"
+          args:
+            executable: /bin/bash
+          register: result
+          until: "'keyspace1' in result.stdout"
+          delay: 60
+          retries: 5
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"  
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR 
+        - name: Generate the litmus result CR to reflect EOT (End of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            app: ""
+            chaostype: ""
+            phase: completed
+            verdict: "{{ flag }}"
+           
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"

--- a/apps/cassandra/workload/test_vars.yml
+++ b/apps/cassandra/workload/test_vars.yml
@@ -1,0 +1,4 @@
+cassandra_loadgen: cassandra-loadgen.yml
+namespace: litmus
+test_name: cassandra-loadgen
+io_minutes: 3


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Include litmus book to run workload on cassandra statefulset.
- Runs loadgen for specified duration.
- Verify the data written by fetching keyspaces inside the pod.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
