### PR TITLE
fix(yaml): fix an indentation error in postgres deployer playbook

### DIFF
--- a/apps/crunchy-postgres/deployers/test.yml
+++ b/apps/crunchy-postgres/deployers/test.yml
@@ -7,7 +7,7 @@
 
   tasks:
     - block:
-       - block:
+        - block:
 
             - name: Record test instance/run ID
               set_fact:


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Fix an indentation error on the postgres deployer playbook

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
