### PR TITLE
fix(yaml): pass application namespace to pumba & kubectl chaoslib utils

### DIFF
--- a/apps/percona/tests/mysql_data_persistence/test.yaml
+++ b/apps/percona/tests/mysql_data_persistence/test.yaml
@@ -90,15 +90,18 @@
 
        - include: /chaoslib/kubectl/pod_evict_by_taint.yaml
          app: "{{ percona_pod_name }}"
+         app_ns: 'litmus'
          taint: "node.kubernetes.io/out-of-disk"
          when: chaos_util ==  "APP_POD_EVICT/KUBECTL"
 
        - include: /chaoslib/kubectl/cordon_drain_node.yaml
          app: "{{ percona_pod_name }}"
+         app_ns: 'litmus'
          when: chaos_util ==  "APP_NODE_DRAIN/KUBECTL"
          
        - include: /chaoslib/pumba/pod_failure_by_sigkill.yaml
          app: "{{ percona_pod_name }}"
+         app_ns: 'litmus'
          when: chaos_util ==  "APP_POD_KILL/PUMBA"
 
        - name: Confirm mysql pod status is running

--- a/chaoslib/kubectl/cordon_drain_node.yaml
+++ b/chaoslib/kubectl/cordon_drain_node.yaml
@@ -1,6 +1,6 @@
 - name: Identify the application node
   shell: >
-    kubectl get pod {{ app }} -n litmus 
+    kubectl get pod {{ app }} -n {{ app_ns }} 
     --no-headers -o custom-columns=:spec.nodeName
   args: 
     executable: /bin/bash

--- a/chaoslib/kubectl/pod_evict_by_taint.yaml
+++ b/chaoslib/kubectl/pod_evict_by_taint.yaml
@@ -1,6 +1,6 @@
 - name: Identify the application node
   shell: >
-    kubectl get pod {{ app }} -n litmus 
+    kubectl get pod {{ app }} -n {{ app_ns }} 
     --no-headers -o custom-columns=:spec.nodeName
   args: 
     executable: /bin/bash

--- a/chaoslib/pumba/pod_failure_by_sigkill.yaml
+++ b/chaoslib/pumba/pod_failure_by_sigkill.yaml
@@ -1,7 +1,7 @@
 - name: Setup pumba chaos infrastructure
   shell: >
     kubectl apply -f /chaoslib/pumba/pumba_kube.yaml 
-    -n litmus 
+    -n {{ app_ns }} 
   args:
     executable: /bin/bash
   register: result
@@ -10,7 +10,7 @@
   shell: >
     kubectl get pod -l app=pumba 
     --no-headers -o custom-columns=:status.phase
-    -n litmus | sort | uniq
+    -n {{ app_ns }} | sort | uniq
   args: 
     executable: /bin/bash
   register: result
@@ -20,7 +20,7 @@
 
 - name: Identify the application node
   shell: >
-    kubectl get pod {{ app }} -n litmus 
+    kubectl get pod {{ app }} -n {{ app_ns }}
     --no-headers -o custom-columns=:spec.nodeName
   args: 
     executable: /bin/bash
@@ -34,7 +34,7 @@
   shell: >
     kubectl get pod {{ app }} 
     --no-headers -o jsonpath={.spec.containers[*].name}
-    -n litmus 
+    -n {{ app_ns }} 
   args:
     executable: /bin/bash
   register: app_container
@@ -42,7 +42,7 @@
 - name: Record the pumba pod on app node 
   shell: >
     kubectl get pod -l app=pumba -o wide 
-    -n litmus | grep {{ app_node }} 
+    -n {{ app_ns }} | grep {{ app_node }} 
     | awk '{print $1}'
   args:
     executable: /bin/bash
@@ -50,7 +50,7 @@
     
 - name: Force kill the application pod using pumba 
   shell: >
-    kubectl exec {{ pumba_pod.stdout}} -n litmus
+    kubectl exec {{ pumba_pod.stdout}} -n {{ app_ns }}
     -- timeout -t 40 pumba --interval 15s kill
     --signal SIGKILL re2:k8s_{{ app_container.stdout }};
   args:
@@ -63,7 +63,8 @@
     timeout: 30
 
 - name: Delete the pumba daemonset 
-  shell: kubectl delete -f /chaoslib/pumba/pumba_kube.yaml  
+  shell: >
+    kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n {{ app_ns }}
   args:
     executable: /bin/bash
   register: result
@@ -71,7 +72,7 @@
 - name: Confirm that the pumba ds is deleted successfully
   shell: >
     kubectl get pod -l app=pumba 
-    --no-headers -n litmus  
+    --no-headers -n {{ app_ns }}
   args: 
     executable: /bin/bash
   register: result


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Standardizes the params taken by the chaoslib modules
- Passes `app_ns` to chaoslib instead of hardcoding to litmus

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
