### PR TITLE
Updated the label for litmus loadgen jobs

### DIFF
--- a/apps/cassandra/workload/cassandra_loadgen.yml
+++ b/apps/cassandra/workload/cassandra_loadgen.yml
@@ -8,7 +8,7 @@ spec:
     metadata:
       name: cassandra-loadgen
       labels:
-        app: cassandra-loadgen
+        loadgen_lkey: loadgen_lvalue
     spec:
       restartPolicy: Never
       containers:

--- a/apps/cassandra/workload/run_litmus_test.yml
+++ b/apps/cassandra/workload/run_litmus_test.yml
@@ -8,6 +8,9 @@ spec:
   template:
     metadata:
       name: litmus
+      labels:
+        loadgen: cassandra-loadjob
+
     spec:
       serviceAccountName: litmus
       restartPolicy: Never
@@ -19,6 +22,12 @@ spec:
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays
             value: default
+
+          - name: LOADGEN_NS
+            value: litmus
+
+          - name: LOADGEN_LABEL
+            value: 'loadgen=cassandra-loadgen'
+
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./cassandra/workload/test.yml -i /etc/ansible/hosts -v; exit 0"]
-        
+        args: ["-c", "ansible-playbook ./cassandra/workload/test.yml -i /etc/ansible/hosts -v; exit 0"]        

--- a/apps/cassandra/workload/test.yml
+++ b/apps/cassandra/workload/test.yml
@@ -40,12 +40,23 @@
           until: "'Active' in npstatus.stdout"
           delay: 30
           retries: 10
+
+        - name: Obtaining the loadgen pod label from env.
+          set_fact:
+            loadgen_lkey: "{{ loadgen_label.split('=')[0] }}"
+            loadgen_lvalue: "{{ loadgen_label.split('=')[1] }}"
+
+        - name: Replace the label in loadgen job spec.
+          replace:
+            path: "{{ mongodb_loadgen }}"
+            regexp: "loadgen_lkey: loadgen_lvalue"
+            replace: "{{ loadgen_lkey }}: {{ loadgen_lvalue }}"
         
         - name: Create Cassandra Loadgen Job
           shell: kubectl apply -f {{ cassandra_loadgen }} -n {{ namespace }} 
 
         - name: Verify load is running for specified duration
-          shell: kubectl get pods -n {{ namespace }} -l app=cassandra-loadgen
+          shell: kubectl get pods -n {{ namespace }} -l {{ loadgen_label }}
           args:
             executable: /bin/bash
           register: result

--- a/apps/cassandra/workload/test_vars.yml
+++ b/apps/cassandra/workload/test_vars.yml
@@ -1,4 +1,5 @@
 cassandra_loadgen: cassandra_loadgen.yml
-namespace: litmus
+namespace: "{{ lookup('env','LOADGEN_NAMESPACE') }}"
 test_name: cassandra-loadgen
+loadgen_label: "{{ lookup('env','LOADGEN_LABEL') }}"
 io_minutes: 3

--- a/apps/cockroachdb/workload/run_litmus_test.yml
+++ b/apps/cockroachdb/workload/run_litmus_test.yml
@@ -9,7 +9,7 @@ spec:
     metadata:
       name: litmus
       labels:
-        loadgen: cockroachdb-load 
+        loadgen: cockroachdb-loadjob
     spec:
       serviceAccountName: litmus
       restartPolicy: Never

--- a/apps/mongodb/workload/run_litmus_test.yml
+++ b/apps/mongodb/workload/run_litmus_test.yml
@@ -10,7 +10,7 @@ spec:
       name: mongodb-loadgen
       namespace: litmus
       labels:
-        app: mongodb-loadgen
+        loadgen: mongodb-loadjob
     spec:
       serviceAccountName: litmus
       restartPolicy: Never

--- a/apps/percona/workload/run_litmus_test.yml
+++ b/apps/percona/workload/run_litmus_test.yml
@@ -10,7 +10,7 @@ spec:
       name: percona-loadgen
       namespace: litmus
       labels:
-        app: percona-loadgen
+        loadgen: percona-loadjob
     spec:
       serviceAccountName: litmus
       restartPolicy: Never


### PR DESCRIPTION
Signed-off-by: sathyaseelan <sathyaseelan.n@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Changed the label names of litmus job of cassandra,mongo,percona and cockroachdb workloads.
@ksatchit @dargasudarshan can you please review this PR