### PR TITLE
Implemented litmusbook for scaling up application replicas

### DIFF
--- a/apps/cassandra/deployers/run_litmus_test.yml
+++ b/apps/cassandra/deployers/run_litmus_test.yml
@@ -44,7 +44,7 @@ spec:
             value: statefulset
 
           - name: APP_REPLICA
-            value: 'replicas=3'
+            value: 'replicas=2'
             
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./cassandra/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/cassandra/functional/scale_replicas/run_litmus_test.yml
+++ b/apps/cassandra/functional/scale_replicas/run_litmus_test.yml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: gprasath/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
 
         env:

--- a/apps/cassandra/functional/scale_replicas/run_litmus_test.yml
+++ b/apps/cassandra/functional/scale_replicas/run_litmus_test.yml
@@ -1,0 +1,43 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-replica-scale-
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: cassandra-scaleup-litmus
+   
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+            # Application label
+          - name: APP_LABEL
+            value: 'app=cassandra'
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: litmus
+
+            # Deployment type either statefulset or deployment
+          - name: DEPLOY_TYPE
+            value: statefulset
+
+            # The total number of replicas
+          - name: REPLICA_COUNT
+            value: '3'
+            
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./cassandra/functional/scale_replicas/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/cassandra/functional/scale_replicas/run_litmus_test.yml
+++ b/apps/cassandra/functional/scale_replicas/run_litmus_test.yml
@@ -3,23 +3,23 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   generateName: litmus-replica-scale-
-  namespace: litmus 
+  namespace: litmus
 spec:
   template:
     metadata:
       name: litmus
       labels:
         app: cassandra-scaleup-litmus
-   
+
     spec:
       serviceAccountName: litmus
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: openebs/ansible-runner:ci
+        image: gprasath/ansible-runner:ci
         imagePullPolicy: Always
 
-        env: 
+        env:
           - name: ANSIBLE_STDOUT_CALLBACK
             value: default
 
@@ -38,6 +38,6 @@ spec:
             # The total number of replicas
           - name: REPLICA_COUNT
             value: '3'
-            
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./cassandra/functional/scale_replicas/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/cassandra/functional/scale_replicas/test.yml
+++ b/apps/cassandra/functional/scale_replicas/test.yml
@@ -9,62 +9,81 @@
     - block:
         - block:
 
-            - name: Record test instance/run ID
+            - name: Record test instance/run ID.
               set_fact:
                 run_id: "{{ lookup('env','RUN_ID') }}"
 
-            - name: Construct testname appended with runID
+            - name: Construct testname appended with runID.
               set_fact:
                 test_name: "{{ test_name }}-{{ run_id }}"
 
           when: lookup('env','RUN_ID')
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
-        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
-          template: 
+        - name: Generate the litmus result CR to reflect SOT (Start of Test).
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: in-progress
             verdict: none
-        
-        - name: Apply the litmus result CR
+
+        - name: Apply the litmus result CR.
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
-          register: lr_status 
+          register: lr_status
           failed_when: "lr_status.rc != 0"
 
           # Including the scaleup_replicas utility from litmus funclib that handles scaling up the replicas.
-        
+
         - include: /funclib/kubectl/scale_replicas.yml
+
+        - name: Forming one of the replicas name statefulset application name.
+          set_fact:
+            replica_name: "{{ app_name }}-0"
+
+        - name: Obtaining the rack name from nodetool.
+          shell: kubectl exec {{ replica_name }} -n litmus -- nodetool info | grep 'Rack' | awk '{print $3}'
+          args:
+            executable: /bin/bash
+          register: rack_name
+
+        - name: Checking data distribution percentage using nodetool.
+          shell: kubectl exec {{ replica_name }} -n {{ app_ns }} -- nodetool status | grep {{ rack_name.stdout }} | awk '{print $6}'
+          args:
+            executable: /bin/bash
+          register: result
+          until: "result.stdout_lines != 0"
+          delay: 10
+          retries: 30
 
         - set_fact:
             flag: "Pass"
 
       rescue:
         - set_fact:
-            flag: "Fail"  
+            flag: "Fail"
 
       always:
-            ## RECORD END-OF-TEST IN LITMUS RESULT CR 
-        - name: Generate the litmus result CR to reflect EOT (End of Test) 
-          template: 
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect EOT (End of Test)
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: completed
             verdict: "{{ flag }}"
-           
+
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
-          register: lr_status 
+          register: lr_status
           failed_when: "lr_status.rc != 0"

--- a/apps/cassandra/functional/scale_replicas/test.yml
+++ b/apps/cassandra/functional/scale_replicas/test.yml
@@ -1,0 +1,70 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            app: ""
+            chaostype: ""
+            phase: in-progress
+            verdict: none
+        
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"
+
+          # Including the scaleup_replicas utility from litmus funclib that handles scaling up the replicas.
+        
+        - include: /funclib/kubectl/scale_replicas.yml
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"  
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR 
+        - name: Generate the litmus result CR to reflect EOT (End of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            app: ""
+            chaostype: ""
+            phase: completed
+            verdict: "{{ flag }}"
+           
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"

--- a/apps/cassandra/functional/scale_replicas/test_vars.yml
+++ b/apps/cassandra/functional/scale_replicas/test_vars.yml
@@ -1,0 +1,11 @@
+---
+
+test_name: scale-app-replicas
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+app_replica_count: "{{ lookup('env','REPLICA_COUNT') }}"
+
+deploy_type: "{{ lookup('env','DEPLOY_TYPE') }}"


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
   - It can scale up the application replicas by taking the replica count as input.
   - Using application label and namespace to find out the app name.
   - Uses scale_replica.yml from funclib.

Modified the default replica count in cassandra deployer to 2. Therefore, cassandra statefulset is deployed with two replicas and scaling up to 3 replicas using this litmusbook.

Here is the sample test run output:
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]
TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}
TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "eb81ff3aa351f54eae4d5a996b04f339d91af7ce", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "8c03f44c2068ed656eb1156d1ab6e81b", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1538740075.1-187222489583954/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.358278", "end": "2018-10-05 11:47:57.273861", "failed_when_result": false, "rc": 0, "start": "2018-10-05 11:47:55.915583", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/scale-app-replicas configured", "stdout_lines": ["litmusresult.litmus.io/scale-app-replicas configured"]}

TASK [Obtaining the application pod name.] *************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get statefulset -n litmus --no-headers -l app=cassandra -o custom-columns=:metadata.name", "delta": "0:00:00.868080", "end": "2018-10-05 11:47:58.325913", "rc": 0, "start": "2018-10-05 11:47:57.457833", "stderr": "", "stderr_lines": [], "stdout": "cassandra", "stdout_lines": ["cassandra"]}

TASK [Recording the application pod name.] *************************************
ok: [127.0.0.1] => {"ansible_facts": {"app_name": "cassandra"}, "changed": false}

TASK [scaling up the replicas.] ************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl scale statefulset cassandra --replicas=3 -n litmus", "delta": "0:00:00.902853", "end": "2018-10-05 11:47:59.466194", "failed_when_result": false, "rc": 0, "start": "2018-10-05 11:47:58.563341", "stderr": "", "stderr_lines": [], "stdout": "statefulset.apps/cassandra scaled", "stdout_lines": ["statefulset.apps/cassandra scaled"]}

TASK [Check if all the application replicas are running.] **********************
FAILED - RETRYING: Check if all the application replicas are running. (15 retries left).
FAILED - RETRYING: Check if all the application replicas are running. (14 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get statefulset -n litmus --no-headers -l app=cassandra -o custom-columns=:..readyReplicas", "delta": "0:00:01.021316", "end": "2018-10-05 11:50:03.424832", "rc": 0, "start": "2018-10-05 11:50:02.403516", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "90a2e4a4074c38e4d5bb4fe105499a658e239490", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "82752bf2568927931ebf9833eeefc41d", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1538740203.67-257511653739459/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.033458", "end": "2018-10-05 11:50:06.793593", "failed_when_result": false, "rc": 0, "start": "2018-10-05 11:50:05.760135", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/scale-app-replicas configured", "stdout_lines": ["litmusresult.litmus.io/scale-app-replicas configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=10   changed=7    unreachable=0    failed=0
```