### PR TITLE
WIP[openebs/litmus] (test): Include a litmus book to perform node maintenance.

### DIFF
--- a/apps/crunchy-postgres/deployers/run_litmus_test.yml
+++ b/apps/crunchy-postgres/deployers/run_litmus_test.yml
@@ -14,6 +14,8 @@ spec:
     spec:
       serviceAccountName: litmus
       restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: test-node 
       containers:
       - name: ansibletest
         image: openebs/ansible-runner:ci
@@ -44,3 +46,8 @@ spec:
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./crunchy-postgres/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]
+      tolerations:
+      - key: "run"
+        operator: "Equal"
+        value: "litmuspod"
+        effect: "NoSchedule"

--- a/apps/crunchy-postgres/liveness/run_litmus_test.yml
+++ b/apps/crunchy-postgres/liveness/run_litmus_test.yml
@@ -4,19 +4,20 @@ kind: Job
 metadata:
   generateName: liveness-pg-
   namespace: litmus
-
 spec:
   template:
     metadata:
       name: liveness
-   
+      labels:
+        liveness: node-chaos
     spec:
       restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: test-node
       containers:
       - name: liveness
-        image: openebs/postgres-client
+        image: openebs/tests-postgresql-client
         imagePullPolicy: Always
-
         env: 
 
             # Time period (in sec) b/w retries for DB init check
@@ -37,11 +38,11 @@ spec:
     
             # No of retries after a db_connect failure before declaring liveness fail
           - name: LIVENESS_RETRY_COUNT
-            value: "6"
+            value: "2"
 
             # Namespace in Which Postgres is Running
           - name: NAMESPACE
-            value: postgres
+            value: app-pgres-ns
 
             # Service Name of postgres 
           - name: SERVICE_NAME
@@ -65,3 +66,8 @@ spec:
 
         command: ["/bin/bash"]
         args: ["-c", "python ./liveness.py ; exit 0"]
+      tolerations:
+      - key: "run"
+        operator: "Equal"
+        value: "litmuspod"
+        effect: "NoSchedule"

--- a/apps/percona/chaos/drain_node/run_litmus_test.yml
+++ b/apps/percona/chaos/drain_node/run_litmus_test.yml
@@ -1,0 +1,82 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: node-failure-drain-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: node-failure-drain
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: test-node 
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+          - name: APP_NAMESPACE
+            value: app-percona-ns 
+
+          - name: APP_LABEL
+            value: 'name=percona'
+
+          - name: LIVENESS_APP_LABEL
+            value: "liveness=node-chaos"
+
+          - name: LIVENESS_APP_NAMESPACE
+            value: "litmus"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./percona/chaos/drain_node/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+          - name: logs
+            mountPath: /var/log/ansible
+        tty: true
+
+      - name: logger
+        image: openebs/logger
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # spec.volumes is not supported via downward API
+          - name: MY_POD_HOSTPATH
+            value: /mnt/chaos/node-failure-drain
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,percona; exit 0"]
+        volumeMounts:
+          - name: kubeconfig
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt
+        tty: true
+      volumes:
+        - name: kubeconfig
+          configMap:
+            name: kubeconfig
+        - name: logs
+          hostPath:
+            path: /mnt/chaos/node-failure-drain
+            type: ""
+
+      tolerations:
+      - key: "run"
+        operator: "Equal"
+        value: "litmuspod"
+        effect: "NoSchedule"

--- a/apps/percona/chaos/drain_node/test.yml
+++ b/apps/percona/chaos/drain_node/test.yml
@@ -1,0 +1,161 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - block:
+
+            - name: Get the liveness pods
+              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o=custom-columns=NAME:".metadata.name" --no-headers
+              register: liveness_pods_before_drain
+
+            - name: Checking status of liveness pods
+              shell: kubectl get pods {{ item }} -n {{ liveness_namespace }} -o=custom-columns=NAME:".status.phase" --no-headers
+              register: result
+              with_items: "{{ liveness_pods_before_drain.stdout_lines }}"
+              until: "'Running' in result.stdout"
+              delay: 10
+              retries: 10
+             
+          when: liveness_label != ''  
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+
+        - block:
+ 
+            - name: Record test instance/run ID 
+              set_fact: 
+                run_id: "{{ lookup('env','RUN_ID') }}"
+           
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+
+        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            chaostype: "drain-node"
+            app: "percona"
+            phase: in-progress
+            verdict: none
+
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"
+
+        ## DISPLAY APP INFORMATION 
+ 
+        - name: Display the app information passed via the test job
+          debug: 
+            msg: 
+              - "The application info is as follows:"
+              - "Namespace    : {{ namespace }}"
+              - "Label        : {{ label }}"
+
+        - name: Verify that the AUT (Application Under Test) is running
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          delay: 10
+          retries: 12
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
+        ## STORAGE FAULT INJECTION 
+
+        - include_tasks: /chaoslib/kubectl/cordon_drain_node.yaml
+          vars:
+            action: "drain"      
+            app_ns: "{{ namespace }}"
+            app: "{{ app_pod_name.stdout }}"
+
+        - name: Verify AUT liveness post fault-injection
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          delay: 10
+          retries: 12
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+        - block:
+
+            - name: Get the liveness pods
+              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o=custom-columns=NAME:".metadata.name" --no-headers
+              register: liveness_pods_after_drain
+
+            - name: Checking status of liveness pods
+              shell: kubectl get pods {{ item }} -n {{ liveness_namespace }} -o=custom-columns=NAME:".status.phase" --no-headers
+              register: result
+              with_items: "{{ liveness_pods_after_drain.stdout_lines }}"
+              until: "'Running' in result.stdout"
+              delay: 10
+              retries: 10
+             
+          when: liveness_label != ''  
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue: 
+        - set_fact: 
+            flag: "Fail"
+
+      always: 
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - name: Uncordon the application node
+          shell: >
+            kubectl uncordon {{ app_node }}
+          args:
+            executable: /bin/bash
+          register: result
+          until: "'uncordoned' in result.stdout"
+          delay: 20
+          retries: 12 
+
+        - name: Generate the litmus result CR to reflect EOT (End of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            chaostype: "drain-node"
+            app: "percona"
+            phase: completed
+            verdict: "{{ flag }}"
+           
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"
+           

--- a/apps/percona/chaos/drain_node/test_vars.yml
+++ b/apps/percona/chaos/drain_node/test_vars.yml
@@ -1,0 +1,7 @@
+test_name: node-failure-drain
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+label: "{{ lookup('env','APP_LABEL') }}"
+liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
+
+

--- a/apps/percona/liveness/run_litmus_test.yml
+++ b/apps/percona/liveness/run_litmus_test.yml
@@ -2,23 +2,14 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  generateName: mysql-liveness-check-
+  generateName: liveness-percona-check-
+  namespace: litmus
   labels:
     name: mysql-liveness-check
+    liveness: node-chaos
 spec:
 
   restartPolicy: Never
-
-  #affinity:
-  #  podAffinity: # (/podAntiAffinity)
-  #    requiredDuringSchedulingIgnoredDuringExecution:
-  #    - labelSelector:
-  #        matchExpressions:
-  #        - key: name
-  #          operator: In
-  #          values: 
-  #          - litmus # (/percona) 
-  #      topologyKey: kubernetes.io/hostname
 
   containers:
   - name: mysql-liveness-check
@@ -51,7 +42,13 @@ spec:
       - mountPath: /db-cred.cnf
         subPath: db-cred.cnf
         name: db-cred
+  tolerations:
+    - key: "run"
+      operator: "Equal"
+      value: "litmuspod"
+      effect: "NoSchedule"
   volumes:
     - name: db-cred
       configMap:
         name: db-cred  
+

--- a/chaoslib/kubectl/cordon_drain_node.yaml
+++ b/chaoslib/kubectl/cordon_drain_node.yaml
@@ -29,9 +29,10 @@
       args:
         executable: /bin/bash
       register: result
-      until: "'drained' in result.stdout"
+      until: "'cordoned' in result.stdout"
       delay: 20
       retries: 12
+      ignore_errors: true
     
     - name: Wait for application pod reschedule (evict)
       # Do not untaint until evict occurs
@@ -39,18 +40,4 @@
         timeout: 30
     
   when: action == "drain"
-
-- block:
-
-    - name: Uncordon the application node
-      shell: >
-        kubectl uncordon {{ app_node }}
-      args:
-        executable: /bin/bash
-      register: result
-      until: "'uncordoned' in result.stdout"
-      delay: 20
-      retries: 12
-      
-  when: action == "uncordon"
 

--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -176,7 +176,7 @@
           failed_when: "'m-apiserver status:  running' not in result_vers.stdout"
 
         - name: Getting the number of nodes
-          shell: kubectl get nodes --no-headers | grep -v master | wc -l
+          shell: kubectl describe node | grep -i taints | grep none | wc -l
           #  kubectl get nodes -o custom-columns=:spec.taints[*].key
           #  --no-headers | grep -iv master | wc -l
           args:
@@ -188,7 +188,7 @@
           args:
             executable: /bin/bash
           register: ndm_count
-          until: (node_count.stdout)|int == (ndm_count.stdout)|int
+          until: (node_count.stdout)|int >= (ndm_count.stdout)|int
           delay: 30
           retries: 100
 

--- a/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: openebs/ansible-runner:ci
+        image: dargas/ansible-runner:ci
         imagePullPolicy: Always
         env: 
           - name: mountPath


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Include a litmus book to perform node maintenance
- This test requires a cluster with 4 nodes and one node tainted to run only liveness and litmus pods.
- Pre-chaos and post chaos will verify the application pod status by verifying the liveness pod status

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
https://gitlab.openebs.ci/openebs/e2e-aws/pipelines/4356
