### PR TITLE
Add RUN_ID/Instance metadata to mongodb workload litmus book

### DIFF
--- a/apps/mongodb/workload/test.yml
+++ b/apps/mongodb/workload/test.yml
@@ -7,6 +7,18 @@
 
   tasks:
     - block:
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
         - name: Generate the litmus result CR to reflect SOT (Start of Test) 
           template: 


### PR DESCRIPTION
Signed-off-by: manjunathd <manjunath.imagin@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Added litmus block to include RUN_ID/Instance metadata to mongodb workload litmus book

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
