### PR TITLE
Litmus common utils for re-usable tasks to add new litmus books.

### DIFF
--- a/common/utils/app-deploy.yml
+++ b/common/utils/app-deploy.yml
@@ -1,0 +1,8 @@
+---
+- name: Deploy Application 
+  shell: kubectl apply -f {{ item }} -n {{ ns }}
+  args:
+    executable: /bin/bash
+  with_items: "{{ app_yml }}"
+
+

--- a/common/utils/deploy-check.yml
+++ b/common/utils/deploy-check.yml
@@ -1,0 +1,9 @@
+---
+- name: Check {{ lvalue }} pod status
+  shell: kubectl get pods -n {{ ns }} -l {{lkey}}={{ lvalue }}
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'Running' in result.stdout"
+  delay: 30
+  retries: 15

--- a/common/utils/litmus-result.yml
+++ b/common/utils/litmus-result.yml
@@ -1,0 +1,42 @@
+---
+- block:
+   - name: Generate the litmus result CR to reflect SOT (Start of Test)
+     template:
+       src: /litmus-result.j2
+       dest: litmus-result.yaml
+     vars:
+       test: "{{ test_name }}"
+       app: ""
+       chaostype: ""
+       phase: in-progress
+       verdict: "{{ flag }}"
+
+   - name: Apply the litmus result CR
+     shell: kubectl apply -f litmus-result.yaml
+     args:
+       executable: /bin/bash
+     register: lr_status
+     failed_when: "lr_status.rc != 0"
+
+  when: status == "SOT"
+
+- block:
+   - name: Generate the litmus result CR to reflect EOT (End of Test)
+     template:
+       src: /litmus-result.j2
+       dest: litmus-result.yaml
+     vars:
+       test: "{{ test_name }}"
+       app: ""
+       chaostype: ""
+       phase: completed
+       verdict: "{{ flag }}"
+
+   - name: Apply the litmus result CR
+     shell: kubectl apply -f litmus-result.yaml
+     args:
+       executable: /bin/bash
+     register: lr_status
+     failed_when: "lr_status.rc != 0"
+
+  when: status == "EOT"

--- a/common/utils/sts-check.yml
+++ b/common/utils/sts-check.yml
@@ -1,0 +1,18 @@
+---
+- name: Obtain the number of replicas.
+  shell: kubectl get statefulset -n {{ namespace }} -l {{ lkey }}={{ lvalue }} -o custom-columns=:spec.replicas
+  args:
+    executable: /bin/bash
+  register: rep_count
+  until: "rep_count.rc == 0"
+  delay: 60
+  retries: 15
+
+- name: Obtain the ready replica count and compare with the replica count.
+  shell: kubectl get statefulset -n {{ namespace }} -l {{ lkey }}={{ lvalue }} -o custom-columns=:..readyReplicas
+  args:
+    executable: /bin/bash
+  register: ready_rep
+  until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
+  delay: 60
+  retries: 15


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Include litmus app-deploy util to deploy any application by passing application spec.
- Include litmus deploy-check util to check the phase of the application pod by using application specs.
- Include litmus sts-check util to verify successful creation of statefulset replica's creation by validation with the number of replica's specified in the sts spec.
- Include litmus result-cr util to set litmus book (Start Of Test) and (End Of Test) state as a CR.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
