### PR TITLE
Using default ansible stdout plugin in the deployers litmusbooks

### DIFF
--- a/apps/cassandra/deployers/run_litmus_test.yml
+++ b/apps/cassandra/deployers/run_litmus_test.yml
@@ -22,7 +22,7 @@ spec:
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays
-            value: actionable
+            value: default
 
           - name: PROVIDER_STORAGE_CLASS
             # Supported values: openebs-standard, local-storage

--- a/apps/cassandra/workload/run_litmus_test.yml
+++ b/apps/cassandra/workload/run_litmus_test.yml
@@ -18,7 +18,7 @@ spec:
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays
-            value: actionable
+            value: default
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./cassandra/workload/test.yml -i /etc/ansible/hosts -v; exit 0"]
         

--- a/apps/fio/tests/run_litmus_test.yml
+++ b/apps/fio/tests/run_litmus_test.yml
@@ -19,7 +19,7 @@ spec:
         image: openebs/ansible-runner
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK
-            value: log_plays
+            value: default
  
           - name: PROVIDER_STORAGE_CLASS
             value: openebs-standard

--- a/apps/mongodb/deployers/run_litmus_test.yml
+++ b/apps/mongodb/deployers/run_litmus_test.yml
@@ -22,7 +22,7 @@ spec:
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays
-            value: actionable
+            value: default
 
           - name: PROVIDER_STORAGE_CLASS
             # Supported values: openebs-standard, local-storage

--- a/apps/percona/tests/mysql_data_persistence/run_litmus_test.yml
+++ b/apps/percona/tests/mysql_data_persistence/run_litmus_test.yml
@@ -18,7 +18,7 @@ spec:
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays
-            value: actionable
+            value: default
  
           - name: PROVIDER_STORAGE_CLASS
             # Supported values: openebs-standard, local-storage

--- a/apps/percona/tests/mysql_storage_benchmark/run_litmus_test.yml
+++ b/apps/percona/tests/mysql_storage_benchmark/run_litmus_test.yml
@@ -18,7 +18,7 @@ spec:
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays
-            value: actionable
+            value: default
  
           - name: PROVIDER_STORAGE_CLASS
             value: openebs-standard


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
- As we use litmus pod logs for debugging, we need to use default plugin for dumping the stdout.
- Changed the plugin to 'default' wherever 'actionable' and 'log_plays' were used.