### PR TITLE
Add Non-Gitlab litmus Executor

### DIFF
--- a/executor/ansible/all.csv
+++ b/executor/ansible/all.csv
@@ -1,0 +1,4 @@
+deployers:/home/shashank/Desktop/workspace/litmus/apps/percona/deployers/run_litmus_test.yml:percona-deployment-litmus
+loadgen:/home/shashank/Desktop/workspace/litmus/apps/percona/workload/run_litmus_test.yml:percona-loadgen-litmus
+deployers:/home/shashank/Desktop/workspace/litmus/apps/mongodb/deployers/run_litmus_test.yml:mongodb-deployment-litmus
+chaos:/home/shashank/Desktop/workspace/litmus/apps/percona/chaos/run_litmus_test.yml:openebs-replica-network-delay-litmus

--- a/executor/ansible/execute.sh
+++ b/executor/ansible/execute.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+file=./all.csv
+var=0;
+
+update_file()
+{
+while IFS=':' read -r col1 col2 col3; do
+  echo "$col2:$col3"
+  test="${col3%-*}"
+  ansible-playbook ./utils/execute.yml -e "LABEL="$col3" PATH="$col2" TYPE="$col1" TESTNAME="$test"" -vv
+done < $file
+}
+
+if [ ! -e $file ]; then
+ echo Unable to find CSV file 
+else 
+ touch result.csv
+ update_file 
+ var="$(cat result.csv | grep Pass | wc -l)"
+ echo "Number of test Passed: $var" >> result.csv
+ cat result.csv
+ #rm result.csv
+fi

--- a/executor/ansible/utils/execute.yml
+++ b/executor/ansible/utils/execute.yml
@@ -1,0 +1,47 @@
+---
+- hosts: localhost
+  connection: local
+
+  tasks:
+    - block:
+
+        - name: Running the defined application 
+          shell: kubectl create -f {{ PATH }}
+
+        - name: Getting status of JOB
+          shell: kubectl get pod -n litmus  -l app={{ LABEL }} -o jsonpath='{.items[0].status.phase}'
+          register: status
+          until: "'Succeeded' in status.stdout"
+          delay: 30
+          retries: 30
+
+        - name: Checking the status of Ansible-test container
+          shell: kubectl get pod -n litmus -l app={{ LABEL }} -o jsonpath='{.items[0].status.containerStatuses[0].ready}'
+          register: container_status
+          until: "'false' in container_status.stdout"
+
+        - name: Getting result CR
+          shell: kubectl get lr {{ TESTNAME }} -o jsonpath='{.spec.testStatus.result}'   
+          register: result
+          until: "'none' not in result.stdout"
+          delay: 20
+          retries: 10
+          
+        - name: Updating the test-result csv
+          lineinfile:
+            path: /home/shashank/Desktop/test/result.csv
+            state: present
+            line: '{{ TYPE }} : {{ TESTNAME }} : {{ result.stdout }}'
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+          
+        - name: Updating the test-result csv
+          lineinfile:
+            path: /home/shashank/Desktop/test/result.csv
+            state: present
+            line: '{{ TYPE }} : {{ TESTNAME }} : {{ flag }}'  
+          
+       
+                                    


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a non-Gitlab litmus executor which runs the litmusbook sequentially as order is defined in **``all.csv``** file.
- The **``executer.yml``** file present in ``executer/ansible/utils/`` takes **TESTNAME**,**PATH** & **LABEL** as a extra vars and does the following:
  - Runs the litmusbook at specified path.
  - Check for the status of litmus-job to be completed.
  - Check for the ansible test-container.
  - On completion of job writes the result **CR** in **result.csv** file.
- The script**(executer.sh)** present at path ``executer/ansible`` reads the all.csv and trigers the executer.yml accordingly. 

**Special notes for your reviewer**:
- To run this excuter we need to follow some naming convention between litmus-job label and test name.
- Here the nameing convention which is followed is as follows:
     - ``litmus-job label : **test-name-(appended with litmus)**``

- **Following is the output after executing the executer.sh:**
```
/home/shashank/Desktop/workspace/litmus/apps/percona/deployers/run_litmus_test.yml:percona-deployment-litmus
ansible-playbook 2.6.1
  config file = None
  configured module search path = [u'/home/shashank/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
No config file found; using defaults
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note
that the implicit localhost does not match 'all'


PLAYBOOK: all.yml **************************************************************
1 plays in all.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /home/shashank/Desktop/test/all.yml:2
ok: [localhost]
META: ran handlers

TASK [Running the defined application] *****************************************
task path: /home/shashank/Desktop/test/all.yml:8
changed: [localhost] => {"changed": true, "cmd": "kubectl create -f /home/shashank/Desktop/workspace/litmus/apps/percona/deployers/run_litmus_test.yml", "delta": "0:00:01.348013", "end": "2018-10-11 16:07:04.858573", "rc": 0, "start": "2018-10-11 16:07:03.510560", "stderr": "", "stderr_lines": [], "stdout": "job.batch/litmus-percona-n995n created", "stdout_lines": ["job.batch/litmus-percona-n995n created"]}

TASK [Getting status of JOB] ***************************************************
task path: /home/shashank/Desktop/test/all.yml:11
FAILED - RETRYING: Getting status of JOB (30 retries left).
FAILED - RETRYING: Getting status of JOB (29 retries left).
FAILED - RETRYING: Getting status of JOB (28 retries left).
FAILED - RETRYING: Getting status of JOB (27 retries left).
FAILED - RETRYING: Getting status of JOB (26 retries left).
FAILED - RETRYING: Getting status of JOB (25 retries left).
changed: [localhost] => {"attempts": 7, "changed": true, "cmd": "kubectl get pod -n litmus -l app=percona-deployment-litmus -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:00.660555", "end": "2018-10-11 16:10:13.410179", "rc": 0, "start": "2018-10-11 16:10:12.749624", "stderr": "", "stderr_lines": [], "stdout": "Succeeded", "stdout_lines": ["Succeeded"]}

TASK [Checking the status of Ansible-test container] ***************************
task path: /home/shashank/Desktop/test/all.yml:18
changed: [localhost] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n litmus -l app=percona-deployment-litmus -o jsonpath='{.items[0].status.containerStatuses[0].ready}'", "delta": "0:00:00.684523", "end": "2018-10-11 16:10:14.271923", "rc": 0, "start": "2018-10-11 16:10:13.587400", "stderr": "", "stderr_lines": [], "stdout": "false", "stdout_lines": ["false"]}

TASK [Getting result CR] *******************************************************
task path: /home/shashank/Desktop/test/all.yml:28
changed: [localhost] => {"attempts": 1, "changed": true, "cmd": "kubectl get lr percona-deployment -o jsonpath='{.spec.testStatus.result}'", "delta": "0:00:00.679892", "end": "2018-10-11 16:10:15.097576", "rc": 0, "start": "2018-10-11 16:10:14.417684", "stderr": "", "stderr_lines": [], "stdout": "Pass", "stdout_lines": ["Pass"]}

TASK [Updating the test-result csv] ********************************************
task path: /home/shashank/Desktop/test/all.yml:35
changed: [localhost] => {"backup": "", "changed": true, "msg": "line added"}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
localhost                  : ok=6    changed=5    unreachable=0    failed=0   

/home/shashank/Desktop/workspace/litmus/apps/percona/workload/run_litmus_test.yml:percona-loadgen-litmus
ansible-playbook 2.6.1
  config file = None
  configured module search path = [u'/home/shashank/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
No config file found; using defaults
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note
that the implicit localhost does not match 'all'


PLAYBOOK: all.yml **************************************************************
1 plays in all.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /home/shashank/Desktop/test/all.yml:2
ok: [localhost]
META: ran handlers

TASK [Running the defined application] *****************************************
task path: /home/shashank/Desktop/test/all.yml:8
changed: [localhost] => {"changed": true, "cmd": "kubectl create -f /home/shashank/Desktop/workspace/litmus/apps/percona/workload/run_litmus_test.yml", "delta": "0:00:01.090931", "end": "2018-10-11 16:10:17.977738", "rc": 0, "start": "2018-10-11 16:10:16.886807", "stderr": "", "stderr_lines": [], "stdout": "job.batch/percona-loadgen-lbqqq created", "stdout_lines": ["job.batch/percona-loadgen-lbqqq created"]}

TASK [Getting status of JOB] ***************************************************
task path: /home/shashank/Desktop/test/all.yml:11
FAILED - RETRYING: Getting status of JOB (30 retries left).
FAILED - RETRYING: Getting status of JOB (29 retries left).
changed: [localhost] => {"attempts": 3, "changed": true, "cmd": "kubectl get pod -n litmus -l app=percona-loadgen-litmus -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:00.683466", "end": "2018-10-11 16:11:20.528020", "rc": 0, "start": "2018-10-11 16:11:19.844554", "stderr": "", "stderr_lines": [], "stdout": "Succeeded", "stdout_lines": ["Succeeded"]}

TASK [Checking the status of Ansible-test container] ***************************
task path: /home/shashank/Desktop/test/all.yml:18
changed: [localhost] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n litmus -l app=percona-loadgen-litmus -o jsonpath='{.items[0].status.containerStatuses[0].ready}'", "delta": "0:00:00.677465", "end": "2018-10-11 16:11:21.348041", "rc": 0, "start": "2018-10-11 16:11:20.670576", "stderr": "", "stderr_lines": [], "stdout": "false", "stdout_lines": ["false"]}

TASK [Getting result CR] *******************************************************
task path: /home/shashank/Desktop/test/all.yml:28
changed: [localhost] => {"attempts": 1, "changed": true, "cmd": "kubectl get lr percona-loadgen -o jsonpath='{.spec.testStatus.result}'", "delta": "0:00:00.666612", "end": "2018-10-11 16:11:22.159818", "rc": 0, "start": "2018-10-11 16:11:21.493206", "stderr": "", "stderr_lines": [], "stdout": "Pass", "stdout_lines": ["Pass"]}

TASK [Updating the test-result csv] ********************************************
task path: /home/shashank/Desktop/test/all.yml:35
changed: [localhost] => {"backup": "", "changed": true, "msg": "line added"}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
localhost                  : ok=6    changed=5    unreachable=0    failed=0   

/home/shashank/Desktop/workspace/litmus/apps/mongodb/deployers/run_litmus_test.yml:mongodb-deployment-litmus
ansible-playbook 2.6.1
  config file = None
  configured module search path = [u'/home/shashank/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
No config file found; using defaults
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note
that the implicit localhost does not match 'all'


PLAYBOOK: all.yml **************************************************************
1 plays in all.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /home/shashank/Desktop/test/all.yml:2
ok: [localhost]
META: ran handlers

TASK [Running the defined application] *****************************************
task path: /home/shashank/Desktop/test/all.yml:8
changed: [localhost] => {"changed": true, "cmd": "kubectl create -f /home/shashank/Desktop/workspace/litmus/apps/mongodb/deployers/run_litmus_test.yml", "delta": "0:00:00.986513", "end": "2018-10-11 16:11:24.928612", "rc": 0, "start": "2018-10-11 16:11:23.942099", "stderr": "", "stderr_lines": [], "stdout": "job.batch/litmus-mongodb-72pbn created", "stdout_lines": ["job.batch/litmus-mongodb-72pbn created"]}

TASK [Getting status of JOB] ***************************************************
task path: /home/shashank/Desktop/test/all.yml:11
FAILED - RETRYING: Getting status of JOB (30 retries left).
FAILED - RETRYING: Getting status of JOB (29 retries left).
FAILED - RETRYING: Getting status of JOB (28 retries left).
FAILED - RETRYING: Getting status of JOB (27 retries left).
FAILED - RETRYING: Getting status of JOB (26 retries left).
FAILED - RETRYING: Getting status of JOB (25 retries left).
FAILED - RETRYING: Getting status of JOB (24 retries left).
FAILED - RETRYING: Getting status of JOB (23 retries left).
FAILED - RETRYING: Getting status of JOB (22 retries left).
FAILED - RETRYING: Getting status of JOB (21 retries left).
FAILED - RETRYING: Getting status of JOB (20 retries left).
FAILED - RETRYING: Getting status of JOB (19 retries left).
FAILED - RETRYING: Getting status of JOB (18 retries left).
FAILED - RETRYING: Getting status of JOB (17 retries left).
FAILED - RETRYING: Getting status of JOB (16 retries left).
FAILED - RETRYING: Getting status of JOB (15 retries left).
FAILED - RETRYING: Getting status of JOB (14 retries left).
FAILED - RETRYING: Getting status of JOB (13 retries left).
FAILED - RETRYING: Getting status of JOB (12 retries left).
FAILED - RETRYING: Getting status of JOB (11 retries left).
FAILED - RETRYING: Getting status of JOB (10 retries left).
FAILED - RETRYING: Getting status of JOB (9 retries left).
FAILED - RETRYING: Getting status of JOB (8 retries left).
FAILED - RETRYING: Getting status of JOB (7 retries left).
FAILED - RETRYING: Getting status of JOB (6 retries left).
FAILED - RETRYING: Getting status of JOB (5 retries left).
FAILED - RETRYING: Getting status of JOB (4 retries left).
FAILED - RETRYING: Getting status of JOB (3 retries left).
FAILED - RETRYING: Getting status of JOB (2 retries left).
FAILED - RETRYING: Getting status of JOB (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 30, "changed": true, "cmd": "kubectl get pod -n litmus -l app=mongodb-deployment-litmus -o jsonpath='{.items[0].status.phase}'", "delta": "0:00:00.683686", "end": "2018-10-11 16:26:58.022643", "rc": 0, "start": "2018-10-11 16:26:57.338957", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set_fact] ****************************************************************
task path: /home/shashank/Desktop/test/all.yml:42
ok: [localhost] => {"ansible_facts": {"flag": "Fail"}, "changed": false}

TASK [Updating the test-result csv] ********************************************
task path: /home/shashank/Desktop/test/all.yml:45
changed: [localhost] => {"backup": "", "changed": true, "msg": "line added"}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
localhost                  : ok=4    changed=2    unreachable=0    failed=1   

/home/shashank/Desktop/workspace/litmus/apps/percona/chaos/run_litmus_test.yml:openebs-replica-network-delay-litmus
ansible-playbook 2.6.1
  config file = None
  configured module search path = [u'/home/shashank/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
No config file found; using defaults
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available. Note
that the implicit localhost does not match 'all'


PLAYBOOK: all.yml **************************************************************
1 plays in all.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /home/shashank/Desktop/test/all.yml:2
ok: [localhost]
META: ran handlers

TASK [Running the defined application] *****************************************
task path: /home/shashank/Desktop/test/all.yml:8
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "kubectl create -f /home/shashank/Desktop/workspace/litmus/apps/percona/chaos/run_litmus_test.yml", "delta": "0:00:00.948039", "end": "2018-10-11 16:27:01.984076", "msg": "non-zero return code", "rc": 1, "start": "2018-10-11 16:27:01.036037", "stderr": "error: the path \"/home/shashank/Desktop/workspace/litmus/apps/percona/chaos/run_litmus_test.yml\" does not exist", "stderr_lines": ["error: the path \"/home/shashank/Desktop/workspace/litmus/apps/percona/chaos/run_litmus_test.yml\" does not exist"], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
task path: /home/shashank/Desktop/test/all.yml:42
ok: [localhost] => {"ansible_facts": {"flag": "Fail"}, "changed": false}

TASK [Updating the test-result csv] ********************************************
task path: /home/shashank/Desktop/test/all.yml:45
changed: [localhost] => {"backup": "", "changed": true, "msg": "line added"}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=1   

deployers : percona-deployment : Pass
loadgen : percona-loadgen : Pass
deployers : mongodb-deployment : Fail
chaos : openebs-replica-network-delay : Fail
Number of test Passed: 2
```