### PR TITLE
(WIP)Litmusbook to create openebs snaspshot and restore the volume

### DIFF
--- a/apps/percona/functional/snapshot/run_litmus_test.yml
+++ b/apps/percona/functional/snapshot/run_litmus_test.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-openebs-snapshot-restore- 
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      labels:
+        name: openebs-snapshot-restore 
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: gprasath/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: OPERATOR_NAMESPACE
+            value: openebs
+ 
+          - name: APP_NAMESPACE
+            value: app-percona-ns
+
+          - name: APP_LABEL
+            value: 'name=percona'
+
+          - name: DB_USERNAME
+            value: root
+
+          - name: DB_PASSWORD
+            value: k8sDem0
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./percona/functional/snapshot/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+ 

--- a/apps/percona/functional/snapshot/test.yml
+++ b/apps/percona/functional/snapshot/test.yml
@@ -1,0 +1,199 @@
+# Description:
+# OpenEBS volume snapshot creation and restoring it to the earlier state..
+# Author: Giri
+# Prerequisites: Application deployed in K8s cluster.
+
+#########################################################################################################
+# Test steps:
+# Create LitmusResult CR.
+# Obtain volume name using the app label and app namespace provided as envs.
+# Create a database and a table.
+# Obtain maya-apiserver pod name and create snapshot.
+
+##########################################################################################################
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+   - block:
+
+       - block:
+
+           - name: Record test instance/run ID.
+             set_fact:
+               run_id: "{{ lookup('env','RUN_ID') }}"
+
+           - name: Construct testname appended with runID.
+             set_fact:
+               test_name: "{{ test_name }}-{{ run_id }}"
+
+         when: lookup('env','RUN_ID')
+
+              ## RECORD START-OF-TEST IN LITMUS RESULT CR
+       - name: Generate the litmus result CR to reflect SOT (Start of Test)
+         template:
+           src: /litmus-result.j2
+           dest: litmus-result.yaml
+         vars:
+           test: "{{ test_name }}"
+           app: ""
+           chaostype: ""
+           phase: in-progress
+           verdict: none
+
+       - name: Apply the litmus result CR.
+         shell: kubectl apply -f litmus-result.yaml
+         args:
+           executable: /bin/bash
+         register: lr_status
+         failed_when: "lr_status.rc != 0"
+
+       - name: Checking the status  of test specific namespace.
+         shell: kubectl get ns {{ app_ns }} -o jsonpath='{.status.phase}'
+         args:
+          executable: /bin/bash
+         register: ns_status
+         until: "'Active' in ns_status.stdout"
+         delay: 30
+         retries: 10
+
+       - name: Obtain the application pod name using its label.
+         shell: >
+           kubectl get pods -n {{ app_ns }} -l {{ app_label }}
+           --no-headers -o custom-columns=:metadata.name
+         args:
+           executable: /bin/bash
+         register: app_pod
+
+       - name: Obtaining pvc name using pod name.
+         shell: >
+           kubectl get pod {{ app_pod.stdout }} -n {{ app_ns }}
+           -o custom-columns=:..claimName --no-headers
+         args:
+           executable: /bin/bash
+         register: pvc_name
+
+       - name: Obtaining PV name using PVC name.
+         shell: >
+           kubectl get pvc {{ pvc_name.stdout }} -n {{ app_ns }}
+           -o custom-columns=:spec.volumeName --no-headers
+         args:
+           executable: /bin/bash
+         register: volume_name
+
+       - name: setting volume name to a variable.
+         set_fact:
+           volume_name: "{{ volume_name.stdout }}"
+
+       - name: Setting pod name to a variable.
+         set_fact:
+           pod_name: "{{ app_pod.stdout }}"
+
+       - name: Write a test database into percona mysql.
+         shell: |
+           kubectl exec -it {{ pod_name }} -n {{ app_ns }} -- mysql -u{{ user_name }} -p{{ password }} -e "create database tdb;"
+           kubectl exec -it {{ pod_name }} -n {{ app_ns }} -- mysql -u{{ user_name }} -p{{ password }} -e "create table ttbl (Data VARCHAR(20));" tdb
+           kubectl exec -it {{ pod_name }} -n {{ app_ns }} -- mysql -u{{ user_name }} -p{{ password }} -e "insert into ttbl (Data) VALUES ('tdata');" tdb
+           kubectl exec -it {{ pod_name }} -n {{ app_ns }} -- mysql -u{{ user_name }} -p{{ password }} -e "flush tables with read lock;"
+         args:
+           executable: /bin/bash
+         register: result
+         failed_when: "result.rc != 0"
+
+       - name: Perform file system sync on percona pod before creating the snapshot.
+         shell: kubectl exec {{ pod_name }} -n {{ app_ns}} -- bash -c "sync;sync;sync"
+         args:
+           executable: /bin/bash
+
+       - name: Creating snapshot.
+         include_tasks: /funclib/openebs/openebs_snapshot_restore.yml
+         vars:
+           action: create_snapshot
+
+       - name: Make changes to the database.
+         shell: |
+           kubectl exec -it {{ pod_name }} -n {{ app_ns }} -- mysql -u{{user_name}} -p{{ password }} -e "unlock tables;"
+           kubectl exec -it {{ pod_name }} -n {{ app_ns }} -- mysql -u{{user_name}} -p{{ password }} -e "drop database tdb"
+           sleep 5
+         args:
+           executable: /bin/bash
+         register: result
+         failed_when: "result.rc != 0"
+
+       - name: Restoring the volume data using snapshot.
+         include_tasks: /funclib/openebs/openebs_snapshot_restore.yml
+         vars:
+           action: restore_snapshot
+
+       - name: Delete application pod to force volume remount upon rescheduling.
+         shell: kubectl delete pod {{pod_name}} -n {{ app_ns }}
+         args:
+           executable: /bin/bash
+         register: result
+         failed_when: "pod_name and 'deleted' not in result.stdout"
+
+       - name: Checking if the application pod is scheduled again
+         shell: kubectl get pod -n {{ app_ns }} -l {{ app_label }}
+         args:
+           executable: /bin/bash
+         register: result
+         until: "'Running' in result.stdout"
+         delay: 30
+         retries: 15
+
+       - name: Obtaining application pod details after restart.
+         shell: >
+           kubectl get pods -n {{ app_ns }} -l {{ app_label }} -o custom-columns=:.metadata.name
+           --no-headers
+         args:
+           executable: /bin/bash
+         register: result
+
+       - name: Store new percona pod name in variable.
+         set_fact:
+           pod_name: "{{ result.stdout }}"
+
+       - name: Verifying whether the restore operation is successful.
+         shell: >
+           kubectl exec -it {{ pod_name }} -n {{ app_ns }} -- mysql -u{{ user_name }} -p{{ password }}
+           -e "select * from ttbl;" tdb
+         args:
+           executable: /bin/bash
+         register: result
+         failed_when: "'tdata' not in result.stdout"
+
+       - name: Test Passed
+         set_fact:
+           flag: "Test Passed"
+
+     rescue:
+       - name: Test Failed
+         set_fact:
+           flag: "Test Failed"
+
+     always:
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+
+       - name: Generate the litmus result CR to reflect EOT (End of Test)
+         template:
+           src: /litmus-result.j2
+           dest: litmus-result.yaml
+         vars:
+           test: "{{ test_name }}"
+           app: ""
+           chaostype: ""
+           phase: completed
+           verdict: "{{ flag }}"
+
+       - name: Apply the litmus result CR
+         shell: kubectl apply -f litmus-result.yaml
+         args:
+           executable: /bin/bash
+         register: lr_status
+         failed_when: "lr_status.rc != 0"

--- a/apps/percona/functional/snapshot/test_vars.yml
+++ b/apps/percona/functional/snapshot/test_vars.yml
@@ -1,0 +1,15 @@
+---
+
+test_name: openebs-snapshot-restore
+
+snapshot_name: percona-snapshot
+
+operator_ns: "{{ lookup('env','OPERATOR_NAMESPACE') }}"
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+user_name: "{{ lookup('env','DB_USERNAME') }}"
+
+password: "{{ lookup('env','DB_PASSWORD') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"

--- a/funclib/openebs/openebs_snapshot_restore.yml
+++ b/funclib/openebs/openebs_snapshot_restore.yml
@@ -10,7 +10,7 @@
 - block:
 
     - name: Obtaining the openebs openebs maya-api server pod name.
-      shell: kubectl get pod -n {{ operator_ns }} -l name=maya-apiserver -o custom-columns=:metadata.name
+      shell: kubectl get pod -n {{ operator_ns }} -l name=maya-apiserver -o custom-columns=:metadata.name --no-headers
       args:
         executable: /bin/bash
       register: result
@@ -27,9 +27,9 @@
       args:
         executable: /bin/bash
       register: result
-      failed_when: "'Created' not in result_snap.stdout"
+      failed_when: "'created' not in result.stdout"
 
-    - name: Confirm successful snapshot creation
+    - name: Confirm successful snapshot creation by listing the snapshots.
       shell: >
         kubectl exec {{ mayapod_name }} -n {{ operator_ns }} -c maya-apiserver
         -- mayactl snapshot list --volname {{ volume_name }} -n {{ app_ns }}
@@ -46,7 +46,7 @@
       shell: >
         kubectl exec {{ mayapod_name }} -n openebs -c maya-apiserver
         -- mayactl snapshot revert --volname {{ volume_name }} -n {{ app_ns }}
-        --snapname {{snap_name}}
+        --snapname {{snapshot_name}}
       args:
         executable: /bin/bash
       register: result


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- The litmusbook accepts application label and namespace to find out the volume for which the snapshot will be created.
- This litmusbook is capable of creating snapshot and restore the volume to the state when the snapshot was created.
- The test has been done against percona deployment. Here, we create a database and create a snapshot. Then, remove the database and restore the volume to the earlier state before the snapshot creation.
- Modified the variable names in openebs-snapshot-restore funclib utility task file. This util can be used in playbooks where either snapshot creation or volume restore has to be performed.



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
