### PR TITLE
refactor(yaml): increase retries for successful bringup of multi-replica statefulset

### DIFF
--- a/apps/cassandra/deployers/test.yml
+++ b/apps/cassandra/deployers/test.yml
@@ -120,7 +120,7 @@
               register: ready_rep
               until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
               delay: 60
-              retries: 15
+              retries: 30 
 
           when: lookup('env','DEPLOY_TYPE') == 'statefulset'
 

--- a/apps/cockroachdb/deployers/test.yml
+++ b/apps/cockroachdb/deployers/test.yml
@@ -118,7 +118,7 @@
               register: ready_rep
               until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
               delay: 60
-              retries: 15
+              retries: 30
 
           when: lookup('env','DEPLOY_TYPE') == 'statefulset'
 

--- a/apps/crunchy-postgres/deployers/test.yml
+++ b/apps/crunchy-postgres/deployers/test.yml
@@ -116,7 +116,7 @@
               register: ready_rep
               until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
               delay: 60
-              retries: 15
+              retries: 30 
 
           when: lookup('env','DEPLOY_TYPE') == 'statefulset'
 

--- a/apps/mongodb/deployers/test.yml
+++ b/apps/mongodb/deployers/test.yml
@@ -102,7 +102,7 @@
               register: ready_rep
               until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
               delay: 60
-              retries: 15
+              retries: 30
 
           when: lookup('env','DEPLOY_TYPE') == 'statefulset'
       


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Litmus job success for deployment of statefulsets with multiple replicas may take time. Increasing retry count before declaring failure.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
