### PR TITLE
Use K8s generateName API for litmusbooks

### DIFF
--- a/apps/cassandra/liveness/run_litmus_test.yml
+++ b/apps/cassandra/liveness/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cassandra-liveness
+  generateName: cassandra-liveness-
   namespace: litmus
  
 spec:

--- a/apps/cassandra/workload/run_litmus_test.yml
+++ b/apps/cassandra/workload/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: litmus-cassandra-loadgen
+  generateName: litmus-cassandra-loadgen-
   namespace: litmus 
 spec:
   template:

--- a/apps/cockroachdb/workload/run_litmus_test.yml
+++ b/apps/cockroachdb/workload/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cockroachdb-loadgen
+  generateName: cockroachdb-loadgen-
   namespace: litmus
 spec:
   template:

--- a/apps/crunchy-postgres/liveness/run_litmus_test.yml
+++ b/apps/crunchy-postgres/liveness/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: liveness-pg
+  generateName: liveness-pg-
   namespace: litmus
 
 spec:

--- a/apps/crunchy-postgres/workloads/run_litmus_test.yml
+++ b/apps/crunchy-postgres/workloads/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: crunchy-loadgen
+  generateName: crunchy-loadgen-
   namespace: litmus
 spec:
   template:

--- a/apps/jenkins/job-simulator/run_litmus_test.yml
+++ b/apps/jenkins/job-simulator/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jenkins-job-simulator
+  generateName: jenkins-job-simulator-
  
 spec:
   template:

--- a/apps/minio/tests/deploy_minio/run_litmus_test.yml
+++ b/apps/minio/tests/deploy_minio/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: odm-operator-verify
+  generateName: odm-operator-verify-
   namespace: litmus
   labels:
     name: odm-operator-verify

--- a/apps/mongodb/liveness/run_litmus_test.yml
+++ b/apps/mongodb/liveness/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: liveness-mongo
+  generateName: liveness-mongo-
  
 spec:
   template:

--- a/apps/mongodb/workload/run_litmus_test.yml
+++ b/apps/mongodb/workload/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: mongodb-loadgen 
+  generateName: mongodb-loadgen -
   namespace: litmus
 spec:
   template:

--- a/apps/mongodb/workload/run_litmus_test.yml
+++ b/apps/mongodb/workload/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: mongodb-loadgen -
+  generateName: mongodb-loadgen-
   namespace: litmus
 spec:
   template:

--- a/apps/percona/liveness/run_litmus_test.yml
+++ b/apps/percona/liveness/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: mysql-liveness-check
+  generateName: mysql-liveness-check-
   labels:
     name: mysql-liveness-check
 spec:

--- a/apps/percona/workload/run_litmus_test.yml
+++ b/apps/percona/workload/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: percona-loadgen -
+  generateName: percona-loadgen-
   namespace: litmus
 spec:
   template:

--- a/apps/percona/workload/run_litmus_test.yml
+++ b/apps/percona/workload/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: percona-loadgen 
+  generateName: percona-loadgen -
   namespace: litmus
 spec:
   template:


### PR DESCRIPTION
Signed-off-by: Roshan <roshanjossey@gmail.com>

**What this PR does / why we need it**:

Previously, some of them were using only name. This prevents from
running the job again.
With generateName, a hash is attached to the end of name to make it
unique

**Which issue this PR fixes** : fixes #259
