### PR TITLE
Checking the application's existence before starting load generation

### DIFF
--- a/apps/cassandra/deployers/run_litmus_test.yml
+++ b/apps/cassandra/deployers/run_litmus_test.yml
@@ -25,8 +25,8 @@ spec:
             value: default
 
           - name: PROVIDER_STORAGE_CLASS
-            # Supported values: openebs-standard, local-storage
-            value: openebs-standard
+            # Supported values: openebs-standard,openebs-standalone,local-storage
+            value: openebs-standalone
 
             # Application pvc
           - name: APP_PVC

--- a/apps/cassandra/functional/scale_replicas/test.yml
+++ b/apps/cassandra/functional/scale_replicas/test.yml
@@ -47,7 +47,7 @@
             replica_name: "{{ app_name }}-0"
 
         - name: Obtaining the rack name from nodetool.
-          shell: kubectl exec {{ replica_name }} -n litmus -- nodetool info | grep 'Rack' | awk '{print $3}'
+          shell: kubectl exec {{ replica_name }} -n {{ app_ns }} -- nodetool info | grep 'Rack' | awk '{print $3}'
           args:
             executable: /bin/bash
           register: rack_name

--- a/apps/cassandra/workload/test.yml
+++ b/apps/cassandra/workload/test.yml
@@ -18,29 +18,23 @@
           when: lookup('env','RUN_ID')
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
-        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
-          template: 
+        - name: Generate the litmus result CR to reflect SOT (Start of Test)
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: in-progress
             verdict: none
-        
+
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
-          register: lr_status 
+          register: lr_status
           failed_when: "lr_status.rc != 0"
-
-        - name: Create test specific namespace.
-          shell: kubectl create ns {{ namespace }}
-          args:
-           executable: /bin/bash
-          when: namespace != 'litmus'
 
         - name: Checking the status  of test specific namespace.
           shell: kubectl get ns {{ namespace }} -o jsonpath='{.status.phase}'
@@ -50,6 +44,26 @@
           until: "'Active' in npstatus.stdout"
           delay: 30
           retries: 10
+
+        # Checking if the application is deployed.
+        #
+        - name: Obtain the number of replicas.
+          shell: kubectl get statefulset -n {{ namespace }} -l {{ application_label }} -o custom-columns=:spec.replicas
+          args:
+            executable: /bin/bash
+          register: rep_count
+          until: "rep_count.rc == 0"
+          delay: 60
+          retries: 30
+
+        - name: Obtain the ready replica count and compare with the replica count.
+          shell: kubectl get statefulset -n {{ namespace }} -l {{ application_label }} -o custom-columns=:..readyReplicas
+          args:
+            executable: /bin/bash
+          register: ready_rep
+          until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
+          delay: 60
+          retries: 30
 
         - name: Obtaining the loadgen pod label from env.
           set_fact:
@@ -62,16 +76,8 @@
             regexp: "loadgen_lkey: loadgen_lvalue"
             replace: "{{ loadgen_lkey }}: {{ loadgen_lvalue }}"
 
-
-        - name: Checking whether application is running
-          shell: kubectl get pod -l {{ application_label }} -n {{ namespace }} 
-          register: running_status
-          until: "'Running' in running_status.stdout"
-          delay: 30
-          retries: 60     
-        
         - name: Create Cassandra Loadgen Job
-          shell: kubectl apply -f {{ cassandra_loadgen }} -n {{ namespace }} 
+          shell: kubectl apply -f {{ cassandra_loadgen }} -n {{ namespace }}
 
         - name: Verify load is running for specified duration
           shell: kubectl get pods -n {{ namespace }} -l {{ loadgen_label }}
@@ -88,7 +94,7 @@
 
         - name: Verify load by using describe keyspaces
           shell: >
-            kubectl exec cassandra-0 -n {{ namespace }} 
+            kubectl exec cassandra-0 -n {{ namespace }}
             -- cqlsh --execute "describe keyspaces;"
           args:
             executable: /bin/bash
@@ -102,24 +108,24 @@
 
       rescue:
         - set_fact:
-            flag: "Fail"  
+            flag: "Fail"
 
       always:
-            ## RECORD END-OF-TEST IN LITMUS RESULT CR 
-        - name: Generate the litmus result CR to reflect EOT (End of Test) 
-          template: 
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect EOT (End of Test)
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: completed
             verdict: "{{ flag }}"
-           
+
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
-          register: lr_status 
+          register: lr_status
           failed_when: "lr_status.rc != 0"

--- a/apps/cassandra/workload/test.yml
+++ b/apps/cassandra/workload/test.yml
@@ -45,9 +45,9 @@
           delay: 30
           retries: 10
 
-        # Checking if the application is deployed.
-        #
-        - name: Obtain the number of replicas.
+        # Checking if the application is deployed before starting load generation.
+
+        - name: Obtaining the number of replicas.
           shell: kubectl get statefulset -n {{ namespace }} -l {{ application_label }} -o custom-columns=:spec.replicas
           args:
             executable: /bin/bash
@@ -92,9 +92,23 @@
           wait_for:
             timeout: "{{ (io_minutes) | int *60 }}"
 
+        - name: Obtaining the application pod name.
+          shell: kubectl get statefulset -n {{ namespace }} --no-headers -l {{ application_label }} -o custom-columns=:metadata.name
+          args:
+            executable: /bin/bash
+          register: result
+
+        - name: Recording the application pod name.
+          set_fact:
+            app_name: "{{ result.stdout }}"
+
+        - name: Forming one of the replicas name statefulset application name.
+          set_fact:
+            replica_name: "{{ app_name }}-0"
+
         - name: Verify load by using describe keyspaces
           shell: >
-            kubectl exec cassandra-0 -n {{ namespace }}
+            kubectl exec {{ replica_name }} -n {{ namespace }}
             -- cqlsh --execute "describe keyspaces;"
           args:
             executable: /bin/bash

--- a/apps/cockroachdb/deployers/run_litmus_test.yml
+++ b/apps/cockroachdb/deployers/run_litmus_test.yml
@@ -25,8 +25,8 @@ spec:
             value: default
 
           - name: PROVIDER_STORAGE_CLASS
-            # Supported values: openebs-standard, local-storage
-            value: openebs-standard
+            # Supported values: openebs-standard,openebs-standalone,local-storage
+            value: openebs-standalone
 
           - name: APP_PVC
             value: cockroachdb-claim

--- a/apps/cockroachdb/deployers/test.yml
+++ b/apps/cockroachdb/deployers/test.yml
@@ -21,22 +21,22 @@
           when: lookup('env','RUN_ID')
 
          ## RECORD START-OF-TEST IN LITMUS RESULT CR
-        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
-          template: 
+        - name: Generate the litmus result CR to reflect SOT (Start of Test)
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: in-progress
             verdict: none
-        
+
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
-          register: lr_status 
+          register: lr_status
           failed_when: "lr_status.rc != 0"
 
          ##Actual test
@@ -82,19 +82,19 @@
           when: app_ns != 'litmus'
 
         - name: Checking the status of test specific namespace.
-          shell: kubectl get ns {{ app_ns }} -o custom-columns=:status.phase --no-headers 
+          shell: kubectl get ns {{ app_ns }} -o custom-columns=:status.phase --no-headers
           args:
            executable: /bin/bash
           register: npstatus
           until: "'Active' in npstatus.stdout"
           delay: 30
           retries: 10
-        
+
         - name: Deploying cockroachdb statefulset.
           shell: kubectl apply -f {{ cockroachdb_deployment }} -n {{ app_ns }}
           args:
             executable: /bin/bash
-         
+
         - name: Deploying cockroachdb service
           shell: kubectl apply -f {{ cockroachdb_svc }} -n {{ app_ns }}
           args:
@@ -135,23 +135,23 @@
       rescue:
         - set_fact:
             flag: "Fail"
-          
+
       always:
-            ## RECORD END-OF-TEST IN LITMUS RESULT CR 
-        - name: Generate the litmus result CR to reflect EOT (End of Test) 
-          template: 
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect EOT (End of Test)
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: completed
             verdict: "{{ flag }}"
-           
+
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
-          register: lr_status 
+          register: lr_status
           failed_when: "lr_status.rc != 0"

--- a/apps/cockroachdb/workload/test.yml
+++ b/apps/cockroachdb/workload/test.yml
@@ -8,7 +8,7 @@
 - hosts: localhost
   connection: local
 
-  vars_files: 
+  vars_files:
     - test_vars.yml
 
   tasks:
@@ -29,10 +29,39 @@
 
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
-          args: 
+          args:
             executable: /bin/bash
           register: lr_status
           failed_when: "lr_status.rc != 0"
+
+        - name: Checking the status  of test specific namespace.
+          shell: kubectl get ns {{ namespace }} -o jsonpath='{.status.phase}'
+          args:
+           executable: /bin/bash
+          register: npstatus
+          until: "'Active' in npstatus.stdout"
+          delay: 30
+          retries: 10
+     
+        # Check if the application is deployed.
+
+        - name: Obtain the number of statefulset replicas.
+          shell: kubectl get statefulset -n {{ namespace }} -l {{ app_label }} -o custom-columns=:spec.replicas
+          args:
+            executable: /bin/bash
+          register: rep_count
+          until: "rep_count.rc == 0"
+          delay: 60
+          retries: 15
+
+        - name: Obtain the ready replica count and compare with the replica count.
+          shell: kubectl get statefulset -n {{ namespace }} -l {{ app_label }} -o custom-columns=:..readyReplicas
+          args:
+            executable: /bin/bash
+          register: ready_rep
+          until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
+          delay: 60
+          retries: 30
 
         - name: Obtaining the application label from env.
           set_fact:
@@ -75,7 +104,7 @@
             path: "{{ cockroachdb_loadgen }}"
             regexp: 'time_duration'
             replace: "{{ lookup('env','TIME_INTERVAL') }}"
-        
+
         - name: Creating cockroachdb loadgen job.
           shell: kubectl apply -f {{ cockroachdb_loadgen }} -n {{ namespace }}
           args:
@@ -92,15 +121,15 @@
 
         - name: Verify the data written
           shell: >
-            kubectl exec -it {{ pod_name.stdout }} -n {{ namespace }} -- /cockroach/cockroach sql --insecure 
-            --host=cockroachdb-public.cockroachdb -d test -e 'show tables;' 
+            kubectl exec -it {{ pod_name.stdout }} -n {{ namespace }} -- /cockroach/cockroach sql --insecure
+            --host=cockroachdb-public.cockroachdb -d test -e 'show tables;'
           args:
             executable: /bin/bash
           register: tables
           until: "'kv' in tables.stdout"
           delay: 60
           retries: 5
-        
+
         - set_fact:
             flag: "Pass"
 
@@ -126,5 +155,5 @@
           args:
             executable: /bin/bash
           register: lr_status
-          failed_when: "lr_status.rc != 0" 
+          failed_when: "lr_status.rc != 0"
 

--- a/apps/crunchy-postgres/deployers/run_litmus_test.yml
+++ b/apps/crunchy-postgres/deployers/run_litmus_test.yml
@@ -25,8 +25,8 @@ spec:
             value: default
 
           - name: PROVIDER_STORAGE_CLASS
-            # Supported values: openebs-standard, local-storage
-            value: openebs-standard
+            # Supported values: openebs-standard,openebs-standalone,local-storage
+            value: openebs-standalone
 
           - name: APP_PVC
             value: pgdata-claim
@@ -37,7 +37,7 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: app-postgres-ns
+            value: app-pgres-ns
 
           - name: DEPLOY_TYPE
             value: statefulset

--- a/apps/crunchy-postgres/deployers/test.yml
+++ b/apps/crunchy-postgres/deployers/test.yml
@@ -20,22 +20,22 @@
           when: lookup('env','RUN_ID')
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
-        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
-          template: 
+        - name: Generate the litmus result CR to reflect SOT (Start of Test)
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: in-progress
             verdict: none
-        
+
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
-          register: lr_status 
+          register: lr_status
           failed_when: "lr_status.rc != 0"
 
      ## Actual Test to deploy Crunchy Postgress  on k8s
@@ -75,7 +75,7 @@
           when: app_ns != 'litmus'
 
         - name: Checking the status  of test specific namespace.
-          shell: kubectl get ns {{ app_ns }} -o custom-columns=:status.phase --no-headers 
+          shell: kubectl get ns {{ app_ns }} -o custom-columns=:status.phase --no-headers
           args:
            executable: /bin/bash
           register: npstatus
@@ -116,7 +116,7 @@
               register: ready_rep
               until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
               delay: 60
-              retries: 30 
+              retries: 30
 
           when: lookup('env','DEPLOY_TYPE') == 'statefulset'
 
@@ -133,23 +133,23 @@
       rescue:
         - set_fact:
             flag: "Fail"
-          
+
       always:
-            ## RECORD END-OF-TEST IN LITMUS RESULT CR 
-        - name: Generate the litmus result CR to reflect EOT (End of Test) 
-          template: 
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect EOT (End of Test)
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: completed
             verdict: "{{ flag }}"
-           
+
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
-          register: lr_status 
+          register: lr_status
           failed_when: "lr_status.rc != 0"

--- a/apps/crunchy-postgres/workload/run_litmus_test.yml
+++ b/apps/crunchy-postgres/workload/run_litmus_test.yml
@@ -32,7 +32,7 @@ spec:
              
             #namespace in which loadgen will run 
           - name: APP_NAMESPACE
-            value: app-postgres-ns
+            value: app-pgres-ns
     
             # Database Name 
           - name: DATABASE_NAME

--- a/apps/crunchy-postgres/workload/test.yml
+++ b/apps/crunchy-postgres/workload/test.yml
@@ -26,6 +26,35 @@
           register: lr_status 
           failed_when: "lr_status.rc != 0"
 
+        - name: Checking the status  of test specific namespace.
+          shell: kubectl get ns {{ namespace }} -o jsonpath='{.status.phase}'
+          args:
+           executable: /bin/bash
+          register: status
+          until: "'Active' in status.stdout"
+          delay: 30
+          retries: 10
+
+        # Checking if the application is deployed before starting load generation
+
+        - name: Obtain the number of statefulset replicas.
+          shell: kubectl get statefulset -n {{ namespace }} -l {{ app_label }} -o custom-columns=:spec.replicas
+          args:
+            executable: /bin/bash
+          register: rep_count
+          until: "rep_count.rc == 0"
+          delay: 60
+          retries: 15
+
+        - name: Obtain the ready replica count and compare with the replica count.
+          shell: kubectl get statefulset -n {{ namespace }} -l {{ app_label }} -o custom-columns=:..readyReplicas
+          args:
+            executable: /bin/bash
+          register: ready_rep
+          until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
+          delay: 60
+          retries: 30
+
         - name: Obtaining the loadgen pod label from env.
           set_fact:
             loadgen_lkey: "{{ loadgen_label.split('=')[0] }}"
@@ -35,7 +64,7 @@
           shell: kubectl get service -n {{ namespace }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
           register: service_name    
 
-        - name: Obtaining the POD name of Application
+        - name: Obtaining the application pod name
           shell: kubectl get pod -n {{ namespace }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
           register: pod_name  
 
@@ -92,15 +121,6 @@
             path: "{{ crunchy_loadgen }}"
             regexp: "paralleltransaction"
             replace: "{{ lookup('env','PARALLEL_TRANSACTION') }}"           
-
-        - name: Checking the status  of test specific namespace.
-          shell: kubectl get ns {{ namespace }} -o jsonpath='{.status.phase}'
-          args:
-           executable: /bin/bash
-          register: npstatus
-          until: "'Active' in npstatus.stdout"
-          delay: 30
-          retries: 10
         
         - name: Create Crunchy-postgres Loadgen Job
           shell: kubectl apply -f {{ crunchy_loadgen }} -n {{ namespace }} 

--- a/apps/crunchy-postgres/workload/test_vars.yml
+++ b/apps/crunchy-postgres/workload/test_vars.yml
@@ -1,5 +1,10 @@
+---
 crunchy_loadgen: crunchy_postgres_loadgen.yml
+
 namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
 test_name: crunchy-loadgen
+
 loadgen_label: "{{ lookup('env','LOADGEN_LABEL') }}"
-app_label: "{{ lookup('env','SERVICE_LABEL') }}" 
+
+app_label: "{{ lookup('env','APP_LABEL') }}" 

--- a/apps/mongodb/deployers/test.yml
+++ b/apps/mongodb/deployers/test.yml
@@ -20,22 +20,22 @@
           when: lookup('env','RUN_ID')
 
          ## RECORD START-OF-TEST IN LITMUS RESULT CR
-        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
-          template: 
+        - name: Generate the litmus result CR to reflect SOT (Start of Test)
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: in-progress
             verdict: none
-        
+
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
-          register: lr_status 
+          register: lr_status
           failed_when: "lr_status.rc != 0"
         - name: Check whether the provider storageclass is applied
           shell: kubectl get sc {{ lookup('env','PROVIDER_STORAGE_CLASS') }}
@@ -64,7 +64,7 @@
           replace:
             path: "{{ mongodb_deployment }}"
             regexp: "lkey: lvalue"
-            replace: "{{ app_lkey }}: {{ app_lvalue }}"            
+            replace: "{{ app_lkey }}: {{ app_lvalue }}"
 
         - name: Create test specific namespace.
           shell: kubectl create ns {{ app_ns }}
@@ -80,9 +80,9 @@
           until: "'Active' in npstatus.stdout"
           delay: 30
           retries: 10
-        
+
         - name: Deploying Mongodb
-          shell: kubectl apply -f {{ mongodb_deployment }} -n {{ app_ns }} 
+          shell: kubectl apply -f {{ mongodb_deployment }} -n {{ app_ns }}
 
         - block:
 
@@ -105,7 +105,7 @@
               retries: 30
 
           when: lookup('env','DEPLOY_TYPE') == 'statefulset'
-      
+
         - set_fact:
             flag: "Pass"
 
@@ -114,21 +114,21 @@
             flag: "Fail"
 
       always:
-            ## RECORD END-OF-TEST IN LITMUS RESULT CR 
-        - name: Generate the litmus result CR to reflect EOT (End of Test) 
-          template: 
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect EOT (End of Test)
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: completed
             verdict: "{{ flag }}"
-           
+
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
           register: lr_status
-          failed_when: "lr_status.rc != 0"   
+          failed_when: "lr_status.rc != 0"

--- a/apps/mongodb/workload/run_litmus_test.yml
+++ b/apps/mongodb/workload/run_litmus_test.yml
@@ -35,5 +35,13 @@ spec:
           - name: DATABASE_NAME
             value: sbtest
 
+            # Application label
+          - name: APP_LABEL
+            value: 'app=mongo'
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: app-mongo-ns
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./mongodb/workload/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/mongodb/workload/test.yml
+++ b/apps/mongodb/workload/test.yml
@@ -30,7 +30,6 @@
             chaostype: ""
             phase: in-progress
             verdict: none
-            
         
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
@@ -38,6 +37,35 @@
             executable: /bin/bash
           register: lr_status 
           failed_when: "lr_status.rc != 0"
+
+        - name: Checking the status  of test specific namespace.
+          shell: kubectl get ns {{ namespace }} -o jsonpath='{.status.phase}'
+          args:
+           executable: /bin/bash
+          register: npstatus
+          until: "'Active' in npstatus.stdout"
+          delay: 30
+          retries: 10
+        
+        # Checking if the application is deployed.
+        
+        - name: Obtaining the number of statefulset replicas.
+          shell: kubectl get statefulset -n {{ namespace }} -l {{ app_label }} -o custom-columns=:spec.replicas
+          args:
+            executable: /bin/bash
+          register: rep_count
+          until: "rep_count.rc == 0"
+          delay: 60
+          retries: 15
+
+        - name: Obtain the ready replica count and compare with the replica count.
+          shell: kubectl get statefulset -n {{ namespace }} -l {{ app_label }} -o custom-columns=:..readyReplicas
+          args:
+            executable: /bin/bash
+          register: ready_rep
+          until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
+          delay: 60
+          retries: 30
         
         - name: Obtaining the loadgen pod label from env.
           set_fact:
@@ -67,21 +95,6 @@
             path: "{{ mongodb_loadgen }}"
             regexp: "database_name"
             replace: "{{ lookup('env','DATABASE_NAME') }}"       
-
-        - name: Create test specific namespace.
-          shell: kubectl create namespace {{ namespace }}
-          args:
-           executable: /bin/bash
-          when: namespace != 'litmus'
-
-        - name: Checking the status  of test specific namespace.
-          shell: kubectl get namespace {{ namespace }} -o jsonpath='{.status.phase}'
-          args:
-           executable: /bin/bash
-          register: npstatus
-          until: "'Active' in npstatus.stdout"
-          delay: 30
-          retries: 10
         
         - name: Create Mongodb Loadgen Job
           shell: kubectl apply -f {{ mongodb_loadgen }} -n {{ namespace }} 

--- a/apps/mongodb/workload/test_vars.yml
+++ b/apps/mongodb/workload/test_vars.yml
@@ -1,4 +1,9 @@
 mongodb_loadgen: mongo_loadgen.yml
-namespace: litmus
+
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
 test_name: mongodb-loadgen
+
 loadgen_label: "{{ lookup('env','LOADGEN_LABEL') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"

--- a/apps/percona/deployers/test.yml
+++ b/apps/percona/deployers/test.yml
@@ -8,7 +8,7 @@
   tasks:
     - block:
         - block:
- 
+
             - name: Record test instance/run ID
               set_fact:
                 run_id: "{{ lookup('env','RUN_ID') }}"
@@ -20,22 +20,22 @@
           when: lookup('env','RUN_ID')
 
          ## RECORD START-OF-TEST IN LITMUS RESULT CR
-        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
-          template: 
+        - name: Generate the litmus result CR to reflect SOT (Start of Test)
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: in-progress
             verdict: none
-        
+
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
-          register: lr_status 
+          register: lr_status
           failed_when: "lr_status.rc != 0"
 
          ##Actual test
@@ -66,7 +66,7 @@
           replace:
             path: "{{ percona_deployment }}"
             regexp: "lkey: lvalue"
-            replace: "{{ app_lkey }}: {{ app_lvalue }}"      
+            replace: "{{ app_lkey }}: {{ app_lvalue }}"
 
         - name: Create test specific namespace.
           shell: kubectl create ns {{ app_ns }}
@@ -75,14 +75,14 @@
           when: app_ns != 'litmus'
 
         - name: Checking the status  of test specific namespace.
-          shell: kubectl get ns {{ app_ns }} -o custom-columns=:status.phase --no-headers 
+          shell: kubectl get ns {{ app_ns }} -o custom-columns=:status.phase --no-headers
           args:
            executable: /bin/bash
           register: npstatus
           until: "'Active' in npstatus.stdout"
           delay: 30
           retries: 10
-        
+
         - name: Deploying percona
           shell: kubectl apply -f {{ percona_deployment }} -n {{ app_ns }}
 
@@ -99,23 +99,23 @@
       rescue:
         - set_fact:
             flag: "Fail"
-          
+
       always:
-            ## RECORD END-OF-TEST IN LITMUS RESULT CR 
-        - name: Generate the litmus result CR to reflect EOT (End of Test) 
-          template: 
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect EOT (End of Test)
+          template:
             src: /litmus-result.j2
             dest: litmus-result.yaml
-          vars: 
+          vars:
             test: "{{ test_name }}"
             app: ""
             chaostype: ""
             phase: completed
             verdict: "{{ flag }}"
-           
+
         - name: Apply the litmus result CR
           shell: kubectl apply -f litmus-result.yaml
           args:
             executable: /bin/bash
-          register: lr_status 
+          register: lr_status
           failed_when: "lr_status.rc != 0"

--- a/apps/percona/workload/test.yml
+++ b/apps/percona/workload/test.yml
@@ -26,6 +26,24 @@
           register: lr_status
           failed_when: "lr_status.rc != 0"
 
+        - name: Checking the status of test specific namespace.
+          shell: kubectl get ns {{ namespace }} -o jsonpath='{.status.phase}'
+          args:
+           executable: /bin/bash
+          register: npstatus
+          until: "'Active' in npstatus.stdout"
+          delay: 30
+          retries: 10
+
+        # Ensuring if the application is running before starting load generation.
+
+        - name: Checking whether application is running
+          shell: kubectl get pod -n {{ namespace }} -l {{ app_label }}
+          register: running_status
+          until: "'Running' in running_status.stdout"
+          delay: 60
+          retries: 10
+
         - name: Obtaining the loadgen pod label from env.
           set_fact:
             loadgen_lkey: "{{ loadgen_label.split('=')[0] }}"
@@ -49,7 +67,7 @@
             regexp: "password"
             replace: "{{ db_password }}"
 
-        - name: Getting the Sevice IP of Application
+        - name: Getting the Service IP of Application
           shell: kubectl get svc -n {{ namespace }} -l {{ app_service_label }} -o jsonpath='{.items[0].spec.clusterIP}'
           register: ip
 
@@ -58,15 +76,6 @@
             path: "{{ percona_loadgen }}"
             regexp: "service_ip"
             replace: "{{ ip.stdout }}"
-
-        - name: Checking the status of test specific namespace.
-          shell: kubectl get ns {{ namespace }} -o jsonpath='{.status.phase}'
-          args:
-           executable: /bin/bash
-          register: npstatus
-          until: "'Active' in npstatus.stdout"
-          delay: 30
-          retries: 10
 
         - name: Checking for configmap
           shell: kubectl get configmap -n {{ namespace }}
@@ -82,13 +91,6 @@
           until: "'tpcc-config' in config.stdout"
           delay: 15
           retries: 15
-
-        - name: Checking whether application is running
-          shell: kubectl get pod -n {{ namespace }} -l {{ app_label }}
-          register: running_status
-          until: "'Running' in running_status.stdout"
-          delay: 30
-          retries: 60
 
         - name: Create Percona Loadgen Job
           shell: kubectl apply -f {{ percona_loadgen }} -n {{ namespace }}


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Using 'openebs-standalone' provider for statefulset deployment.
- Checking if the application is deployed successfully before starting load generation.
- Added application label env in mongo workload litmus book.
- Removed hard-coded namespace value in litmusbooks.
- Removed whitespaces and blank lines in litmusbooks.
