### PR TITLE
Add option to set underlying CPU size in GCE

### DIFF
--- a/k8s/gcp/k8s-installer/create-k8s-cluster.yml
+++ b/k8s/gcp/k8s-installer/create-k8s-cluster.yml
@@ -38,7 +38,7 @@
     - name: Creating the Cluster & InstanceGroup objects in our state store
       shell: |
         export KOPS_FEATURE_FLAGS=AlphaAllowGCE
-        kops create cluster {{ cluster_name }}.k8s.local --kubernetes-version {{ k8s_version }} --zones {{zone}} --state gs://{{ cluster_name }}/ --project {{ project }} --node-count {{ nodes }} --networking kubenet --image "ubuntu-os-cloud/ubuntu-1604-xenial-v20170202" --vpc {{ vpc }}
+        kops create cluster {{ cluster_name }}.k8s.local --kubernetes-version {{ k8s_version }} --zones {{zone}} --state gs://{{ cluster_name }}/ --project {{ project }} --node-count {{ nodes }} --networking kubenet --image "ubuntu-os-cloud/ubuntu-1604-xenial-v20170202" --vpc {{ vpc }} --node-size {{ node_size | default('n1-standard-4')}} --master-size {{ master_size | default('n1-standard-4')}}
     - name: Creating K8s Cluster
       shell: |
         export KOPS_FEATURE_FLAGS=AlphaAllowGCE


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add option to set the size of underlying CPUs of VMs(master and
  nodes), for the Kubernetes cluster in gce
- Set `n1-standard-4 (4 vCPUs, 15 GB memory)` as the default value if
none cpu size provided whatsoever.
- To set size of VMs, pass variable in extra vars:
  e.g: `--extra-var "master-size=n1-standard-4 node_size=n1-standard-4"`

Signed-off-by: harshvkarn <harshvkarn54@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->


**Special notes for your reviewer**:
![image](https://user-images.githubusercontent.com/18168330/46717806-ca81fa80-cc86-11e8-9da1-584c024893d1.png)

![image](https://user-images.githubusercontent.com/18168330/46717846-e38aab80-cc86-11e8-97b6-6fa34f1230a8.png)
