### PR TITLE
test(yaml)Litmusbook for single replica failure.

### DIFF
--- a/apps/cassandra/chaos/openebs_single_replica_failure/run_litmus_test.yml
+++ b/apps/cassandra/chaos/openebs_single_replica_failure/run_litmus_test.yml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: openebs-single-replica-failure-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: openebs-single-replica-failure
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: gprasath/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: app-cass-ns 
+
+          - name: APP_LABEL
+            value: 'app=cassandra'
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./cassandra/chaos/openebs_single_replica_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+          - name: logs
+            mountPath: /var/log/ansible
+        tty: true
+      - name: logger
+        image: openebs/logger
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # spec.volumes is not supported via downward API
+          - name: MY_POD_HOSTPATH
+            value: /mnt/chaos/openebs-volume-replica-failure
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,cassandra; exit 0"]
+        volumeMounts:
+          - name: kubeconfig
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt
+        tty: true
+      volumes:
+        - name: kubeconfig
+          configMap:
+            name: kubeconfig
+        - name: logs
+          hostPath:
+            path: /mnt/chaos/openebs_single_replica_failure
+            type: ""
+

--- a/apps/cassandra/chaos/openebs_single_replica_failure/run_litmus_test.yml
+++ b/apps/cassandra/chaos/openebs_single_replica_failure/run_litmus_test.yml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: gprasath/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
         env:
           - name: ANSIBLE_STDOUT_CALLBACK
@@ -45,7 +45,7 @@ spec:
                 fieldPath: metadata.namespace
           # spec.volumes is not supported via downward API
           - name: MY_POD_HOSTPATH
-            value: /mnt/chaos/openebs-volume-replica-failure
+            value: /mnt/chaos/openebs-single-replica-failure
         command: ["/bin/bash"]
         args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,cassandra; exit 0"]
         volumeMounts:

--- a/apps/cassandra/chaos/openebs_single_replica_failure/run_litmus_test.yml
+++ b/apps/cassandra/chaos/openebs_single_replica_failure/run_litmus_test.yml
@@ -20,47 +20,13 @@ spec:
           - name: ANSIBLE_STDOUT_CALLBACK
             value: default
 
+          ## Namespace where the application is deployed.
           - name: APP_NAMESPACE
             value: app-cass-ns 
-
+          
+          ## Label of application pod whose replica has to be killed.  
           - name: APP_LABEL
             value: 'app=cassandra'
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./cassandra/chaos/openebs_single_replica_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
-        volumeMounts:
-          - name: logs
-            mountPath: /var/log/ansible
-        tty: true
-      - name: logger
-        image: openebs/logger
-        env:
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          # spec.volumes is not supported via downward API
-          - name: MY_POD_HOSTPATH
-            value: /mnt/chaos/openebs-single-replica-failure
-        command: ["/bin/bash"]
-        args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,cassandra; exit 0"]
-        volumeMounts:
-          - name: kubeconfig
-            mountPath: /root/admin.conf
-            subPath: admin.conf
-          - name: logs
-            mountPath: /mnt
-        tty: true
-      volumes:
-        - name: kubeconfig
-          configMap:
-            name: kubeconfig
-        - name: logs
-          hostPath:
-            path: /mnt/chaos/openebs_single_replica_failure
-            type: ""
-

--- a/apps/cassandra/chaos/openebs_single_replica_failure/test.yml
+++ b/apps/cassandra/chaos/openebs_single_replica_failure/test.yml
@@ -104,7 +104,7 @@
             dest: litmus-result.yaml
           vars: 
             test: "{{ test_name }}"
-            chaostype: "aingle-replica-failure"
+            chaostype: "single-replica-failure"
             app: ""
             phase: completed
             verdict: "{{ flag }}"

--- a/apps/cassandra/chaos/openebs_single_replica_failure/test.yml
+++ b/apps/cassandra/chaos/openebs_single_replica_failure/test.yml
@@ -41,7 +41,7 @@
         - name: Verify that the AUT (Application Under Test) is running 
           shell: >
             kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-            -o custom-columns=:status.phase
+            -o jsonpath={.items[0].status.phase}
           args:
             executable: /bin/bash
           register: app_status
@@ -79,7 +79,7 @@
         - name: Verify AUT existence post fault-injection
           shell: >
             kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-            -o custom-columns=:status.phase
+            -o jsonpath={.items[0].status.phase}
           args:
             executable: /bin/bash
           register: app_status

--- a/apps/cassandra/chaos/openebs_single_replica_failure/test.yml
+++ b/apps/cassandra/chaos/openebs_single_replica_failure/test.yml
@@ -1,0 +1,118 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+        - block:
+ 
+            - name: Record test instance/run ID 
+              set_fact: 
+                run_id: "{{ lookup('env','RUN_ID') }}"
+           
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+
+        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            chaostype: "Single-replica-failure"
+            app: ""
+            phase: in-progress
+            verdict: none
+
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"
+
+        - name: Verify that the AUT (Application Under Test) is running 
+          shell: >
+            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          delay: 30
+          retries: 12
+
+        - name: Obtaining the application pod name through its label.
+          shell: >
+             kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers 
+             -o jsonpath='{.items[0].metadata.name}'
+          args:
+            executable: /bin/bash
+          register: app_pod
+
+        - name: Obtaining the PVC through the application pod
+          shell: >
+            kubectl get pods {{ app_pod.stdout }} -n {{ app_ns }} 
+            --no-headers -o custom-columns=:..claimName
+          args:
+            executable: /bin/bash
+          register: pvc_name
+
+        - name: Recording PVC name in a variable.
+          set_fact:
+            pvc: "{{ pvc_name.stdout }}"
+
+        ## INCLUDING THE CHAOSLIB UTILITY TO KILL THE STORAGE REPLICA POD
+
+        - include: /chaoslib/openebs/jiva_replica_pod_failure.yaml
+          app_pvc: "{{ pvc }}"
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify AUT existence post fault-injection
+          shell: >
+            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          delay: 30
+          retries: 12
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue: 
+        - set_fact: 
+            flag: "Fail"
+
+      always: 
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+ 
+        - name: Generate the litmus result CR to reflect EOT (End of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            chaostype: "aingle-replica-failure"
+            app: ""
+            phase: completed
+            verdict: "{{ flag }}"
+           
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"
+           

--- a/apps/cassandra/chaos/openebs_single_replica_failure/test.yml
+++ b/apps/cassandra/chaos/openebs_single_replica_failure/test.yml
@@ -45,7 +45,7 @@
           args:
             executable: /bin/bash
           register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          until: "'Running' in app_status.stdout"
           delay: 30
           retries: 12
 
@@ -83,7 +83,7 @@
           args:
             executable: /bin/bash
           register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          until: "'Running' in app_status.stdout"
           delay: 30
           retries: 12
 

--- a/apps/cassandra/chaos/openebs_single_replica_failure/test_vars.yml
+++ b/apps/cassandra/chaos/openebs_single_replica_failure/test_vars.yml
@@ -1,0 +1,9 @@
+---
+test_name: openebs-single-replica-failure
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+app_label: "{{ lookup('env','APP_LABEL') }}"
+
+
+

--- a/chaoslib/openebs/jiva_replica_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_replica_pod_failure.yaml
@@ -12,6 +12,14 @@
     # Depends on the naming convention in maya-apiserver (<pv-id>-rep)  
     jiva_replica_deploy: "{{ pv.stdout }}-rep"
 
+- name: Obtain the number of replicas in the deployment
+  shell: >
+    kubectl get deployment {{ jiva_replica_deploy }} -n {{ app_ns }}
+    --no-headers -o custom-columns=:spec.replicas
+  args:
+    executable: /bin/bash
+  register: replica_count
+
 - name: Get the resourceVersion of the replica deploy before fault injection
   shell: >
     kubectl get deploy {{ jiva_replica_deploy }} -n {{ app_ns }} 
@@ -38,6 +46,17 @@
 - name: Wait for 10s post fault injection 
   wait_for:
     timeout: 10
+
+- name: Check if the replica pod is scheduled back.
+  shell: >
+    kubectl get deployment {{ jiva_replica_deploy }} -n {{ app_ns }}
+    --no-headers -o custom-columns=:..readyReplicas
+  args:
+    executable: /bin/bash
+  register: available_replicas
+  until: "available_replicas.stdout | int == replica_count.stdout | int"
+  delay: 30
+  retries: 10
 
 - name: Get the resourceVersion of the replica deploy after fault injection
   shell: >

--- a/chaoslib/openebs/jiva_replica_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_replica_pod_failure.yaml
@@ -43,10 +43,6 @@
   args:
     executable: /bin/bash
 
-- name: Wait for 10s post fault injection 
-  wait_for:
-    timeout: 10
-
 - name: Check if the replica pod is scheduled back.
   shell: >
     kubectl get deployment {{ jiva_replica_deploy }} -n {{ app_ns }}


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
-  This litmusbook kills the replica pod in a deployment and checks if the application is alive post rescheduling
-  This book accepts application label and its namespace as env. Derives the PVC name and the replica deployment name using the label and namespace.
- Included a condition in the chaoslib utility task file that checks if all the pods in the deployment are running after scheduling again.


Test-run execution sample result:
```
PLAYBOOK: test.yml *************************************************************
1 plays in ./cassandra/chaos/openebs_single_replica_failure/test.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:2
ok: [127.0.0.1]
META: ran handlers

TASK [Record test instance/run ID] *********************************************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:13
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:17
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:23
changed: [127.0.0.1] => {"changed": true, "checksum": "61d7fcc997e6ba11b01c42f4b7fa9732c82c5380", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b9e3b545aea0711ebc650aa32fde02c9", "mode": "0644", "owner": "root", "size": 453, "src": "/root/.ansible/tmp/ansible-tmp-1539608929.96-82286924123793/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:34
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.265123", "end": "2018-10-15 13:08:52.090443", "failed_when_result": false, "rc": 0, "start": "2018-10-15 13:08:50.825320", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-single-replica-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-single-replica-failure configured"]}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:41
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-cass-ns -l app=cassandra --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.209321", "end": "2018-10-15 13:08:53.595120", "rc": 0, "start": "2018-10-15 13:08:52.385799", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning", "stdout_lines": ["Running", "Running"]}

TASK [Obtaining the application pod name through its label.] *******************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:52
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-cass-ns -l app=cassandra --no-headers -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.267726", "end": "2018-10-15 13:08:55.097262", "rc": 0, "start": "2018-10-15 13:08:53.829536", "stderr": "", "stderr_lines": [], "stdout": "cassandra-0", "stdout_lines": ["cassandra-0"]}

TASK [Obtaining the PVC through the application pod] ***************************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:60
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods cassandra-0 -n app-cass-ns --no-headers -o custom-columns=:..claimName", "delta": "0:00:01.180631", "end": "2018-10-15 13:08:56.507175", "rc": 0, "start": "2018-10-15 13:08:55.326544", "stderr": "", "stderr_lines": [], "stdout": "openebs-cassandra-cassandra-0", "stdout_lines": ["openebs-cassandra-cassandra-0"]}

TASK [Recording PVC name in a variable.] ***************************************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:68
ok: [127.0.0.1] => {"ansible_facts": {"pvc": "openebs-cassandra-cassandra-0"}, "changed": false}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:1
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-cassandra-cassandra-0 -o custom-columns=:spec.volumeName -n app-cass-ns --no-headers", "delta": "0:00:00.909258", "end": "2018-10-15 13:08:57.908749", "rc": 0, "start": "2018-10-15 13:08:56.999491", "stderr": "", "stderr_lines": [], "stdout": "pvc-8b6a18df-d066-11e8-8e31-42010a8000f5", "stdout_lines": ["pvc-8b6a18df-d066-11e8-8e31-42010a8000f5"]}

TASK [Record the jiva replica deployment of the PV] ****************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:10
ok: [127.0.0.1] => {"ansible_facts": {"jiva_replica_deploy": "pvc-8b6a18df-d066-11e8-8e31-42010a8000f5-rep"}, "changed": false}

TASK [Obtain the number of replicas in the deployment] *************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:15
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployment pvc-8b6a18df-d066-11e8-8e31-42010a8000f5-rep -n app-cass-ns --no-headers -o custom-columns=:spec.replicas", "delta": "0:00:00.941459", "end": "2018-10-15 13:08:59.089343", "rc": 0, "start": "2018-10-15 13:08:58.147884", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}
TASK [Get the resourceVersion of the replica deploy before fault injection] ****
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:23
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-8b6a18df-d066-11e8-8e31-42010a8000f5-rep -n app-cass-ns -o yaml | grep resourceVersion | awk '{print $2}' | sed 's|\"||g'", "delta": "0:00:00.940328", "end": "2018-10-15 13:09:00.222148", "rc": 0, "start": "2018-10-15 13:08:59.281820", "stderr": "", "stderr_lines": [], "stdout": "3307560", "stdout_lines": ["3307560"]}

TASK [Randomly pick a jiva replica pod belonging to the PV] ********************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:31
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica -n app-cass-ns --no-headers | grep pvc-8b6a18df-d066-11e8-8e31-42010a8000f5 | shuf -n1 | awk '{print $1}'", "delta": "0:00:00.917883", "end": "2018-10-15 13:09:01.332140", "rc": 0, "start": "2018-10-15 13:09:00.414257", "stderr": "", "stderr_lines": [], "stdout": "pvc-8b6a18df-d066-11e8-8e31-42010a8000f5-rep-f995dfd96-lsztp", "stdout_lines": ["pvc-8b6a18df-d066-11e8-8e31-42010a8000f5-rep-f995dfd96-lsztp"]}

TASK [Kill the jiva replica pod] ***********************************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:40
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod pvc-8b6a18df-d066-11e8-8e31-42010a8000f5-rep-f995dfd96-lsztp -n app-cass-ns", "delta": "0:00:11.318755", "end": "2018-10-15 13:09:12.831007", "rc": 0, "start": "2018-10-15 13:09:01.512252", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-8b6a18df-d066-11e8-8e31-42010a8000f5-rep-f995dfd96-lsztp\" deleted", "stdout_lines": ["pod \"pvc-8b6a18df-d066-11e8-8e31-42010a8000f5-rep-f995dfd96-lsztp\" deleted"]}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:46
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Check if the replica pod is scheduled back.] *****************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:50
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get deployment pvc-8b6a18df-d066-11e8-8e31-42010a8000f5-rep -n app-cass-ns --no-headers -o custom-columns=:..readyReplicas", "delta": "0:00:01.231379", "end": "2018-10-15 13:09:24.711089", "rc": 0, "start": "2018-10-15 13:09:23.479710", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Get the resourceVersion of the replica deploy after fault injection] *****
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:61
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy pvc-8b6a18df-d066-11e8-8e31-42010a8000f5-rep -n app-cass-ns -o yaml | grep resourceVersion | awk '{print $2}' | sed 's|\"||g'", "delta": "0:00:01.142140", "end": "2018-10-15 13:09:26.186492", "rc": 0, "start": "2018-10-15 13:09:25.044352", "stderr": "", "stderr_lines": [], "stdout": "3307899", "stdout_lines": ["3307899"]}

TASK [Compare resourceVersions of replica deployment] **************************
task path: /chaoslib/openebs/jiva_replica_pod_failure.yaml:69
ok: [127.0.0.1] => {
    "msg": "Verified replica pods were restarted by fault injection"
}

TASK [Verify AUT existence post fault-injection] *******************************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:79
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-cass-ns -l app=cassandra --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.963869", "end": "2018-10-15 13:09:27.557733", "rc": 0, "start": "2018-10-15 13:09:26.593864", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning", "stdout_lines": ["Running", "Running"]}

TASK [set_fact] ****************************************************************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:90
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:101
changed: [127.0.0.1] => {"changed": true, "checksum": "47c2e64f7a8591f3b4816330bcaf0272bfca5d67", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "7db65e7350619a0f36715562c2b50a08", "mode": "0644", "owner": "root", "size": 451, "src": "/root/.ansible/tmp/ansible-tmp-1539608967.71-21727918430328/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
task path: /cassandra/chaos/openebs_single_replica_failure/test.yml:112
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.166397", "end": "2018-10-15 13:09:30.949564", "failed_when_result": false, "rc": 0, "start": "2018-10-15 13:09:29.783167", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-single-replica-failure configured", "stdout_lines": ["litmusresult.litmus.io/openebs-single-replica-failure configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=21   changed=15   unreachable=0    failed=0
```