### PR TITLE
refactor(yaml): add checks for run_id & use kubectl create cmd in postgres workload 

### DIFF
--- a/apps/cockroachdb/workload/test.yml
+++ b/apps/cockroachdb/workload/test.yml
@@ -14,6 +14,17 @@
   tasks:
 
     - block:
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
 
            ## RECORD START-OF-TEST IN LITMUS RESULT CR
         - name: Generate the litmus result CR to reflect SOT (Start of Test)

--- a/apps/crunchy-postgres/workload/test.yml
+++ b/apps/crunchy-postgres/workload/test.yml
@@ -7,6 +7,18 @@
 
   tasks:
     - block:
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+
        ## RECORD START-OF-TEST IN LITMUS RESULT CR
         - name: Generate the litmus result CR to reflect SOT (Start of Test) 
           template: 
@@ -123,7 +135,7 @@
             replace: "{{ lookup('env','PARALLEL_TRANSACTION') }}"           
         
         - name: Create Crunchy-postgres Loadgen Job
-          shell: kubectl apply -f {{ crunchy_loadgen }} -n {{ namespace }} 
+          shell: kubectl create -f {{ crunchy_loadgen }} -n {{ namespace }} 
 
         - name: Verify loadgen pod is running 
           shell: kubectl get pods -n {{ namespace }} -l {{ loadgen_label }} -o jsonpath='{.items[0].status.phase}'

--- a/apps/percona/workload/test.yml
+++ b/apps/percona/workload/test.yml
@@ -7,6 +7,18 @@
 
   tasks:
     - block:
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+        
        ## RECORD START-OF-TEST IN LITMUS RESULT CR
         - name: Generate the litmus result CR to reflect SOT (Start of Test)
           template:


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Uses `kubectl create` in postgres workload litmusbook the loadgen uses generateName
- Updates run_id check in crunchy-postgres & percona workload/loadgen litmusbooks

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
