### PR TITLE
Add a litmusbook for crunchy-workload

### DIFF
--- a/apps/crunchy-postgres/workload/crunchy_postgres_loadgen.yml
+++ b/apps/crunchy-postgres/workload/crunchy_postgres_loadgen.yml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: postgres-loadgen
-        image: openebs/postgres-client
+        image: openebs/tests-postgresql-client
         imagePullPolicy: Always
 
         env: 

--- a/apps/crunchy-postgres/workload/crunchy_postgres_loadgen.yml
+++ b/apps/crunchy-postgres/workload/crunchy_postgres_loadgen.yml
@@ -8,6 +8,8 @@ spec:
   template:
     metadata:
       name: crunchy-loadgen
+      labels:
+        loadgen_lkey: loadgen_lvalue
       
     spec:
       restartPolicy: Never
@@ -19,35 +21,35 @@ spec:
         env: 
             # Time period (in sec) b/w retries for DB init check
           - name: NAMESPACE
-            value: postgres
+            value: name_space
     
             # Service name of postgres application 
           - name: SERVICE_NAME
-            value: pgset
+            value: servicename
     
             # Database Name 
           - name: DATABASE_NAME
-            value: postgres
+            value: dbname
     
            # Password to access Database
           - name: PASSWORD
-            value: password
+            value: database_password
     
            # Database user
           - name: DATABASE_USER
-            value: testuser
+            value: dbuser
           
             #Port on which crunchy databse is listening
           - name: PORT
-            value: "5432"
+            value: "port"
             
             #Number of parallel transactions to perform
           - name: PARALLEL_TRANSACTION
-            value: "5"
+            value: "paralleltransaction"
             
             #Number of transaction to perform
           - name: TRANSACTIONS
-            value: "200"
+            value: "database_transaction"
 
         command: ["/bin/bash"]
-        args: ["-c", "./crunchy-postgres/workload/test.sh ; exit 0"] 
+        args: ["-c", "./test.sh ; exit 0"] 

--- a/apps/crunchy-postgres/workload/run_litmus_test.yml
+++ b/apps/crunchy-postgres/workload/run_litmus_test.yml
@@ -1,0 +1,63 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: crunchy-postgres-loadgen 
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: crunchy_postgres-loadgen
+      namespace: litmus
+      labels:
+        app: crunchy-postgres-loadgen
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: loadgen
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: default
+
+          - name: LOADGEN_LABEL
+            value: loadgen=crunchy-loadgen
+             
+            #namespace in which loadgen will run 
+          - name: LOADGEN_NAMESPACE
+            value: litmus
+    
+            # Service name of postgres application 
+          - name: SERVICE_LABEL
+            value: pgset
+    
+            # Database Name 
+          - name: DATABASE_NAME
+            value: postgres
+    
+           # Password to access Database
+          - name: PASSWORD
+            value: password
+    
+           # Database user
+          - name: DATABASE_USER
+            value: postgres
+          
+            #Port on which crunchy databse is listening
+          - name: PORT
+            value: "5432"
+            
+            #Number of parallel transactions to perform
+          - name: PARALLEL_TRANSACTION
+            value: "5"
+            
+            #Number of transaction to perform
+          - name: TRANSACTIONS
+            value: "200"  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./crunchy-postgres/workload/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/crunchy-postgres/workload/run_litmus_test.yml
+++ b/apps/crunchy-postgres/workload/run_litmus_test.yml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: litmus
       restartPolicy: Never
       containers:
-      - name: loadgen
+      - name: ansibletest
         image: openebs/ansible-runner:ci
         imagePullPolicy: Always
         env: 

--- a/apps/crunchy-postgres/workload/run_litmus_test.yml
+++ b/apps/crunchy-postgres/workload/run_litmus_test.yml
@@ -24,16 +24,15 @@ spec:
             #value: log_plays
             value: default
 
+          - name: APP_LABEL
+            value: 'app=pgset'  
+
           - name: LOADGEN_LABEL
-            value: loadgen=crunchy-loadgen
+            value: 'loadgen=crunchy-loadgen'
              
             #namespace in which loadgen will run 
-          - name: LOADGEN_NAMESPACE
-            value: litmus
-    
-            # Service name of postgres application 
-          - name: SERVICE_LABEL
-            value: app=pgset
+          - name: APP_NAMESPACE
+            value: 'litmus'
     
             # Database Name 
           - name: DATABASE_NAME

--- a/apps/crunchy-postgres/workload/run_litmus_test.yml
+++ b/apps/crunchy-postgres/workload/run_litmus_test.yml
@@ -33,7 +33,7 @@ spec:
     
             # Service name of postgres application 
           - name: SERVICE_LABEL
-            value: pgset
+            value: app=pgset
     
             # Database Name 
           - name: DATABASE_NAME

--- a/apps/crunchy-postgres/workload/test.yml
+++ b/apps/crunchy-postgres/workload/test.yml
@@ -32,7 +32,7 @@
             loadgen_lvalue: "{{ loadgen_label.split('=')[1] }}"
 
         - name: Obtaining the Service name 
-          shell: kubectl get service -n litmus -l  app={{ service_label }} -o jsonpath='{.items[0].metadata.name}'
+          shell: kubectl get service -n litmus -l {{ service_label }} -o jsonpath='{.items[0].metadata.name}'
           register: service_name    
 
         - name: Replace the label in loadgen job spec.

--- a/apps/crunchy-postgres/workload/test.yml
+++ b/apps/crunchy-postgres/workload/test.yml
@@ -1,0 +1,152 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+       ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            app: ""
+            chaostype: ""
+            phase: in-progress
+            verdict: none
+        
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"
+
+        - name: Obtaining the loadgen pod label from env.
+          set_fact:
+            loadgen_lkey: "{{ loadgen_label.split('=')[0] }}"
+            loadgen_lvalue: "{{ loadgen_label.split('=')[1] }}"
+
+        - name: Obtaining the Service name 
+          shell: kubectl get service -n litmus -l  app={{ service_label }} -o jsonpath='{.items[0].metadata.name}'
+          register: service_name    
+
+        - name: Replace the label in loadgen job spec.
+          replace:
+            path: "{{ crunchy_loadgen }}"
+            regexp: "loadgen_lkey: loadgen_lvalue"
+            replace: "{{ loadgen_lkey }}: {{ loadgen_lvalue }}"
+
+        - name: Replace namespace placeholder in Crunchy-loadgen
+          replace:
+            path: "{{ crunchy_loadgen }}"
+            regexp: "name_space"
+            replace: "{{ namespace }}"
+
+        - name: Replace service placeholder in Crunchy-loadgen
+          replace:
+            path: "{{ crunchy_loadgen }}"
+            regexp: "servicename"
+            replace: "{{ service_name.stdout }}"
+
+        - name: Replace database placeholder
+          replace:
+            path: "{{ crunchy_loadgen }}"
+            regexp: "dbname"
+            replace: "{{ lookup('env','DATABASE_NAME') }}"
+
+        - name: Replace password placeholder in Crunchy-loadgen
+          replace:
+            path: "{{ crunchy_loadgen }}"
+            regexp: "database_password"
+            replace: "{{ lookup('env','PASSWORD') }}"
+
+        - name: Replace database-user placeholder in Crunchy-loadgen
+          replace:
+            path: "{{ crunchy_loadgen }}"
+            regexp: "dbuser"
+            replace: "{{ lookup('env','DATABASE_USER') }}"
+
+        - name: Replace port placeholder in Crunchy-loadgen
+          replace:
+            path: "{{ crunchy_loadgen }}"
+            regexp: "port"
+            replace: "{{ lookup('env','PORT') }}" 
+
+        - name: Replace transaction placeholder in Crunchy-loadgen
+          replace:
+            path: "{{ crunchy_loadgen }}"
+            regexp: "database_transaction"
+            replace: "{{ lookup('env','TRANSACTIONS') }}"
+
+        - name: Replace parallel-transaction placeholder in Crunchy-loadgen
+          replace:
+            path: "{{ crunchy_loadgen }}"
+            regexp: "paralleltransaction"
+            replace: "{{ lookup('env','PARALLEL_TRANSACTION') }}"           
+    
+
+        - name: Create test specific namespace.
+          shell: kubectl create ns {{ namespace }}
+          args:
+           executable: /bin/bash
+          when: namespace != 'litmus'
+
+        - name: Checking the status  of test specific namespace.
+          shell: kubectl get ns {{ namespace }} -o jsonpath='{.status.phase}'
+          args:
+           executable: /bin/bash
+          register: npstatus
+          until: "'Active' in npstatus.stdout"
+          delay: 30
+          retries: 10
+        
+        - name: Create Crunchy-postgres Loadgen Job
+          shell: kubectl apply -f {{ crunchy_loadgen }} -n {{ namespace }} 
+
+        - name: Verify loadgen pod is running 
+          shell: kubectl get pods -n {{ namespace }} -l {{ loadgen_label }} -o jsonpath='{.items[0].status.phase}'
+          args:
+            executable: /bin/bash
+          register: result
+          until: "'Running' in result.stdout"
+          delay: 30
+          retries: 15
+
+        - name: Verifying Load-generation
+          shell: kubectl exec -it pgset-0 -n {{ namespace }} -- psql -c '\dt'
+          register: output
+          until: "'pgbench_accounts' in output.stdout"
+          delay: 30
+          retries: 15
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"  
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR 
+        - name: Generate the litmus result CR to reflect EOT (End of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            app: ""
+            chaostype: ""
+            phase: completed
+            verdict: "{{ flag }}"
+           
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"

--- a/apps/crunchy-postgres/workload/test.yml
+++ b/apps/crunchy-postgres/workload/test.yml
@@ -32,8 +32,12 @@
             loadgen_lvalue: "{{ loadgen_label.split('=')[1] }}"
 
         - name: Obtaining the Service name 
-          shell: kubectl get service -n litmus -l {{ service_label }} -o jsonpath='{.items[0].metadata.name}'
+          shell: kubectl get service -n {{ namespace }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
           register: service_name    
+
+        - name: Obtaining the POD name of Application
+          shell: kubectl get pod -n {{ namespace }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
+          register: pod_name  
 
         - name: Replace the label in loadgen job spec.
           replace:
@@ -88,13 +92,6 @@
             path: "{{ crunchy_loadgen }}"
             regexp: "paralleltransaction"
             replace: "{{ lookup('env','PARALLEL_TRANSACTION') }}"           
-    
-
-        - name: Create test specific namespace.
-          shell: kubectl create ns {{ namespace }}
-          args:
-           executable: /bin/bash
-          when: namespace != 'litmus'
 
         - name: Checking the status  of test specific namespace.
           shell: kubectl get ns {{ namespace }} -o jsonpath='{.status.phase}'
@@ -118,7 +115,7 @@
           retries: 15
 
         - name: Verifying Load-generation
-          shell: kubectl exec -it pgset-0 -n {{ namespace }} -- psql -c '\dt'
+          shell: kubectl exec -it {{ pod_name.stdout }} -n {{ namespace }} -- psql -c '\dt'
           register: output
           until: "'pgbench_accounts' in output.stdout"
           delay: 30

--- a/apps/crunchy-postgres/workload/test_vars.yml
+++ b/apps/crunchy-postgres/workload/test_vars.yml
@@ -1,5 +1,5 @@
 crunchy_loadgen: crunchy_postgres_loadgen.yml
-namespace: "{{ lookup('env','LOADGEN_NAMESPACE') }}"
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
 test_name: crunchy-postgres-loadgen
 loadgen_label: "{{ lookup('env','LOADGEN_LABEL') }}"
-service_label: "{{ lookup('env','SERVICE_LABEL') }}"
+app_label: "{{ lookup('env','SERVICE_LABEL') }}" 

--- a/apps/crunchy-postgres/workload/test_vars.yml
+++ b/apps/crunchy-postgres/workload/test_vars.yml
@@ -1,0 +1,5 @@
+crunchy_loadgen: crunchy_postgres_loadgen.yml
+namespace: "{{ lookup('env','LOADGEN_NAMESPACE') }}"
+test_name: crunchy-postgres-loadgen
+loadgen_label: "{{ lookup('env','LOADGEN_LABEL') }}"
+service_label: "{{ lookup('env','SERVICE_LABEL') }}"


### PR DESCRIPTION
**This PR does the following**:
- Adds a litmusbook which trigers a crunchy-postgres-loadgen job.
- The litmusbook checks for the following after deploying the loadgen:
  1. Weather the loadgen pod is in running state.
  2. Weather the loadgen has perfomed a write operation on database or not.
- Accordingly ansible task updates the result in result CR.
 
**Special note for Reviewers**
- The stateful set for the mongodb deployment is also modified to make the mongo workload work properly
  refer:https://github.com/openebs/test-tools/pull/12

**Following is the output acheived after deploying the loadgen:**
```
PLAY [localhost] ***************************************************************

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************

TASK [Apply the litmus result CR] **********************************************

TASK [Checking the status  of test specific namespace.] ************************

TASK [Create Cassandra Loadgen Job] ********************************************
FAILED - RETRYING: Verify loadgen pod is running (15 retries left).

TASK [Verify loadgen pod is running] *******************************************

TASK [Verifying Load-generation] ***********************************************

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************

TASK [Apply the litmus result CR] **********************************************

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=10   changed=8    unreachable=0    failed=0   

```
**Following is the output of load-generation:**
```
spawn pgbench -i -h pgset.litmus.svc.cluster.local -p 5432 -U testuser -s 30 postgres
Password: 
password

NOTICE:  table "pgbench_history" does not exist, skipping
NOTICE:  table "pgbench_tellers" does not exist, skipping
NOTICE:  table "pgbench_accounts" does not exist, skipping
NOTICE:  table "pgbench_branches" does not exist, skipping
creating tables...
100000 of 3000000 tuples (3%) done (elapsed 0.05 s, remaining 1.44 s)
200000 of 3000000 tuples (6%) done (elapsed 0.51 s, remaining 7.11 s)
300000 of 3000000 tuples (10%) done (elapsed 0.95 s, remaining 8.54 s)
400000 of 3000000 tuples (13%) done (elapsed 1.04 s, remaining 6.75 s)
500000 of 3000000 tuples (16%) done (elapsed 1.44 s, remaining 7.21 s)
600000 of 3000000 tuples (20%) done (elapsed 1.55 s, remaining 6.18 s)
700000 of 3000000 tuples (23%) done (elapsed 1.86 s, remaining 6.10 s)
800000 of 3000000 tuples (26%) done (elapsed 2.25 s, remaining 6.19 s)
900000 of 3000000 tuples (30%) done (elapsed 2.34 s, remaining 5.47 s)
1000000 of 3000000 tuples (33%) done (elapsed 3.13 s, remaining 6.25 s)
1100000 of 3000000 tuples (36%) done (elapsed 3.32 s, remaining 5.74 s)
1200000 of 3000000 tuples (40%) done (elapsed 3.58 s, remaining 5.37 s)
1300000 of 3000000 tuples (43%) done (elapsed 4.34 s, remaining 5.67 s)
1400000 of 3000000 tuples (46%) done (elapsed 4.57 s, remaining 5.22 s)
1500000 of 3000000 tuples (50%) done (elapsed 4.85 s, remaining 4.85 s)
1600000 of 3000000 tuples (53%) done (elapsed 5.95 s, remaining 5.21 s)
1700000 of 3000000 tuples (56%) done (elapsed 6.13 s, remaining 4.69 s)
1800000 of 3000000 tuples (60%) done (elapsed 6.40 s, remaining 4.27 s)
1900000 of 3000000 tuples (63%) done (elapsed 6.75 s, remaining 3.91 s)
2000000 of 3000000 tuples (66%) done (elapsed 7.49 s, remaining 3.75 s)
2100000 of 3000000 tuples (70%) done (elapsed 8.24 s, remaining 3.53 s)
2200000 of 3000000 tuples (73%) done (elapsed 8.68 s, remaining 3.16 s)
2300000 of 3000000 tuples (76%) done (elapsed 8.89 s, remaining 2.71 s)
spawn pgbench -c 4 -h pgset.litmus.svc.cluster.local -p 5432 -U testuser -j 5 -t 200 postgres
Password: 

starting vacuum...end.
spawn pgbench -c 4 -h pgset.litmus.svc.cluster.local -p 5432 -U testuser -j 5 -t 200 postgres
Password: 
starting vacuum...end.
spawn pgbench -c 4 -h pgset.litmus.svc.cluster.local -p 5432 -U testuser -j 5 -t 200 postgres
Password: 

starting vacuum...end.
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 30
query mode: simple
number of clients: 4
number of threads: 4
number of transactions per client: 200
number of transactions actually processed: 800/800
latency average = 24.736 ms
tps = 161.704601 (including connections establishing)
tps = 162.821928 (excluding connections establishing)
spawn pgbench -c 4 -h pgset.litmus.svc.cluster.local -p 5432 -U testuser -j 5 -t 200 postgres
Password: 
starting vacuum...end.
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 30
query mode: simple
number of clients: 4
number of threads: 4
number of transactions per client: 200
number of transactions actually processed: 800/800
latency average = 5.522 ms
tps = 724.385802 (including connections establishing)
tps = 734.919177 (excluding connections establishing)
spawn pgbench -c 4 -h pgset.litmus.svc.cluster.local -p 5432 -U testuser -j 5 -t 200 postgres
Password: 
starting vacuum...end.
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 30
query mode: simple
number of clients: 4
number of threads: 4
number of transactions per client: 200
number of transactions actually processed: 800/800
latency average = 6.196 ms
tps = 645.625025 (including connections establishing)
tps = 663.130595 (excluding connections establishing)
spawn pgbench -c 4 -h pgset.litmus.svc.cluster.local -p 5432 -U testuser -j 5 -t 200 postgres
Password: 
starting vacuum...end.
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 30
query mode: simple
number of clients: 4
number of threads: 4
number of transactions per client: 200
number of transactions actually processed: 800/800
latency average = 5.488 ms
tps = 728.816841 (including connections establishing)
tps = 735.939821 (excluding connections establishing)
spawn pgbench -c 4 -h pgset.litmus.svc.cluster.local -p 5432 -U testuser -j 5 -t 200 postgres
Password: 
starting vacuum...end.
transaction type: <builtin: TPC-B (sort of)>
scaling factor: 30
query mode: simple
number of clients: 4
number of threads: 4
number of transactions per client: 200
number of transactions actually processed: 800/800
latency average = 5.798 ms
tps = 689.949885 (including connections establishing)
tps = 711.724228 (excluding connections establishing)
```