### PR TITLE
Liveness integration of openebs_target_failure

### DIFF
--- a/apps/percona/chaos/openebs_target_failure/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_target_failure/run_litmus_test.yml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: openebs/ansible-runner
+        image: ranjnshashank855/ansible-runner:v1
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays
@@ -32,6 +32,12 @@ spec:
 
           - name: APP_PVC
             value: "demo-vol1-claim"
+
+          - name: LIVENESS_APP_LABEL
+            value: ""
+
+          - name: LIVENESS_APP_NAMESPACE
+            value: ""
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./percona/chaos/openebs_target_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/apps/percona/chaos/openebs_target_failure/test.yml
+++ b/apps/percona/chaos/openebs_target_failure/test.yml
@@ -9,7 +9,17 @@
     - block:
 
         ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE       
- 
+        - block:
+
+            - name: Checking status of liveness pod
+              shell: kubectl get po -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
+              register: liveness_pod
+              until: "'Running' in liveness_pod.stdout"
+              delay: 10
+              retries: 10
+             
+          when: liveness_label != ''  
+
         - include: test_prerequisites.yml
   
         - include_vars:
@@ -83,6 +93,17 @@
           until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
           delay: 10
           retries: 12
+        
+        - block:
+
+            - name: Checking status of liveness pod
+              shell: kubectl get po -n {{ namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
+              register: liveness_pod
+              until: "'Running' in liveness_pod.stdout"
+              delay: 10
+              retries: 10
+
+          when: liveness_label != ''
 
         - set_fact:
             flag: "Pass"

--- a/apps/percona/chaos/openebs_target_failure/test_vars.yml
+++ b/apps/percona/chaos/openebs_target_failure/test_vars.yml
@@ -3,5 +3,7 @@ namespace: "{{ lookup('env','APP_NAMESPACE') }}"
 target_namespace: "{{ lookup('env','TARGET_NAMESPACE') }}"
 label: "{{ lookup('env','APP_LABEL') }}"
 pvc: "{{ lookup('env','APP_PVC') }}"
+liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
 
 


### PR DESCRIPTION

**What this PR does / why we need it**:
- Adds a liveness integration of openebs_target_failure.
- Once the litmus job (openebs_target_failure) is executed it checks for the liveness pod which spawns over an application under test.
- When test get executed at last it again check for the liveness pod status.
- The labels for the livenss-application & namespace is passed as an env-var in litmus job.

**Following is the output when liveness application's label is passed as env**
```
TASK [Checking status of liveness pod] *****************************************
task path: /percona/chaos/openebs_target_failure/test.yml:14
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get po -n litmus -l name=mysql-liveness-check -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:01.871983", "end": "2018-09-25 12:18:51.879900", "rc": 0, "start": "2018-09-25 12:18:50.007917", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Identify the storage class used by the PVC] ******************************
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:2
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-claim -n litmus --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.592201", "end": "2018-09-25 12:18:54.277414", "rc": 0, "start": "2018-09-25 12:18:52.685213", "stderr": "", "stderr_lines": [], "stdout": "openebs-percona", "stdout_lines": ["openebs-percona"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:10
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-percona --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.609722", "end": "2018-09-25 12:18:56.602767", "rc": 0, "start": "2018-09-25 12:18:54.993045", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:18
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-percona"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:22
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:27
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-claim -n litmus --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.573288", "end": "2018-09-25 12:18:59.480453", "rc": 0, "start": "2018-09-25 12:18:57.907165", "stderr": "", "stderr_lines": [], "stdout": "pvc-77e02dfb-bd97-11e8-bf22-506b4b432478", "stdout_lines": ["pvc-77e02dfb-bd97-11e8-bf22-506b4b432478"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:35
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-77e02dfb-bd97-11e8-bf22-506b4b432478 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.583176", "end": "2018-09-25 12:19:01.792483", "rc": 0, "start": "2018-09-25 12:19:00.209307", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Record the storage engine name] ******************************************
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:43
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": ""}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:48
changed: [127.0.0.1] => {"changed": true, "checksum": "4776f9f1c9b58a3ffa26c15712bc1dcace1aa18f", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "229c36a1b99081f585b99190b4f4df01", "mode": "0664", "owner": "root", "size": 58, "src": "/root/.ansible/tmp/ansible-tmp-1537877942.39-10254687044866/source", "state": "file", "uid": 0}
```

**Following is the output when the livenes-application's label is not specified:**
```

TASK [Gathering Facts] *********************************************************
task path: /percona/chaos/openebs_target_failure/test.yml:2
ok: [127.0.0.1]
META: ran handlers

TASK [Checking status of liveness pod] *****************************************
task path: /percona/chaos/openebs_target_failure/test.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:2
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-claim -n litmus --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.001050", "end": "2018-09-25 12:15:53.125562", "rc": 0, "start": "2018-09-25 12:15:52.124512", "stderr": "", "stderr_lines": [], "stdout": "openebs-percona", "stdout_lines": ["openebs-percona"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:10
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-percona --no-headers -o custom-columns=:provisioner", "delta": "0:00:00.875535", "end": "2018-09-25 12:15:54.440638", "rc": 0, "start": "2018-09-25 12:15:53.565103", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:18
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-percona"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /percona/chaos/openebs_target_failure/test_prerequisites.yml:22
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

```
