### PR TITLE
refactor(yaml): reduce characters in namespace to help keep openebs k8s resource names under 63 char

### DIFF
--- a/apps/cassandra/deployers/run_litmus_test.yml
+++ b/apps/cassandra/deployers/run_litmus_test.yml
@@ -38,7 +38,7 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: app-cassandra-ns 
+            value: app-cass-ns 
 
           - name: DEPLOY_TYPE
             value: statefulset


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Reduce characters in namespace to help keep openebs pv/svc names under 63 char

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
