### PR TITLE
Add k8s version support for packet cloud

### DIFF
--- a/k8s/packet/k8s-installer/README.md
+++ b/k8s/packet/k8s-installer/README.md
@@ -22,14 +22,32 @@ export PACKET_API_TOKEN=<api-token>
 ansible-playbook create_packet_cluster.yml --extra-vars "k8s_version=<version>" -vv
 ```
 
-**example** :- ansible-playbook create_packet_cluster.yml --extra-vars "k8s_version=1.10.0" -vv
+**example** :- ansible-playbook create_packet_cluster.yml --extra-vars "k8s_version=1.10.0-00" -vv
 
 **Optional**
 
-- User can also provide the Cluster name at the time of creation in `--extra-vars`
+--extra-vars:
+
+1. k8s-version:
+   To get the available kubeadm versions run the below steps as a sudo user:
+
+   ```bash
+   apt-get update && apt-get install -y curl
+   curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+   touch /etc/apt/sources.list.d/kubernetes.list
+   sh -c 'echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
+   apt-get update
+   apt-cache madison kubeadm
+      kubeadm |  1.11.3-00 | https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages
+      kubeadm |  1.10.8-00 | https://apt.kubernetes.io kubernetes-xenial/main amd64 Packages
+   ```
+
+2. clustername:
+
+- User can also provide the Cluster name at the time of creation
 
 ```bash
-ansible-playbook create_packet_cluster.yml -vv --extra-vars "k8s_version=<version> cluster_name=<name-of-cluster>"
+ansible-playbook create_packet_cluster.yml -vv --extra-vars "k8s_version=1.11.3-00 cluster_name=<name-of-cluster>"
 ```
 
 ### Deleting k8s cluster in packet

--- a/k8s/packet/k8s-installer/README.md
+++ b/k8s/packet/k8s-installer/README.md
@@ -9,7 +9,8 @@ These playbook act as a wrapper class for all the `kubeadm` and `packet`  comman
 - Ansible
 - packet-python >= 1.35
 - packet api token (https://app.packet.net/users/example-id-cb2c1b67cc9/api-keys)
-- project_id
+- project_id of packet cloud
+- `packet` directory present in location `/tmp`
 
 ### Creating k8s cluster in packet
 
@@ -18,15 +19,17 @@ These playbook act as a wrapper class for all the `kubeadm` and `packet`  comman
 ```bash
 export PACKET_API_TOKEN=<api-token>
 
-ansible-playbook create_packet_cluster.yml -vv
+ansible-playbook create_packet_cluster.yml --extra-vars "k8s_version=<version>" -vv
 ```
+
+**example** :- ansible-playbook create_packet_cluster.yml --extra-vars "k8s_version=1.10.0" -vv
 
 **Optional**
 
 - User can also provide the Cluster name at the time of creation in `--extra-vars`
 
 ```bash
-ansible-playbook create_packet_cluster.yml -vv --extra-vars cluster_name=<name-of-cluster>"
+ansible-playbook create_packet_cluster.yml -vv --extra-vars "k8s_version=<version> cluster_name=<name-of-cluster>"
 ```
 
 ### Deleting k8s cluster in packet

--- a/k8s/packet/k8s-installer/create_packet_cluster.yml
+++ b/k8s/packet/k8s-installer/create_packet_cluster.yml
@@ -23,7 +23,7 @@
 
   vars:
     cluster_name:
-    kubernetes_version: "{{ k8s_version }}"
+    k8s_version:
 
   tasks:
     - block:
@@ -39,6 +39,10 @@
         - set_fact:
             cluster_name: "{{ cluster_name.stdout }}"
           when: cluster_name.stdout is defined
+
+        - set_fact:
+            k8s_version: "{{ default_k8s_version }}"
+          when: not k8s_version
 
         - name: Creating master instance in packet
           packet_device:
@@ -95,7 +99,7 @@
             - "{{ workers.devices }}"
 
         - name: install kubeadm inside master
-          shell: bash pre_requisite.sh "{{ kubernetes_version }}" "{{ item.public_ipv4 }}" "{{ network_cidr }}" master | grep "kubeadm join" | cut -d'"' -f2 | sed -e 's/^[ \t]*//'
+          shell: bash pre_requisite.sh "{{ k8s_version }}" "{{ item.public_ipv4 }}" "{{ network_cidr }}" master | grep "kubeadm join" | cut -d'"' -f2 | sed -e 's/^[ \t]*//'
           args:
             executable: /bin/bash
           delegate_to: "root@{{ item.public_ipv4 }}"
@@ -109,7 +113,7 @@
         - name: joining workers node with master
           args:
             executable: /bin/bash
-          shell: bash pre_requisite.sh "{{ kubernetes_version }}" && {{ storage.results[0].stdout }}
+          shell: bash pre_requisite.sh "{{ k8s_version }}" && {{ storage.results[0].stdout }}
           delegate_to: "root@{{ item.public_ipv4 }}"
           with_items: "{{ workers.devices }}"
   

--- a/k8s/packet/k8s-installer/create_packet_cluster.yml
+++ b/k8s/packet/k8s-installer/create_packet_cluster.yml
@@ -23,6 +23,7 @@
 
   vars:
     cluster_name:
+    kubernetes_version: "{{ k8s_version }}"
 
   tasks:
     - block:
@@ -94,7 +95,7 @@
             - "{{ workers.devices }}"
 
         - name: install kubeadm inside master
-          shell: bash pre_requisite.sh "{{ item.public_ipv4 }}" "{{ network_cidr }}" master | grep "kubeadm join" | cut -d'"' -f2 | sed -e 's/^[ \t]*//'
+          shell: bash pre_requisite.sh "{{ kubernetes_version }}-00" "{{ item.public_ipv4 }}" "{{ network_cidr }}" master | grep "kubeadm join" | cut -d'"' -f2 | sed -e 's/^[ \t]*//'
           args:
             executable: /bin/bash
           delegate_to: "root@{{ item.public_ipv4 }}"
@@ -108,7 +109,7 @@
         - name: joining workers node with master
           args:
             executable: /bin/bash
-          shell: bash pre_requisite.sh && {{ storage.results[0].stdout }}
+          shell: bash pre_requisite.sh "{{ kubernetes_version }}-00" && {{ storage.results[0].stdout }}
           delegate_to: "root@{{ item.public_ipv4 }}"
           with_items: "{{ workers.devices }}"
   

--- a/k8s/packet/k8s-installer/create_packet_cluster.yml
+++ b/k8s/packet/k8s-installer/create_packet_cluster.yml
@@ -95,7 +95,7 @@
             - "{{ workers.devices }}"
 
         - name: install kubeadm inside master
-          shell: bash pre_requisite.sh "{{ kubernetes_version }}-00" "{{ item.public_ipv4 }}" "{{ network_cidr }}" master | grep "kubeadm join" | cut -d'"' -f2 | sed -e 's/^[ \t]*//'
+          shell: bash pre_requisite.sh "{{ kubernetes_version }}" "{{ item.public_ipv4 }}" "{{ network_cidr }}" master | grep "kubeadm join" | cut -d'"' -f2 | sed -e 's/^[ \t]*//'
           args:
             executable: /bin/bash
           delegate_to: "root@{{ item.public_ipv4 }}"
@@ -109,7 +109,7 @@
         - name: joining workers node with master
           args:
             executable: /bin/bash
-          shell: bash pre_requisite.sh "{{ kubernetes_version }}-00" && {{ storage.results[0].stdout }}
+          shell: bash pre_requisite.sh "{{ kubernetes_version }}" && {{ storage.results[0].stdout }}
           delegate_to: "root@{{ item.public_ipv4 }}"
           with_items: "{{ workers.devices }}"
   

--- a/k8s/packet/k8s-installer/pre_requisite.sh
+++ b/k8s/packet/k8s-installer/pre_requisite.sh
@@ -3,7 +3,7 @@ apt-get update && apt-get install -y docker.io apt-transport-https curl
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 touch /etc/apt/sources.list.d/kubernetes.list
 sh -c 'echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list'
-apt-get update && apt-get install -y kubelet kubeadm kubectl
+apt-get update && apt-get install -y kubelet=$1 kubeadm=$1 kubectl=$1
 swapoff -a
 
 master() {
@@ -19,6 +19,6 @@ master() {
     kubectl apply -f https://raw.githubusercontent.com/cloudnativelabs/kube-router/master/daemonset/kubeadm-kuberouter.yaml
 }
 
-if [ "$3" == "master" ];then
-  master $1 $2
+if [ "$4" == "master" ];then
+  master $2 $3
 fi

--- a/k8s/packet/k8s-installer/vars.yml
+++ b/k8s/packet/k8s-installer/vars.yml
@@ -7,3 +7,4 @@ os: ubuntu_16_04
 network_cidr: 10.1.0.0/16
 master_config: t1.small.x86
 workers_config: t1.small.x86
+default_k8s_version: 1.10.0-00

--- a/k8s/packet/k8s-installer/vars.yml
+++ b/k8s/packet/k8s-installer/vars.yml
@@ -5,5 +5,5 @@ master_count: 1 # kubeadm support single master only
 location: ams1
 os: ubuntu_16_04
 network_cidr: 10.1.0.0/16
-master_config: m1.xlarge.x86
+master_config: t1.small.x86
 workers_config: t1.small.x86


### PR DESCRIPTION
**What this PR does / why we need it**:

Add k8s version support for packet cloud

- Modify `create_packet_cluster.yml` for add k8s_version support and pass
it to bash script

- Modify `vars.yml` for provide maximum resourses for nodes

Signed-off-by: Chandan Kumar <chandan.kr404@gmail.com>

**Special notes for your reviewer**:

```
$ kubectl get nodes
NAME                   STATUS    ROLES     AGE       VERSION
master-nervous-nobel   Ready     master    30m       v1.10.0
node-nervous-nobel01   Ready     <none>    27m       v1.10.0
node-nervous-nobel02   Ready     <none>    28m       v1.10.0
node-nervous-nobel03   Ready     <none>    29m       v1.10.0
```