### PR TITLE
[Litmus] Include chaoslib for pod kill using chaoskube tool.

### DIFF
--- a/chaoslib/chaoskube/chaoskube.yaml
+++ b/chaoslib/chaoskube/chaoskube.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: chaoskube
+  labels:
+    app: chaoskube
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: chaoskube
+    spec:
+      serviceAccountName: chaoskube
+      containers:
+      - name: chaoskube
+        image: quay.io/linki/chaoskube:v0.8.0
+        args:
+        # Provided below are possible flags to set in chaoskube.
+        # This deployment will create a vanilla chaoskube w/o policies
+        # which will be configured by a test playbook
+       
+        # kill a pod every 10 minutes
+        #- --interval=10m
+        
+        # only target pods in the test environment
+        #- --labels=openebs.io/controller=jiva-controller
+        
+        # only consider pods with this annotation
+        #- --annotations=chaos.alpha.kubernetes.io/enabled=true
+        
+        # exclude all pods in the kube-system namespace
+        #- --namespaces=!kube-system
+        
+        # don't kill anything on weekends
+        #- --excluded-weekdays=Sat,Sun
+        
+        # don't kill anything during the night or at lunchtime
+        #- --excluded-times-of-day=22:00-08:00,11:00-13:00
+        
+        # don't kill anything as a joke or on christmas eve
+        #- --excluded-days-of-year=Apr1,Dec24
+        
+        # let's make sure we all agree on what the above times mean
+        #- --timezone=UTC
+        
+        # terminate pods for real: this disables dry-run mode which is on by default
+        #- --no-dry-run
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chaoskube
+  labels:
+    app: chaoskube

--- a/chaoslib/chaoskube/pod_failure_by_chaoskube.yaml
+++ b/chaoslib/chaoskube/pod_failure_by_chaoskube.yaml
@@ -1,0 +1,70 @@
+- name: Setup chaoskube infrastructure
+  shell: |
+    kubectl apply -f /chaoslib/chaoskube/rbac.yaml -n {{ namespace }}
+    kubectl apply -f /chaoslib/chaoskube/chaoskube.yaml -n {{ namespace }}
+  args:
+    executable: /bin/bash
+
+- name: Confirm that chaoskube pod is running
+  shell: >
+    kubectl get pod -l app=choaskube
+    --no-headers -n {{ namespace }}
+  args:
+    executable: /bin/bash
+  register: chaoskube
+  until: "'Running' in chaoskube.stdout"
+  delay: 20
+  retries: 15
+
+- name: Set the replica pod name to variable
+  set_fact:
+    chaoskube_pod: "{{ chaoskube.stdout.split()[0] }}"
+
+- name: Get the name of the volume deployment
+  shell: >
+    kubectl get deployments -n {{ namespace }}
+    -l {{ label }} --no-headers
+  args:
+    executable: /bin/bash
+  register: result_deploy
+
+- name: Set the deployment name to variable
+  set_fact:
+    volume_deploy: "{{ result_deploy.stdout_lines[0].split()[0] }}"
+
+- name: Get the resourceVersion of the {{ volume_deploy }}
+  shell: >
+    kubectl get deploy -n {{ namespace }}
+    {{ volume_deploy }} -o yaml | grep resourceVersion
+    | awk '{print $2}' | sed 's|"||g'
+  args:
+    executable: /bin/bash
+  register: rv_bef
+  changed_when: true
+
+- name: Initiate periodic pod failures through chaoskube
+  shell: >
+    kubectl exec {{ chaospod }} -n {{ namespace }}
+    -- timeout -t {{ chaos_duration }} chaoskube
+    --labels {{ label }}
+    --no-dry-run --interval={{ chaos_interval }}s
+    --debug
+    --namespaces={{ namespace }}
+  args:
+    executable: /bin/bash
+  register: chaos_result
+  ignore_errors: true
+
+- name: Get the resourceVersion of the volume deployment
+  shell: >
+    kubectl get deploy -n {{ namespace }}
+    {{ volume_deploy }} -o yaml | grep resourceVersion
+    | awk '{print $2}' | sed 's|"||g'
+  args:
+    executable: /bin/bash
+  register: rv_aft
+
+- name: Compare resourceVersions of volume deployments
+  debug:
+    msg: "Verified replica pods were restarted by chaoskube"
+  failed_when: "rv_bef.stdout | int == rv_aft.stdout | int"

--- a/chaoslib/chaoskube/rbac.yaml
+++ b/chaoslib/chaoskube/rbac.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chaoskube
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "delete"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chaoskube
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chaoskube
+subjects:
+- kind: ServiceAccount
+  name: chaoskube
+  namespace: default


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Include chaoslib for pod kill using chaoskube tool.
- The arguments required for this chaoslib util are < lable > (Lable of the pod to kill ), < namespace > (namespace on which pod is deployed).
- This util performs pod kills and verifies resource version before kill and after kill.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
