### PR TITLE
Add a litmusbook for jiva-replica-scaleup

### DIFF
--- a/apps/percona/deployers/run_litmus_test.yml
+++ b/apps/percona/deployers/run_litmus_test.yml
@@ -26,7 +26,7 @@ spec:
 
           - name: PROVIDER_STORAGE_CLASS
             # Supported values: openebs-standard, local-storage
-            value: openebs-standard
+            value: openebs-standalone
 
           - name: APP_PVC
             value: percona-mysql-claim

--- a/apps/percona/deployers/run_litmus_test.yml
+++ b/apps/percona/deployers/run_litmus_test.yml
@@ -26,7 +26,7 @@ spec:
 
           - name: PROVIDER_STORAGE_CLASS
             # Supported values: openebs-standard, local-storage
-            value: openebs-standalone
+            value: openebs-standard
 
           - name: APP_PVC
             value: percona-mysql-claim

--- a/apps/percona/functional/scale_jiva_replica/run_litmus_test.yml
+++ b/apps/percona/functional/scale_jiva_replica/run_litmus_test.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-scale-jiva-replica-
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: scaleup-jiva-replica-litmus
+   
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK 
+            value: default
+
+          - name: APP_NAMESPACE
+            value: 'app-percona-ns'
+          
+          - name: PVC_NAME
+            value: 'percona-mysql-claim'
+
+          - name: OPERATOR_NS
+            value: 'openebs'  
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./percona/functional/scale_jiva_replica/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/percona/functional/scale_jiva_replica/test.yml
+++ b/apps/percona/functional/scale_jiva_replica/test.yml
@@ -1,0 +1,111 @@
+---
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - vars.yml
+
+  tasks:
+
+   - block:
+
+      ## RECORD START-OF-TEST IN LITMUS RESULT CR
+       - name: Generate the litmus result CR to reflect SOT (Start of Test)
+         template:
+           src: /litmus-result.j2
+           dest: litmus-result.yaml
+         vars:
+           test: "{{ test_name }}"
+           app: ""
+           chaostype: ""
+           phase: in-progress
+           verdict: none
+
+       - name: Apply the litmus result CR
+         shell: kubectl apply -f litmus-result.yaml
+         args:
+           executable: /bin/bash
+         register: lr_status
+         failed_when: "lr_status.rc != 0"
+
+       - name: Get the number of nodes in the cluster
+         shell: kubectl get nodes | grep 'none' | wc -l
+         args:
+           executable: /bin/bash
+         register: node_out
+        
+       - name: Fetch the node count from stdout
+         set_fact:
+            node_count: "{{node_out.stdout}}"
+        
+       - name: Get the replica deployment name
+         shell: kubectl get deployments -n {{ namespace }} -l openebs.io/replica=jiva-replica -o jsonpath='{.items[0].metadata.name}'
+         args:
+           executable: /bin/bash
+         register: rep_deployment_name
+        
+       - name: Get the controller deployment name 
+         shell: kubectl get deployment -n {{ namespace }} -l openebs.io/controller=jiva-controller -o jsonpath='{.items[0].metadata.name}'
+         args:
+           executable: /bin/bash
+         register: ctrl_deploy
+
+       - name: Obtaining the current replication factor
+         shell: kubectl get deployments {{ ctrl_deploy.stdout }} -n {{ namespace }} -o jsonpath='{.spec.template.spec.containers[0].env[0].value}'    
+         register: replication_factor
+
+       - name: Update Controller deployment
+         shell: kubectl set env deployment/{{ ctrl_deploy.stdout }} -n {{ namespace }}  REPLICATION_FACTOR="{{ node_count }}" 
+         register: update_ctrl 
+         until: "'env updated' in update_ctrl.stdout"
+         retries: 5
+         delay: 10
+         when: replication_factor.stdout != node_count 
+ 
+
+       #### scale up the storage replica using kubectl command ####
+        
+       - name: Scaleing-up Jiva replica
+         include_tasks: "/funclib/kubectl/scale_replicas.yml"
+         vars:
+             app_ns: "{{ namespace }}"
+             deploy_type: "deployment"
+             app_name: "{{ rep_deployment_name.stdout }}"   
+             app_label: "openebs.io/replica=jiva-replica"  
+             app_replica_count: "{{ node_count }}"
+
+        #### Check the replica access mode after scaling up using mayactl commands ####
+       - name: Check the replicas access mode
+         include_tasks: "/funclib/openebs/access-mode-check.yml"
+         vars:
+           ns: "{{ namespace }}"
+           pvc_name: "{{ persistant_vol_name }}"
+           operator_ns: "{{ operator_namespace }}"
+
+       - set_fact: 
+           flag: "Pass" 
+          
+     rescue:
+       - set_fact:
+           flag: "Fail"
+
+     always:
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect EOT (End of Test)
+          template:
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars:
+            test: "{{ test_name }}"
+            app: ""
+            chaostype: ""
+            phase: completed
+            verdict: "{{ flag }}"
+
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status
+          failed_when: "lr_status.rc != 0"

--- a/apps/percona/functional/scale_jiva_replica/test.yml
+++ b/apps/percona/functional/scale_jiva_replica/test.yml
@@ -11,23 +11,9 @@
    - block:
 
       ## RECORD START-OF-TEST IN LITMUS RESULT CR
-       - name: Generate the litmus result CR to reflect SOT (Start of Test)
-         template:
-           src: /litmus-result.j2
-           dest: litmus-result.yaml
+       - include_tasks: /common/utils/update_litmus_result_resource.yml
          vars:
-           test: "{{ test_name }}"
-           app: ""
-           chaostype: ""
-           phase: in-progress
-           verdict: none
-
-       - name: Apply the litmus result CR
-         shell: kubectl apply -f litmus-result.yaml
-         args:
-           executable: /bin/bash
-         register: lr_status
-         failed_when: "lr_status.rc != 0"
+           status: 'SOT'
 
        - name: Get the number of nodes in the cluster
          shell: kubectl get nodes | grep 'none' | wc -l
@@ -92,20 +78,6 @@
 
      always:
            ## RECORD END-OF-TEST IN LITMUS RESULT CR
-        - name: Generate the litmus result CR to reflect EOT (End of Test)
-          template:
-            src: /litmus-result.j2
-            dest: litmus-result.yaml
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
-            test: "{{ test_name }}"
-            app: ""
-            chaostype: ""
-            phase: completed
-            verdict: "{{ flag }}"
-
-        - name: Apply the litmus result CR
-          shell: kubectl apply -f litmus-result.yaml
-          args:
-            executable: /bin/bash
-          register: lr_status
-          failed_when: "lr_status.rc != 0"
+            status: 'EOT'

--- a/apps/percona/functional/scale_jiva_replica/vars.yml
+++ b/apps/percona/functional/scale_jiva_replica/vars.yml
@@ -1,0 +1,4 @@
+test_name: scaleup-jiva-replica
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+persistant_vol_name: "{{ lookup('env','PVC_NAME') }}"
+operator_namespace: "{{ lookup('env','OPERATOR_NS') }}"

--- a/funclib/openebs/access-mode-check.yml
+++ b/funclib/openebs/access-mode-check.yml
@@ -1,0 +1,46 @@
+
+       - name: Get the pv name
+         shell: kubectl get pvc {{ pvc_name }} -n {{ ns }} -o jsonpath='{.spec.volumeName}'
+         args:
+           executable: /bin/bash
+         register: pv_name
+         changed_when: True
+
+       - name: Get the nodes count
+         shell: kubectl get nodes | grep '<none>' | wc -l
+         args:
+           executable: /bin/bash
+         register: node_count
+
+       - name: Get the maya-apiserver pod name
+         shell:  kubectl get pods -n {{ operator_ns }} -l name=maya-apiserver --no-headers -o jsonpath='{.items[0].metadata.name}'
+         args:
+           executable: /bin/bash
+         register: mayapod
+         changed_when: True
+
+       - name: Get the volume list
+         shell: kubectl exec -it {{ mayapod.stdout }} -n {{ operator_ns }} -- mayactl volume list
+         args:
+           executable: /bin/bash
+         register: volname
+         changed_when: True
+         until: 'pv_name.stdout in volname.stdout'
+         delay: 30
+         retries: 5
+
+       - name: Get the replicas access mode
+         shell: >   
+            kubectl exec -it {{ mayapod.stdout }} -n {{ operator_ns }} -- mayactl volume info --volname "{{ pv_name.stdout }}" -n {{ ns }} | grep 'RW' | wc -l
+         args:
+           executable: /bin/bash
+         register: result
+         until: result.stdout| int == node_count.stdout | int
+         delay: 30
+         retries: 15
+         changed_when: True
+
+       - debug:
+           msg: "All the replicas are in sync"
+         when: "result.rc == 0"
+


### PR DESCRIPTION

**What this PR does / why we need it**:
- Add a Litmusbook for jiva-replica-scaleup.
- Add a **access-mode-check.yml** in funclib to checking the replica-access mode.
**Following is the output for the litmus job log:**
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "1df2d431d14527432a66738db78b77fd3695e86b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "64d3375040c2b0cfa197b3dd9adf5745", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1540549875.76-121244277305473/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.211735", "end": "2018-10-26 10:31:21.025831", "failed_when_result": false, "rc": 0, "start": "2018-10-26 10:31:18.814096", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/scaleup-jiva-replica unchanged", "stdout_lines": ["litmusresult.litmus.io/scaleup-jiva-replica unchanged"]}

TASK [Get the number of nodes in the cluster] **********************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes | grep 'none' | wc -l", "delta": "0:00:01.557612", "end": "2018-10-26 10:31:23.255204", "rc": 0, "start": "2018-10-26 10:31:21.697592", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Fetch the node count from stdout] ****************************************
ok: [127.0.0.1] => {"ansible_facts": {"node_count": "3"}, "changed": false}

TASK [Get the replica deployment name] *****************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployments -n app-cass-ns -l openebs.io/replica=jiva-replica -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.607629", "end": "2018-10-26 10:31:25.833505", "rc": 0, "start": "2018-10-26 10:31:24.225876", "stderr": "", "stderr_lines": [], "stdout": "app-cass-ns-openebs-cassandra-cassandra-0-3477814300-rep", "stdout_lines": ["app-cass-ns-openebs-cassandra-cassandra-0-3477814300-rep"]}

TASK [Get the controller deployment name] **************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployment -n app-cass-ns -l openebs.io/controller=jiva-controller -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.509148", "end": "2018-10-26 10:31:28.043237", "rc": 0, "start": "2018-10-26 10:31:26.534089", "stderr": "", "stderr_lines": [], "stdout": "app-cass-ns-openebs-cassandra-cassandra-0-3477814300-ctrl", "stdout_lines": ["app-cass-ns-openebs-cassandra-cassandra-0-3477814300-ctrl"]}

TASK [Obtain the Controller deployment yaml] ***********************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployment -n app-cass-ns app-cass-ns-openebs-cassandra-cassandra-0-3477814300-ctrl -o yaml > \"./ctrl_deployment.yml\"", "delta": "0:00:01.547470", "end": "2018-10-26 10:31:30.266833", "rc": 0, "start": "2018-10-26 10:31:28.719363", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Replace the Replication factor value] ************************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Update the controller deployment] ****************************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl patch deployment \"app-cass-ns-openebs-cassandra-cassandra-0-3477814300-ctrl\" -n \"app-cass-ns\" -p \"$(cat ./ctrl_deployment.yml)\"", "delta": "0:00:01.551975", "end": "2018-10-26 10:31:33.719793", "rc": 0, "start": "2018-10-26 10:31:32.167818", "stderr": "", "stderr_lines": [], "stdout": "deployment.extensions/app-cass-ns-openebs-cassandra-cassandra-0-3477814300-ctrl patched", "stdout_lines": ["deployment.extensions/app-cass-ns-openebs-cassandra-cassandra-0-3477814300-ctrl patched"]}

TASK [Scaleing-up Jiva replica] ************************************************
included: /funclib/kubectl/scale_replicas.yml for 127.0.0.1

TASK [Obtaining the application pod name.] *************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployment -n app-cass-ns --no-headers -l openebs.io/replica=jiva-replica -o custom-columns=:metadata.name", "delta": "0:00:01.559299", "end": "2018-10-26 10:31:36.300912", "rc": 0, "start": "2018-10-26 10:31:34.741613", "stderr": "", "stderr_lines": [], "stdout": "app-cass-ns-openebs-cassandra-cassandra-0-3477814300-rep", "stdout_lines": ["app-cass-ns-openebs-cassandra-cassandra-0-3477814300-rep"]}

TASK [Recording the application pod name.] *************************************
ok: [127.0.0.1] => {"ansible_facts": {"app_name": "app-cass-ns-openebs-cassandra-cassandra-0-3477814300-rep"}, "changed": false}

TASK [scaling up the replicas.] ************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl scale deployment app-cass-ns-openebs-cassandra-cassandra-0-3477814300-rep --replicas=3 -n app-cass-ns", "delta": "0:00:01.578666", "end": "2018-10-26 10:31:38.860427", "failed_when_result": false, "rc": 0, "start": "2018-10-26 10:31:37.281761", "stderr": "", "stderr_lines": [], "stdout": "deployment.extensions/app-cass-ns-openebs-cassandra-cassandra-0-3477814300-rep scaled", "stdout_lines": ["deployment.extensions/app-cass-ns-openebs-cassandra-cassandra-0-3477814300-rep scaled"]}

TASK [Check if all the application replicas are running.] **********************
FAILED - RETRYING: Check if all the application replicas are running. (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get deployment -n app-cass-ns --no-headers -l openebs.io/replica=jiva-replica -o custom-columns=:..readyReplicas", "delta": "0:00:01.647696", "end": "2018-10-26 10:32:43.357121", "rc": 0, "start": "2018-10-26 10:32:41.709425", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Check the replicas access mode] ******************************************
included: /funclib/openebs/access-mode-check.yml for 127.0.0.1

TASK [Get the pv name] *********************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n app-cass-ns", "delta": "0:00:01.571993", "end": "2018-10-26 10:32:45.971710", "rc": 0, "start": "2018-10-26 10:32:44.399717", "stderr": "", "stderr_lines": [], "stdout": "NAME                            STATUS   VOLUME                                                 CAPACITY   ACCESS MODES   STORAGECLASS         AGE\nopenebs-cassandra-cassandra-0   Bound    app-cass-ns-openebs-cassandra-cassandra-0-3477814300   5G         RWO            openebs-standalone   3m", "stdout_lines": ["NAME                            STATUS   VOLUME                                                 CAPACITY   ACCESS MODES   STORAGECLASS         AGE", "openebs-cassandra-cassandra-0   Bound    app-cass-ns-openebs-cassandra-cassandra-0-3477814300   5G         RWO            openebs-standalone   3m"]}

TASK [Get the nodes count] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes | grep '<none>' | wc -l", "delta": "0:00:01.587200", "end": "2018-10-26 10:32:48.245893", "rc": 0, "start": "2018-10-26 10:32:46.658693", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Set PV name to a variable] ***********************************************
ok: [127.0.0.1] => {"ansible_facts": {"pvname": "app-cass-ns-openebs-cassandra-cassandra-0-3477814300"}, "changed": false}

TASK [Get the maya-apiserver pod name] *****************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l name=maya-apiserver --no-headers -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:01.580886", "end": "2018-10-26 10:32:50.737897", "rc": 0, "start": "2018-10-26 10:32:49.157011", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-5c9cdbb549-5q97q", "stdout_lines": ["maya-apiserver-5c9cdbb549-5q97q"]}

TASK [Get the volume list] *****************************************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it maya-apiserver-5c9cdbb549-5q97q -n openebs -- mayactl volume list", "delta": "0:00:02.178965", "end": "2018-10-26 10:32:53.570848", "rc": 0, "start": "2018-10-26 10:32:51.391883", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Name                                                  Status   Type\napp-cass-ns-openebs-cassandra-cassandra-0-3477814300  Running  jiva", "stdout_lines": ["Name                                                  Status   Type", "app-cass-ns-openebs-cassandra-cassandra-0-3477814300  Running  jiva"]}

TASK [Get the replicas access mode] ********************************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it maya-apiserver-5c9cdbb549-5q97q -n openebs -- mayactl volume info --volname \"app-cass-ns-openebs-cassandra-cassandra-0-3477814300\" -n app-cass-ns | grep 'RW' | wc -l", "delta": "0:00:01.945990", "end": "2018-10-26 10:32:56.234764", "rc": 0, "start": "2018-10-26 10:32:54.288774", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "3", "stdout_lines": ["3"]}

TASK [debug] *******************************************************************
ok: [127.0.0.1] => {
    "msg": "All the replicas are in sync"
}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "3b4bb83ca22cba9857f7b3e4b2e251f9632be213", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c028cd2c5d058fbe509b12e49ba88bc4", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1540549977.08-88835587518713/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.877909", "end": "2018-10-26 10:33:02.879341", "failed_when_result": false, "rc": 0, "start": "2018-10-26 10:33:01.001432", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/scaleup-jiva-replica configured", "stdout_lines": ["litmusresult.litmus.io/scaleup-jiva-replica configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=26   changed=18   unreachable=0    failed=0   

```