### PR TITLE
fix indentation of code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,19 @@ Users have a Kubernetes environment with a given stateful workload and underlyin
 
 - Clone the Litmus repo and setup a dedicated RBAC for Litmus.
 
-```
-git clone https://github.com/openebs/litmus.git
-cd litmus
-kubectl apply -f hack/rbac.yaml 
-```
+  ```
+  git clone https://github.com/openebs/litmus.git
+  cd litmus
+  kubectl apply -f hack/rbac.yaml 
+  ```
 
 - Create a configmap from the cluster's in-cluster-config (kubeconfig) file with the data placed in "admin.conf". 
 Typically, this file is located at ~/.kube/config or /etc/kubernetes/admin.conf etc.., depending on the type of cluster setup. 
 To perform this step, copy the kubeconfig file into "admin.conf" (if it is named differently) and execute the following command:
 
-```
-kubectl create configmap kubeconfig --from-file=<path/to/admin.conf> -n litmus 
-```
+  ```
+  kubectl create configmap kubeconfig --from-file=<path/to/admin.conf> -n litmus 
+  ```
 
 - The tests are categorized based on application workloads, with different aspects/use-cases of the application 
 constituting a separate test. Select a workload and follow the instructions under the corresponding 
@@ -58,11 +58,11 @@ constituting a separate test. Select a workload and follow the instructions unde
 
   For example, to run a MySQL benchmarking test:
 
-```
-cd apps/percona/tests/mysql_storage_benchmark/
-<Modify the PROVIDER_STORAGE_CLASS in run_litmus_test.yaml>
-kubectl create -f run_litmus_test.yaml
-```
+  ```
+  cd apps/percona/tests/mysql_storage_benchmark/
+  <Modify the PROVIDER_STORAGE_CLASS in run_litmus_test.yaml>
+  kubectl create -f run_litmus_test.yaml
+  ```
 
   The above test runs a Kubernetes job that:
   - Verifies that the StorageClass mentioned (default: OpenEBS) is loaded in the cluster
@@ -120,4 +120,3 @@ For a full list, please checkout the [tools](./tools) directory.
 ## License
 
 Litmus is licensed under the Apache License, Version 2.0. See [LICENSE](./LICENSE) for the full license text. Some of the projects used by the Litmus project may be governed by a different license, please refer to its specific license. 
-


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix indentation of code blocks in README.

# Was:

![image](https://user-images.githubusercontent.com/25141164/46381969-49889900-c6b1-11e8-81f9-e2beac7a81e9.png)

# Now

![image](https://user-images.githubusercontent.com/25141164/46382010-72a92980-c6b1-11e8-8d5e-393bec9253fd.png)


<details>
<summary>DCO</summary>

Signed-off by: StrikerRUS < nekit94-08 at mail.ru >
</details>