### PR TITLE
refactor(yaml): remove use of litmus namespace in crunchy-postgres loadgen YAML

### DIFF
--- a/apps/crunchy-postgres/workload/crunchy_postgres_loadgen.yml
+++ b/apps/crunchy-postgres/workload/crunchy_postgres_loadgen.yml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   generateName: crunchy-loadgen-
-  namespace: litmus
 spec:
   template:
     metadata:


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- The litmus loadgen job deploys the loadgen in the app's namespace per the playbook. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
