### PR TITLE
refactor(yaml): Add initcheck tasks for successful db init in percona deployer litmusbook

### DIFF
--- a/apps/percona/deployers/test.yml
+++ b/apps/percona/deployers/test.yml
@@ -93,6 +93,17 @@
           delay: 10
           retries: 100
 
+        - name: Getting the Percona POD name
+          shell: kubectl get po -n {{ app_ns }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
+          register: pod_name
+
+        - name: Check if db is ready for connections
+          shell: kubectl logs {{ pod_name.stdout }} -n {{ app_ns }} | grep 'ready for connections' | wc -l
+          register: initcheck
+          until: initcheck.stdout == "2"
+          delay: 60
+          retries: 20
+
         - set_fact:
             flag: "Pass"
 

--- a/apps/percona/deployers/test.yml
+++ b/apps/percona/deployers/test.yml
@@ -102,7 +102,7 @@
           register: initcheck
           until: initcheck.stdout == "2"
           delay: 60
-          retries: 20
+          retries: 15
 
         - set_fact:
             flag: "Pass"


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Add initcheck tasks for successful db init in percona deployer litmusbook
- Verifies db init status by searching 'ready for connections' log messages in application pod logs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
