### PR TITLE
feat(install): setup litmus-prerequisites on cluster

### DIFF
--- a/hack/litmus-prerequisites.sh
+++ b/hack/litmus-prerequisites.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+error_handler()
+{
+rc=$1; message=$(echo $2 | cut -d "=" -f 2); act=$(echo $3 | cut -d "=" -f 2)
+if [ $rc -ne 0 ]; then
+  echo "$message"
+  if [ "$act" == "exit" ]; then
+    exit 1 
+  fi
+fi
+}
+
+default_kube_config_path="$HOME/.kube/config"
+read -p "Provide the KUBECONFIG path: [default=$default_kube_config_path] " answer
+: ${answer:=$default_kube_config_path}
+
+echo "Selected kubeconfig file: $answer"
+
+echo "Applying the litmus RBAC.."
+kubectl apply -f rbac.yaml; retcode=$?
+error_handler $retcode msg="Unable to setup litmus RBAC, exiting" action="exit"
+
+cp $answer admin.conf; retcode=$?
+error_handler $retcode msg="Unable to find the kubeconfig file, exiting" action="exit"
+
+echo "Creating configmap.."
+kubectl create configmap kubeconfig --from-file=admin.conf -n litmus; retcode=$?
+error_handler $retcode msg="Unable to create kubeconfig configmap, exiting" action="exit"
+


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

Simplifies the process of setting up litmus pre-requisites before running the test jobs. 

- Take kubeconfig path as user input, with defaults specified
- Setup litmus RBAC and create kubeconfig configmap (after renaming to admin.conf) 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
