### PR TITLE
Add a task for mongo wokload to verify application is running

### DIFF
--- a/apps/mongodb/workload/run_litmus_test.yml
+++ b/apps/mongodb/workload/run_litmus_test.yml
@@ -23,12 +23,6 @@ spec:
             #value: log_plays
             value: default
 
-          - name: POD_NAME
-            value: mongo-0
-
-          - name: SERVICE_NAME 
-            value: mongo
-
           - name: LOADGEN_LABEL
             value: loadgen=mongo-loadgen
 

--- a/apps/mongodb/workload/run_litmus_test.yml
+++ b/apps/mongodb/workload/run_litmus_test.yml
@@ -24,7 +24,7 @@ spec:
             value: default
 
           - name: LOADGEN_LABEL
-            value: loadgen=mongo-loadgen
+            value: 'loadgen=mongo-loadgen'
 
           - name: DATABASE_NAME
             value: sbtest

--- a/apps/mongodb/workload/test.yml
+++ b/apps/mongodb/workload/test.yml
@@ -89,7 +89,7 @@
             replace: "{{ service_name.stdout }}"
 
         - name: Getting the Pod name of the Application
-          shell: kubectl get po -n {{ namespace }} -l lkey=lvalue -o jsonpath='{.items[0].metadata.name}'
+          shell: kubectl get po -n {{ namespace }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
           register: pod_name   
 
         - name: Replace pod placeholder in mongo-loadgen

--- a/apps/mongodb/workload/test.yml
+++ b/apps/mongodb/workload/test.yml
@@ -89,7 +89,7 @@
             replace: "{{ service_name.stdout }}"
 
         - name: Getting the Pod name of the Application
-          shell: kubectl get po -n {{ namespace }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
+          shell: kubectl get pod -n {{ namespace }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
           register: pod_name   
 
         - name: Replace pod placeholder in mongo-loadgen
@@ -103,8 +103,6 @@
             path: "{{ mongodb_loadgen }}"
             regexp: "database_name"
             replace: "{{ lookup('env','DATABASE_NAME') }}"       
-<<<<<<< 362985a909db9f4c0913d55f68a1260640008118
-=======
 
         - name: Create test specific namespace.
           shell: kubectl create namespace {{ namespace }}
@@ -125,9 +123,8 @@
           shell: kubectl get pod {{ pod_name.stdout }} -n {{ namespace }} -o jsonpath='{.status.phase}'
           register: running_status
           until: "'Running' in running_status.stdout"
-          delay: 10
+          delay: 60
           retries: 15  
->>>>>>> Add a task to verigy application is running
         
         - name: Create Mongodb Loadgen Job
           shell: kubectl apply -f {{ mongodb_loadgen }} -n {{ namespace }} 
@@ -142,7 +139,7 @@
           retries: 15
 
         - name: Verifying load-generation  
-          shell: kubectl exec -it mongo-0 -n {{ namespace }} -- mongo --eval 'db.getMongo().getDBNames()'
+          shell: kubectl exec -it {{ pod_name.stdout }} -n {{ namespace }} -- mongo --eval 'db.getMongo().getDBNames()'
           register: output
           until: "'sbtest' in output.stdout"
           delay: 30

--- a/apps/mongodb/workload/test.yml
+++ b/apps/mongodb/workload/test.yml
@@ -95,6 +95,31 @@
             path: "{{ mongodb_loadgen }}"
             regexp: "database_name"
             replace: "{{ lookup('env','DATABASE_NAME') }}"       
+<<<<<<< 362985a909db9f4c0913d55f68a1260640008118
+=======
+
+        - name: Create test specific namespace.
+          shell: kubectl create namespace {{ namespace }}
+          args:
+           executable: /bin/bash
+          when: namespace != 'litmus'
+
+        - name: Checking the status  of test specific namespace.
+          shell: kubectl get namespace {{ namespace }} -o jsonpath='{.status.phase}'
+          args:
+           executable: /bin/bash
+          register: npstatus
+          until: "'Active' in npstatus.stdout"
+          delay: 30
+          retries: 10
+
+        - name: Checking whether application is running
+          shell: kubectl get pod {{ pod_name }} -n {{ namespace }} -o jsonpath='{.status.phase}'
+          register: running_status
+          until: "'Running' in running_status.stdout"
+          delay: 10
+          retries: 15  
+>>>>>>> Add a task to verigy application is running
         
         - name: Create Mongodb Loadgen Job
           shell: kubectl apply -f {{ mongodb_loadgen }} -n {{ namespace }} 

--- a/apps/mongodb/workload/test.yml
+++ b/apps/mongodb/workload/test.yml
@@ -78,17 +78,25 @@
             regexp: "loadgen_lkey: loadgen_lvalue"
             replace: "{{ loadgen_lkey }}: {{ loadgen_lvalue }}"
 
+        - name: Getting the Service name of the Application
+          shell: kubectl get service -n {{ namespace }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}' 
+          register: service_name   
+
         - name: Replace service placeholder in mongo-loadgen
           replace:
             path: "{{ mongodb_loadgen }}"
             regexp: "servicename"
-            replace: "{{ lookup('env','SERVICE_NAME') }}"
+            replace: "{{ service_name.stdout }}"
+
+        - name: Getting the Pod name of the Application
+          shell: kubectl get po -n {{ namespace }} -l lkey=lvalue -o jsonpath='{.items[0].metadata.name}'
+          register: pod_name   
 
         - name: Replace pod placeholder in mongo-loadgen
           replace:
             path: "{{ mongodb_loadgen }}"
             regexp: "podname"
-            replace: "{{ lookup('env','POD_NAME') }}" 
+            replace: "{{ pod_name.stdout }}" 
 
         - name: Replace database-name placeholder in mongo-loadgen
           replace:
@@ -114,7 +122,7 @@
           retries: 10
 
         - name: Checking whether application is running
-          shell: kubectl get pod {{ pod_name }} -n {{ namespace }} -o jsonpath='{.status.phase}'
+          shell: kubectl get pod {{ pod_name.stdout }} -n {{ namespace }} -o jsonpath='{.status.phase}'
           register: running_status
           until: "'Running' in running_status.stdout"
           delay: 10


### PR DESCRIPTION

**What this PR does / why we need it**:
- Add a task in test.yml to ensure that the application is in running state before running the workloads.
**Following is the output of the loadgen job:**
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "36013a5fb17389d4868376831bb1f1664ede99bb", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "152847753a56a7e07248164e6a09fc44", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1538743725.09-62926032569003/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.227424", "end": "2018-10-05 12:48:48.119008", "failed_when_result": false, "rc": 0, "start": "2018-10-05 12:48:46.891584", "stderr": "", "stderr_lines": [], "stdout": "litmusresult \"mongodb-loadgen\" configured", "stdout_lines": ["litmusresult \"mongodb-loadgen\" configured"]}

TASK [Obtaining the loadgen pod label from env.] *******************************
ok: [127.0.0.1] => {"ansible_facts": {"loadgen_lkey": "loadgen", "loadgen_lvalue": "mongo-loadgen"}, "changed": false}

TASK [Replace the label in loadgen job spec.] **********************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Getting the Service name of the Application] *****************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get service -n litmus -l lkey=lvalue -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:00.830513", "end": "2018-10-05 12:48:50.330105", "rc": 0, "start": "2018-10-05 12:48:49.499592", "stderr": "", "stderr_lines": [], "stdout": "mongo", "stdout_lines": ["mongo"]}

TASK [Replace service placeholder in mongo-loadgen] ****************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Getting the Pod name of the Application] *********************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n litmus -l lkey=lvalue -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:00.930120", "end": "2018-10-05 12:48:52.080344", "rc": 0, "start": "2018-10-05 12:48:51.150224", "stderr": "", "stderr_lines": [], "stdout": "mongo-0", "stdout_lines": ["mongo-0"]}

TASK [Replace pod placeholder in mongo-loadgen] ********************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace database-name placeholder in mongo-loadgen] **********************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Create test specific namespace.] *****************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the status  of test specific namespace.] ************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get namespace litmus -o jsonpath='{.status.phase}'", "delta": "0:00:00.816671", "end": "2018-10-05 12:48:54.253380", "rc": 0, "start": "2018-10-05 12:48:53.436709", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Checking whether application is running] *********************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod mongo-0 -n litmus -o jsonpath='{.status.phase}'", "delta": "0:00:00.914809", "end": "2018-10-05 12:48:55.587468", "rc": 0, "start": "2018-10-05 12:48:54.672659", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Create Mongodb Loadgen Job] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f mongo_loadgen.yml -n litmus", "delta": "0:00:01.019539", "end": "2018-10-05 12:48:57.031165", "rc": 0, "start": "2018-10-05 12:48:56.011626", "stderr": "", "stderr_lines": [], "stdout": "job \"mongo-loadgen\" created", "stdout_lines": ["job \"mongo-loadgen\" created"]}

TASK [Verify load-gen pod is running] ******************************************
FAILED - RETRYING: Verify load-gen pod is running (15 retries left).
FAILED - RETRYING: Verify load-gen pod is running (14 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pods -n litmus -l loadgen=mongo-loadgen -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:00.909377", "end": "2018-10-05 12:50:00.752658", "rc": 0, "start": "2018-10-05 12:49:59.843281", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Verifying load-generation] ***********************************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it mongo-0 -n litmus -- mongo --eval 'db.getMongo().getDBNames()'", "delta": "0:00:01.237807", "end": "2018-10-05 12:50:02.409817", "rc": 0, "start": "2018-10-05 12:50:01.172010", "stderr": "Defaulting container name to mongo.\nUse 'kubectl describe pod/mongo-0' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to mongo.", "Use 'kubectl describe pod/mongo-0' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "MongoDB shell version v4.0.3\nconnecting to: mongodb://127.0.0.1:27017\nImplicit session: session { \"id\" : UUID(\"dfb1791b-930e-40cb-a653-c74d6f57e511\") }\nMongoDB server version: 4.0.3\n[ \"admin\", \"config\", \"local\", \"sbtest\" ]", "stdout_lines": ["MongoDB shell version v4.0.3", "connecting to: mongodb://127.0.0.1:27017", "Implicit session: session { \"id\" : UUID(\"dfb1791b-930e-40cb-a653-c74d6f57e511\") }", "MongoDB server version: 4.0.3", "[ \"admin\", \"config\", \"local\", \"sbtest\" ]"]}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "6391aef0e1af42aae8c394854267adb8a93ed7ac", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "9effe1c89dd299b132ff9788caac4c10", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1538743802.75-86833959040921/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.005477", "end": "2018-10-05 12:50:05.828425", "failed_when_result": false, "rc": 0, "start": "2018-10-05 12:50:04.822948", "stderr": "", "stderr_lines": [], "stdout": "litmusresult \"mongodb-loadgen\" configured", "stdout_lines": ["litmusresult \"mongodb-loadgen\" configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=18   changed=15   unreachable=0    failed=0   

```