### PR TITLE
Change master and nodes type of aws cluster

### DIFF
--- a/k8s/aws/k8s-installer/vars.yml
+++ b/k8s/aws/k8s-installer/vars.yml
@@ -5,7 +5,7 @@ cidr_block: 10.0.0.0/16
 cidr_block2: 10.0.1.0/24
 destination_cidr: 0.0.0.0/0
 image: ami-6b3fd60c
-master_size: t2.large
-node_size: t2.large
+master_size: t2.xlarge
+node_size: t2.xlarge
 networking: kube-router
 node_count: 3


### PR DESCRIPTION
Signed-off-by: Chandan Kumar <chandan.kr404@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Change master and nodes instance type from `t2.large` to `t2.xlarge`

**Special notes for your reviewer**:

![image](https://user-images.githubusercontent.com/28861964/46716678-9e647a80-cc82-11e8-9257-e5ae957e1d3a.png)
