### PR TITLE
refactor(yaml): update jenkins deployment PVC spec to change storagelass def mechanism

### DIFF
--- a/apps/jenkins/deployers/jenkins.yml
+++ b/apps/jenkins/deployers/jenkins.yml
@@ -2,9 +2,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: testclaim
-  annotations:
-    volume.beta.kubernetes.io/storage-class: testclass
 spec:
+  storageClassName: testclass
   accessModes:
     - ReadWriteOnce
   resources:

--- a/chaoslib/openebs/jiva_controller_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_controller_pod_failure.yaml
@@ -22,9 +22,8 @@
 
 - name: Get jiva controller pod belonging to the PV
   shell: > 
-    kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n {{ app_ns }} 
-    #-o jsonpath='{.items[?(@.metadata.labels.vsm=="{{ pv.stdout }}")].metadata.name}' #ERR
-    -o jsonpath='{.items[?(@.metadata.labels.vsm=="{{pv.stdout}}")].metadata.name}'
+    kubectl get pods --no-headers -l openebs.io/controller=jiva-controller -n {{ app_ns }}
+    -o jsonpath="{.items[?(@.metadata.labels.openebs\\.io/persistent-volume==\"{{pv.stdout}}\")].metadata.name}" 
   args:
     executable: /bin/bash
   register: jiva_controller_pod


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Uses `storageClassName` attribute in PVC spec in jenkins 
- Updates the jiva controller failure chaoslib to use latest PV label check

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
