### PR TITLE
Add a task to check for running status of percona-application

### DIFF
--- a/apps/percona/workload/test.yml
+++ b/apps/percona/workload/test.yml
@@ -88,6 +88,13 @@
           until: "'tpcc-config' in config.stdout"
           delay: 15
           retries: 15
+
+        - name: Checking whether application is running
+          shell: kubectl get pod -n {{ namespace }} -l {{ app_label }}
+          register: running_status
+          until: "'Running' in running_status.stdout"
+          delay: 10
+          retries: 15
         
         - name: Create Percona Loadgen Job
           shell: kubectl apply -f {{ percona_loadgen }} -n {{ namespace }} 

--- a/apps/percona/workload/test.yml
+++ b/apps/percona/workload/test.yml
@@ -93,8 +93,8 @@
           shell: kubectl get pod -n {{ namespace }} -l {{ app_label }}
           register: running_status
           until: "'Running' in running_status.stdout"
-          delay: 10
-          retries: 15
+          delay: 30
+          retries: 60
         
         - name: Create Percona Loadgen Job
           shell: kubectl apply -f {{ percona_loadgen }} -n {{ namespace }} 


### PR DESCRIPTION


**What this PR does / why we need it**:
Add a task to check the running status of application before triggering the workload.
