### PR TITLE
Modified namespace variable name in cassandra workload litmusbook

### DIFF
--- a/apps/cassandra/workload/test_vars.yml
+++ b/apps/cassandra/workload/test_vars.yml
@@ -1,5 +1,5 @@
 cassandra_loadgen: cassandra_loadgen.yml
-namespace: "{{ lookup('env','LOADGEN_NAMESPACE') }}"
+namespace: "{{ lookup('env','LOADGEN_NS') }}"
 test_name: cassandra-loadgen
 loadgen_label: "{{ lookup('env','LOADGEN_LABEL') }}"
 io_minutes: 3

--- a/apps/mongodb/deployers/test.yml
+++ b/apps/mongodb/deployers/test.yml
@@ -57,7 +57,7 @@
         - name: Create test specific namespace.
           shell: source ~/.profile;  kubectl create ns {{ app_ns }}
           args:
-           executable: /bin/bas
+           executable: /bin/bash
           when: app_ns != 'litmus'
 
         - name: Checking the status  of test specific namespace.

--- a/apps/percona/deployers/test.yml
+++ b/apps/percona/deployers/test.yml
@@ -59,7 +59,7 @@
         - name: Create test specific namespace.
           shell: source ~/.profile;  kubectl create ns {{ app_ns }}
           args:
-           executable: /bin/bas
+           executable: /bin/bash
           when: app_ns != 'litmus'
 
         - name: Checking the status  of test specific namespace.


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
- Corrected the namespace variable name in cassandra workload litmusbook.
- Corrected typo in percona and mongodb deployers.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
