### PR TITLE
Changed the namespace for cassandra and postgres loadgen jobs

### DIFF
--- a/apps/cassandra/functional/scale_replicas/run_litmus_test.yml
+++ b/apps/cassandra/functional/scale_replicas/run_litmus_test.yml
@@ -29,7 +29,7 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: litmus
+            value: app-cass-ns
 
             # Deployment type either statefulset or deployment
           - name: DEPLOY_TYPE

--- a/apps/cassandra/workload/run_litmus_test.yml
+++ b/apps/cassandra/workload/run_litmus_test.yml
@@ -24,7 +24,7 @@ spec:
             value: default
 
           - name: LOADGEN_NS
-            value: app-cassandra-ns
+            value: app-cass-ns
 
           - name: LOADGEN_LABEL
             value: 'loadgen=cassandra-loadgen'

--- a/apps/cockroachdb/deployers/run_litmus_test.yml
+++ b/apps/cockroachdb/deployers/run_litmus_test.yml
@@ -37,7 +37,7 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: app-cockroachdb-ns
+            value: app-cdb-ns
 
           - name: DEPLOY_TYPE
             value: statefulset

--- a/apps/cockroachdb/workload/run_litmus_test.yml
+++ b/apps/cockroachdb/workload/run_litmus_test.yml
@@ -22,7 +22,7 @@ spec:
             value: default
 
           - name: APP_NS
-            value: app-cockroachdb-ns
+            value: app-cdb-ns
 
           - name: APP_LABEL
             value: 'app=cockroachdb'

--- a/apps/crunchy-postgres/workload/run_litmus_test.yml
+++ b/apps/crunchy-postgres/workload/run_litmus_test.yml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: crunchy-loadgen-litmus
+  generateName: crunchy-loadgen-litmus-
   namespace: litmus
 spec:
   template:
@@ -32,7 +32,7 @@ spec:
              
             #namespace in which loadgen will run 
           - name: APP_NAMESPACE
-            value: 'litmus'
+            value: app-postgres-ns
     
             # Database Name 
           - name: DATABASE_NAME


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Using same namespace where application is deployed for cassandra and postgres loadgen jobs.

