### PR TITLE
Modify GCP playbook for random VPC name support

### DIFF
--- a/k8s/gcp/k8s-installer/create-k8s-cluster.yml
+++ b/k8s/gcp/k8s-installer/create-k8s-cluster.yml
@@ -38,7 +38,7 @@
     - name: Creating the Cluster & InstanceGroup objects in our state store
       shell: |
         export KOPS_FEATURE_FLAGS=AlphaAllowGCE
-        kops create cluster {{ cluster_name }}.k8s.local --kubernetes-version {{ k8s_version }} --zones us-east1-b --state gs://{{ cluster_name }}/ --project {{ project }} --node-count {{ nodes }} --networking kubenet --image "ubuntu-os-cloud/ubuntu-1604-xenial-v20170202" --vpc {{ vpc }}
+        kops create cluster {{ cluster_name }}.k8s.local --kubernetes-version {{ k8s_version }} --zones {{zone}} --state gs://{{ cluster_name }}/ --project {{ project }} --node-count {{ nodes }} --networking kubenet --image "ubuntu-os-cloud/ubuntu-1604-xenial-v20170202" --vpc {{ vpc }}
     - name: Creating K8s Cluster
       shell: |
         export KOPS_FEATURE_FLAGS=AlphaAllowGCE

--- a/k8s/gcp/k8s-installer/create-k8s-cluster.yml
+++ b/k8s/gcp/k8s-installer/create-k8s-cluster.yml
@@ -19,15 +19,22 @@
       shell: python ../../utils/name_generator/namesgenerator.py
       register: cluster_name
       when: not cluster_name
+
+    - name: Get VPC Name
+      shell: cat ~/logs/vpc
+      register: vpc
+
     - set_fact:
         cluster_name: "{{ cluster_name.stdout }}"
-      when: cluster_name.stdout is defined
+    - set_fact:
+        vpc: "{{ vpc.stdout }}"
+        
     - name: Creating Bucket
       shell: gsutil mb gs://{{ cluster_name }}/
     - name: Creating the Cluster & InstanceGroup objects in our state store
       shell: |
         export KOPS_FEATURE_FLAGS=AlphaAllowGCE
-        kops create cluster {{ cluster_name }}.k8s.local --kubernetes-version {{ k8s_version }} --zones us-east1-b --state gs://{{ cluster_name }}/ --project {{ project }} --node-count {{ nodes }} --networking kubenet --image "ubuntu-os-cloud/ubuntu-1604-xenial-v20170202" --vpc {{ vpc_name }}
+        kops create cluster {{ cluster_name }}.k8s.local --kubernetes-version {{ k8s_version }} --zones us-east1-b --state gs://{{ cluster_name }}/ --project {{ project }} --node-count {{ nodes }} --networking kubenet --image "ubuntu-os-cloud/ubuntu-1604-xenial-v20170202" --vpc {{ vpc }}
     - name: Creating K8s Cluster
       shell: |
         export KOPS_FEATURE_FLAGS=AlphaAllowGCE

--- a/k8s/gcp/k8s-installer/create-k8s-cluster.yml
+++ b/k8s/gcp/k8s-installer/create-k8s-cluster.yml
@@ -14,11 +14,15 @@
 - hosts: localhost
   vars: 
     cluster_name:
+    zone:
   tasks:
     - name: Generating Random Cluster Name
       shell: python ../../utils/name_generator/namesgenerator.py
       register: cluster_name
       when: not cluster_name
+
+    - set_fact: zone="us-east1-b"
+      when: not zone
 
     - name: Get VPC Name
       shell: cat ~/logs/vpc

--- a/k8s/gcp/k8s-installer/create-vpc.yml
+++ b/k8s/gcp/k8s-installer/create-vpc.yml
@@ -11,8 +11,21 @@
 - hosts: localhost
   tasks:
        - block:
-             - name: Creating VPC 'openebs-e2e'
-               shell: gcloud compute --project={{ project }} networks create {{ vpc_name }} --subnet-mode=auto
+
+             - name: Generating Random VPC Name
+               shell: python ../../utils/name_generator/namesgenerator.py
+               register: vpc
+             - set_fact:
+                 vpc: "{{ vpc.stdout }}"
+             - name: Creating VPC
+               shell: gcloud compute --project={{ project }} networks create {{ vpc }} --subnet-mode=auto
+
+             - lineinfile:
+                 create: yes
+                 state: present
+                 path: "~/logs/vpc"
+                 line: "{{ vpc }}"
+
              - name: Test Passed
                set_fact:
                  flag: "Test Passed"

--- a/k8s/gcp/k8s-installer/delete-vpc.yml
+++ b/k8s/gcp/k8s-installer/delete-vpc.yml
@@ -10,11 +10,22 @@
 - hosts: localhost
   tasks:
        - block:
+           - name: Fetch VPC Name
+             shell: cat ~/logs/vpc
+             register: vpc
+           - set_fact:
+              vpc: "{{ vpc.stdout }}"
            - name: Deleting Routes, if exists
-             shell: gcloud compute routes delete $(gcloud compute routes list --filter="network:{{ vpc_name }}"  --format="get(name)") -q
+             shell: gcloud compute routes delete $(gcloud compute routes list --filter="network:{{ vpc }}"  --format="get(name)") -q
              ignore_errors: yes
            - name: Deleting VPC
-             shell: gcloud compute --project={{ project }} networks delete {{ vpc_name }} -q 
+             shell: gcloud compute --project={{ project }} networks delete {{ vpc }} -q 
+
+           - name: Removing VPC Name entry from log
+             lineinfile:
+               path: ~/logs/vpc
+               state: absent
+               regexp: '{{ vpc }}'
            - name: Test Passed
              set_fact:
                flag: "Test Passed"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Modify create-vpc.yml to create random vpc instead to hardcoding and
  store the vpc name in a log file
- This allows the playbook to support multiple cluster creation
  simultaneously.
- Modify create-k8s-cluster.yml to read the vpc name from log file and
  use it per se in kops
- Modify delete-vpc.yml to fetch the vpc name from the log file

Signed-off-by: harshvkarn <harshvkarn54@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
