### PR TITLE
Add a task to ensure application running status of cassandra.

### DIFF
--- a/apps/cassandra/workload/run_litmus_test.yml
+++ b/apps/cassandra/workload/run_litmus_test.yml
@@ -29,5 +29,8 @@ spec:
           - name: LOADGEN_LABEL
             value: 'loadgen=cassandra-loadgen'
 
+          - name: APPLICATION_LABEL
+            value: 'app=cassandra'
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./cassandra/workload/test.yml -i /etc/ansible/hosts -v; exit 0"]        

--- a/apps/cassandra/workload/test.yml
+++ b/apps/cassandra/workload/test.yml
@@ -57,8 +57,8 @@
           shell: kubectl get pod -l {{ application_label }} -n {{ namespace }} 
           register: running_status
           until: "'Running' in running_status.stdout"
-          delay: 10
-          retries: 15     
+          delay: 30
+          retries: 60     
         
         - name: Create Cassandra Loadgen Job
           shell: kubectl apply -f {{ cassandra_loadgen }} -n {{ namespace }} 

--- a/apps/cassandra/workload/test.yml
+++ b/apps/cassandra/workload/test.yml
@@ -51,6 +51,14 @@
             path: "{{ cassandra_loadgen }}"
             regexp: "loadgen_lkey: loadgen_lvalue"
             replace: "{{ loadgen_lkey }}: {{ loadgen_lvalue }}"
+
+
+        - name: Checking whether application is running
+          shell: kubectl get pod -l {{ application_label }} -n {{ namespace }} 
+          register: running_status
+          until: "'Running' in running_status.stdout"
+          delay: 10
+          retries: 15     
         
         - name: Create Cassandra Loadgen Job
           shell: kubectl apply -f {{ cassandra_loadgen }} -n {{ namespace }} 

--- a/apps/cassandra/workload/test_vars.yml
+++ b/apps/cassandra/workload/test_vars.yml
@@ -3,3 +3,4 @@ namespace: "{{ lookup('env','LOADGEN_NS') }}"
 test_name: cassandra-loadgen
 loadgen_label: "{{ lookup('env','LOADGEN_LABEL') }}"
 io_minutes: 3
+application_label: "{{ lookup('env','APPLICATION_LABEL') }}"


### PR DESCRIPTION


**What this PR does / why we need it**:
- Add a task in test.yml to ensure that application is running before running the workloads.