### PR TITLE
refactor(yaml): remove cstor references in the target failure test

### DIFF
--- a/apps/percona/chaos/openebs_target_failure/test_vars.yml
+++ b/apps/percona/chaos/openebs_target_failure/test_vars.yml
@@ -1,4 +1,4 @@
-test_name: openebs-cstor-target-failure
+test_name: openebs-target-failure
 namespace: "{{ lookup('env','APP_NAMESPACE') }}"
 target_namespace: "{{ lookup('env','TARGET_NAMESPACE') }}"
 label: "{{ lookup('env','APP_LABEL') }}"


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Removes reference to cstor in the target failure test (as it can invoke both openebs-cstor & openebs-jiva related chaoslib utils) 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
