### PR TITLE
refactor(yaml): remove additional spaces for jinja template used in kubectl cmd w/ jsonpath

### DIFF
--- a/chaoslib/openebs/jiva_controller_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_controller_pod_failure.yaml
@@ -23,7 +23,8 @@
 - name: Get jiva controller pod belonging to the PV
   shell: > 
     kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n {{ app_ns }} 
-    -o jsonpath='{.items[?(@.metadata.labels.vsm=="{{ pv.stdout }}")].metadata.name}'
+    #-o jsonpath='{.items[?(@.metadata.labels.vsm=="{{ pv.stdout }}")].metadata.name}' #ERR
+    -o jsonpath='{.items[?(@.metadata.labels.vsm=="{{pv.stdout}}")].metadata.name}'
   args:
     executable: /bin/bash
   register: jiva_controller_pod


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- The presence of spaces around jinja template in a shell (kubectl) command that used -o jsonpath args
was causing the register variable to be unassigned. This PR removes it. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
