### PR TITLE
Check ansible syntax in Travis

### DIFF
--- a/apps/jupyter/deployers/test.yml
+++ b/apps/jupyter/deployers/test.yml
@@ -96,10 +96,10 @@
         - set_fact:
            flag: "Pass"
 
-    - rescue:
+      rescue:
         - set_fact:
-          flag: "Fail"
           
+            flag: "Fail"
       always:
             ## RECORD END-OF-TEST IN LITMUS RESULT CR 
         - name: Generate the litmus result CR to reflect EOT (End of Test) 

--- a/apps/mongodb/workload/test.yml
+++ b/apps/mongodb/workload/test.yml
@@ -100,7 +100,7 @@
           register: output
           until: "'sbtest' in output.stdout"
           delay: 30
-          retry: 15
+          retries: 15
 
         - set_fact:
             flag: "Pass"

--- a/apps/percona/tests/mysql_storage_benchmark/test.yml
+++ b/apps/percona/tests/mysql_storage_benchmark/test.yml
@@ -27,7 +27,7 @@
                kubectl get pod -l name={{ item }} --no-headers 
                -o custom-columns=:status.phase --all-namespaces 
              args: 
-             executable: /bin/bash
+               executable: /bin/bash
              register: result
              until: "result.stdout == 'Running'"
              delay: 10
@@ -79,7 +79,8 @@
          shell: >
            kubectl create configmap tpcc-config --from-file=tpcc.conf 
            -n litmus 
-         executable: /bin/bash
+         args:
+           executable: /bin/bash
 
        - name: Deploy percona mysql pod
          shell: kubectl apply -f {{ pod_yaml_alias }} -n litmus  

--- a/apps/percona/workload/test.yml
+++ b/apps/percona/workload/test.yml
@@ -117,7 +117,7 @@
           register: output
           until: "'tpcc-' in output.stdout"
           delay: 30
-          retry: 15
+          retries: 15
 
         - set_fact:
             flag: "Pass"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR would enable ansible playbook syntax checks on Travis

**Which issue this PR fixes**: 
fixes #207

**Special notes for your reviewer**:
~~Not entirely sure if there is a way to generate a list of playbooks to check~~
* [x] `find ./apps -iname 'test.yml'` to get a list of playbooks (without included files) 
