### PR TITLE
refactor(yaml): Include block to drain/taint based chaoslib

### DIFF
--- a/chaoslib/kubectl/cordon_drain_node.yaml
+++ b/chaoslib/kubectl/cordon_drain_node.yaml
@@ -1,49 +1,56 @@
-- name: Identify the application node
-  shell: >
-    kubectl get pod {{ app }} -n {{ app_ns }} 
-    --no-headers -o custom-columns=:spec.nodeName
-  args: 
-    executable: /bin/bash
-  register: result 
-           
-- name: Record the application node name 
-  set_fact:
-    app_node: "{{ result.stdout }}"
+- block:
 
-- name: Cordon the application node
-  shell: >
-    kubectl cordon {{ app_node }}
-  args:
-    executable: /bin/bash
-  register: result
-  until: "'cordoned' in result.stdout"
-  delay: 20
-  retries: 12
+    - name: Identify the application node
+      shell: >
+        kubectl get pod {{ app }} -n {{ app_ns }} 
+        --no-headers -o custom-columns=:spec.nodeName
+      args: 
+        executable: /bin/bash
+      register: result 
+               
+    - name: Record the application node name 
+      set_fact:
+        app_node: "{{ result.stdout }}"
+    
+    - name: Cordon the application node
+      shell: >
+        kubectl cordon {{ app_node }}
+      args:
+        executable: /bin/bash
+      register: result
+      until: "'cordoned' in result.stdout"
+      delay: 20
+      retries: 12
+    
+    - name: Drain the application node
+      shell: >
+        kubectl drain {{ app_node }}
+        --ignore-daemonsets --force
+      args:
+        executable: /bin/bash
+      register: result
+      until: "'drained' in result.stdout"
+      delay: 20
+      retries: 12
+    
+    - name: Wait for application pod reschedule (evict)
+      # Do not untaint until evict occurs
+      wait_for:
+        timeout: 30
+    
+  when: action == "drain"
 
-- name: Drain the application node
-  shell: >
-    kubectl drain {{ app_node }}
-    --ignore-daemonsets --force
-  args:
-    executable: /bin/bash
-  register: result
-  until: "'drained' in result.stdout"
-  delay: 20
-  retries: 12
+- block:
 
-- name: Wait for application pod reschedule (evict)
-  # Do not untaint until evict occurs
-  wait_for:
-    timeout: 30
+    - name: Uncordon the application node
+      shell: >
+        kubectl uncordon {{ app_node }}
+      args:
+        executable: /bin/bash
+      register: result
+      until: "'uncordoned' in result.stdout"
+      delay: 20
+      retries: 12
+      
+  when: action == "uncordon"
 
-- name: Uncordon the application node
-  shell: >
-    kubectl uncordon {{ app_node }}
-  args:
-    executable: /bin/bash
-  register: result
-  until: "'uncordoned' in result.stdout"
-  delay: 20
-  retries: 12
-  
-  

--- a/chaoslib/kubectl/pod_evict_by_taint.yaml
+++ b/chaoslib/kubectl/pod_evict_by_taint.yaml
@@ -1,38 +1,45 @@
-- name: Identify the application node
-  shell: >
-    kubectl get pod {{ app }} -n {{ app_ns }} 
-    --no-headers -o custom-columns=:spec.nodeName
-  args: 
-    executable: /bin/bash
-  register: result 
-           
-- name: Record the application node name 
-  set_fact:
-    app_node: "{{ result.stdout }}"
+- block:
+        
+    - name: Identify the application node
+      shell: >
+        kubectl get pod {{ app }} -n {{ app_ns }} 
+        --no-headers -o custom-columns=:spec.nodeName
+      args: 
+        executable: /bin/bash
+      register: result 
+               
+    - name: Record the application node name 
+      set_fact:
+        app_node: "{{ result.stdout }}"
+    
+    - name: Force eviction of pods by tainting the app node
+      shell: >
+        kubectl taint node {{ app_node }}
+        {{ taint }}=:NoExecute
+      args:
+        executable: /bin/bash
+      register: result
+      until: "'tainted' in result.stdout"
+      delay: 20
+      retries: 12
+    
+    - name: Wait for application pod reschedule (evict)
+      # Do not untaint until evict occurs
+      wait_for:
+        timeout: 30
+    
+  when: action == "taint"
 
-- name: Force eviction of pods by tainting the app node
-  shell: >
-    kubectl taint node {{ app_node }}
-    {{ taint }}=:NoExecute
-  args:
-    executable: /bin/bash
-  register: result
-  until: "'tainted' in result.stdout"
-  delay: 20
-  retries: 12
+- block:
 
-- name: Wait for application pod reschedule (evict)
-  # Do not untaint until evict occurs
-  wait_for:
-    timeout: 30
-
-- name: Untaint the application node
-  shell: >
-    kubectl taint node {{ app_node }}
-    {{ taint }}:NoExecute-
-  args:
-    executable: /bin/bash
-  register: result
-  failed_when: "'untainted' not in result.stdout"
-  
-  
+    - name: Untaint the application node
+      shell: >
+        kubectl taint node {{ app_node }}
+        {{ taint }}:NoExecute-
+      args:
+        executable: /bin/bash
+      register: result
+      failed_when: "'untainted' not in result.stdout"
+      
+  when: action == "untaint"
+      


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR enhances the current chaoslib utils for drain and taint nodes.
- Included a block to trigger the drain/uncordon operations based on the action(var) passed.
- Included a block to trigger the taint/untaint operations based on the action(var) passed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
