### PR TITLE
Update provider litmusbook to check maya-apiserver container status instead of pod status 

### DIFF
--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -135,9 +135,12 @@
 
 
         - name: Checking Maya-API-Server is running
-          shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.labels.name=="maya-apiserver")].status.phase}'
+          #shell: kubectl get pods -n {{ namespace }} -o jsonpath='{.items[?(@.metadata.labels.name=="maya-apiserver")].status.phase}'
+          shell: >
+            kubectl get pods --no-headers -n openebs -l name=maya-apiserver
+            -o jsonpath='{.items[?(@.status.containerStatuses[*].name=="maya-apiserver")].status.containerStatuses[*].ready}' 
           register: maya_api
-          until: "'Running' in maya_api.stdout"
+          until: "'true' in maya_api.stdout"
           delay: 30
           retries: 100
 

--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -45,20 +45,20 @@
             url: "{{ openebs_operator_link }}"
             dest: "{{ playbook_dir }}/{{ openebs_operator }}"
             force: yes
-         register: result
-         until:  "'OK' in result.msg"
-         delay: 5
-         retries: 3
+          register: result
+          until:  "'OK' in result.msg"
+          delay: 5
+          retries: 3
 
         - name: Downloading openebs-storageclasses.yaml
           get_url:
             url: "{{ storageclass_link }}"
             dest: "{{ playbook_dir }}/{{ storageclass }}"
             force: yes
-         register: result
-         until:  "'OK' in result.msg"
-         delay: 5
-         retries: 3
+          register: result
+          until:  "'OK' in result.msg"
+          delay: 5
+          retries: 3
 
         - name: Updating maya api server image
           replace:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Due to liveness probe addition to the maya-apiserver deployment in openebs operator, the container
takes requests after the initialDelaySeconds of 300s. 

- During this period the pod.status.phase check returns 'Running'

- The new check verifies container 'ready' status instead of the above

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
