### PR TITLE
Include CAS Templates creation check as part of setup_openebs.

### DIFF
--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -186,6 +186,15 @@
             delay: 30
             retries: 100
 
+          - name: Confirm CAS Templates are deployed
+            shell: kubectl get cast -n {{ namespace }}
+            args:
+              executable: /bin/bash
+            register: result
+            until:  "result.rc ==0"
+            delay: 5
+            retries: 3
+
           - set_fact:
               flag: "Pass"
       rescue:


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Include CAS Templates creation check as part of setup_openebs.
- Verifies CAS templates creation by kubectl command  `kubectl get cast -n <namespace>` with retry count of 3.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
