### PR TITLE
refactor(yaml): make env values across chaos jobs consistent 

### DIFF
--- a/apps/percona/chaos/openebs_replica_network_delay/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_replica_network_delay/run_litmus_test.yml
@@ -22,16 +22,16 @@ spec:
             value: default
 
           - name: OPERATOR_NAMESPACE
-            value: "openebs"
+            value: openebs
  
           - name: APP_NAMESPACE
-            value: "litmus"
+            value: litmus
 
           - name: APP_LABEL
-            value: "name=percona"
+            value: 'name=percona'
 
           - name: APP_PVC
-            value: "percona-mysql-claim"
+            value: percona-mysql-claim
 
           - name: NETWORK_DELAY
             value: "3000" # in milliseconds

--- a/apps/percona/chaos/openebs_target_failure/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_target_failure/run_litmus_test.yml
@@ -22,16 +22,16 @@ spec:
             value: default
  
           - name: APP_NAMESPACE
-            value: "default"
+            value: litmus
 
           - name: TARGET_NAMESPACE
-            value: "openebs"
+            value: openebs
 
           - name: APP_LABEL
-            value: "name=percona"
+            value: 'name=percona'
 
           - name: APP_PVC
-            value: "demo-vol1-claim"
+            value: percona-mysql-claim
 
           - name: LIVENESS_APP_LABEL
             value: ""

--- a/apps/percona/chaos/openebs_target_network_delay/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_target_network_delay/run_litmus_test.yml
@@ -22,16 +22,16 @@ spec:
             value: default
 
           - name: OPERATOR_NAMESPACE
-            value: "openebs"
+            value: openebs
  
           - name: APP_NAMESPACE
-            value: "litmus"
+            value: litmus
 
           - name: APP_LABEL
-            value: "name=percona"
+            value: 'name=percona'
 
           - name: APP_PVC
-            value: "percona-mysql-claim"
+            value: percona-mysql-claim
 
           - name: NETWORK_DELAY
             value: "3000" # in milliseconds

--- a/apps/percona/chaos/openebs_volume_replica_failure/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_volume_replica_failure/run_litmus_test.yml
@@ -22,13 +22,13 @@ spec:
             value: default
  
           - name: APP_NAMESPACE
-            value: "percona"
+            value: litmus
 
           - name: APP_LABEL
-            value: "name=percona"
+            value: 'name=percona'
 
           - name: APP_PVC
-            value: "percona-mysql-claim"
+            value: percona-mysql-claim
 
           - name: LIVENESS_APP_LABEL
             value: ""


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- There may be user wrapper scripts that have been templatized & serve the purpose of replacing env values in the existing jobs. This requires that the litmus jobs follow a certain standard/convention with respect to the way in which the values of the env are specified. For ex: wrapping them with `""` v/s `' '` v/s `not-quoting` them at all etc,. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- This may cease to be an issue when there are tools that inherently understand the K8s spec. But it cannot be assumed that the users will use only such tools while pre-conditioning a litmus job
