### PR TITLE
Improvements to ansible-runner docker image

### DIFF
--- a/tools/ansible-runner/Dockerfile
+++ b/tools/ansible-runner/Dockerfile
@@ -2,25 +2,30 @@ FROM ubuntu
 
 LABEL maintainer="OpenEBS"
 
-RUN rm -rf /var/lib/apt/lists/* && apt-get clean && \
+#Installing necessary ubuntu packages
+RUN rm -rf /var/lib/apt/lists/* && \
+    apt-get clean && \
     apt-get update --fix-missing || true && \
     apt-get install -y python-minimal python-pip \
     curl openssh-client
 
+#Installing ansible
 RUN pip install ansible
 
+#Installing Kubectl
 ENV KUBE_LATEST_VERSION="v1.12.0"
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
-RUN mkdir /etc/ansible/ /ansible
-
-RUN echo "[local]" >> /etc/ansible/hosts && \
+#Adding hosts entries and making ansible folders
+RUN mkdir /etc/ansible/ /ansible && \
+    echo "[local]" >> /etc/ansible/hosts && \
     echo "127.0.0.1" >> /etc/ansible/hosts
 
-ADD providers/openebs/installers/ ./
+#Copying Necessary Files
+COPY providers/openebs/installers/ ./
 
-ADD ./apps/ ./
+COPY ./apps/ ./
 
 COPY ./chaoslib ./chaoslib/
 


### PR DESCRIPTION
Used COPY instead of ADD as recommended in docker best practices, 
clubbed RUN commands to reduce number of layers,
added comments
fixes #204 

Ran both the images and used ```find <dir> -type f``` for a couple of directories and compared files to verify.

Signed-off-by: darshkpatel <darshkpatel@gmail.com>

