### PR TITLE
refactor(yaml): use jsonpath to derive the controller pod name (w/ vsm label) 

### DIFF
--- a/apps/crunchy-postgres/deployers/run_litmus_test.yml
+++ b/apps/crunchy-postgres/deployers/run_litmus_test.yml
@@ -37,7 +37,7 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: postgres
+            value: litmus
 
           - name: DEPLOY_TYPE
             value: statefulset

--- a/apps/mongodb/deployers/run_litmus_test.yml
+++ b/apps/mongodb/deployers/run_litmus_test.yml
@@ -29,7 +29,7 @@ spec:
             value: openebs-mongodb
 
           - name: APP_PVC
-            value: openebs-mongodb
+            value: openebs-mongo
 
             # Application label
           - name: APP_LABEL

--- a/chaoslib/openebs/jiva_controller_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_controller_pod_failure.yaml
@@ -22,8 +22,8 @@
 
 - name: Get jiva controller pod belonging to the PV
   shell: > 
-    kubectl get pods -l openebs.io/controller=jiva-controller
-    -n {{ app_ns }} -o=custom-columns=NAME:".metadata.name" --no-headers
+    kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n {{ app_ns }} 
+    -o jsonpath='{.items[?(@.metadata.labels.vsm=="{{ pv.stdout }}")].metadata.name}'
   args:
     executable: /bin/bash
   register: jiva_controller_pod


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- use jsonpath to derive the controller pod name (w/ vsm label) 
- use consistent default namespace values and pvc naming convention in deployer jobs 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
