### PR TITLE
Make azure k8s(AKS) node size generic while creation

### DIFF
--- a/k8s/azure/k8s-installer/README.md
+++ b/k8s/azure/k8s-installer/README.md
@@ -13,7 +13,7 @@ To create a cluster you need to authenticate the Azure CLI at the first place.
 ```
 - To create a cluster:
 ```bash
-ansible-playbook create-k8s-cluster.yml --extra-vars "nodes=3"
+ansible-playbook create-k8s-cluster.yml --extra-vars "nodes=3 node_vm_size=Standard_D3"
 ```
 
 - To delete the cluster
@@ -23,4 +23,4 @@ ansible-playbook delete-k8s-cluster.yml
 ```
 > Optionally, you can also pass the cluster name in the `extra-vars` while running Creation/Deletion playbook
 
-**NOTE**: Currently the total node count is 3 and VM Size is set to `Standard_D1`.
+**NOTE**: Currently the total node count is 3 and VM Size is set to `Standard_D3`.

--- a/k8s/azure/k8s-installer/create-k8s-cluster.yml
+++ b/k8s/azure/k8s-installer/create-k8s-cluster.yml
@@ -27,7 +27,7 @@
       shell: az group create -l eastus -n aks-{{ cluster_name }}-rg
 
     - name: Creating AKS Cluster
-      shell: az aks create -n aks-{{ cluster_name }}-cluster  -g aks-{{ cluster_name }}-rg --node-count {{ nodes }} --node-vm-size Standard_D1 --generate-ssh-key
+      shell: az aks create -n aks-{{ cluster_name }}-cluster  -g aks-{{ cluster_name }}-rg --node-count {{ nodes }} --node-vm-size {{ node_size }} --generate-ssh-key
 
     - name: Getting Kubeconfig for the AKS Cluster
       shell: az aks get-credentials --resource-group aks-{{ cluster_name }}-rg --name aks-{{ cluster_name }}-cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
- remove hardcoded node vm size and make it generic
- pass node vm size in extra-vars, i.e,
  `--extra-vars "node_vm-size=Standard_D3"`

Signed-off-by: harshvkarn <harshvkarn54@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->


**Special notes for your reviewer**:
An extra variable is required while executing the cluster creation playbook.