### PR TITLE
Updating ci tag in cassandra loadgen litmusbook

### DIFF
--- a/apps/cassandra/workload/run_litmus_test.yml
+++ b/apps/cassandra/workload/run_litmus_test.yml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: openebs/ansible-runner
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
Updated ci tag to the ansible-runner image
