### PR TITLE
Add task for taint node with specified value

### DIFF
--- a/k8s/aws/k8s-installer/README.md
+++ b/k8s/aws/k8s-installer/README.md
@@ -38,12 +38,32 @@ ansible-playbook pre-requisite.yml -vv --extra-vars "vpc_name=<name-of-vpc>"
 ansible-playbook create-aws-cluster.yml -vv --extra-vars "k8s_version=<Kubernetes_version>"
 ```
 
+example:  
+
+```bash
+ansible-playbook create-aws-cluster.yml -vv --extra-vars "k8s_version=1.10.0"
+```
+
 **Optional**
 
-- User can also provide the Cluster name at the time of creation in `--extra-vars`
+--extra-vars
+
+1 - Set Cluster Name
 
 ```bash
 ansible-playbook create-aws-cluster.yml -vv --extra-vars "k8s_version=<Kubernetes_version> cluster_name=<name-of-cluster>"
+```
+
+2 - Taint Node with specific key, value and effect
+
+```bash
+ansible-playbook create-aws-cluster.yml -vv --extra-vars "k8s_version=<Kubernetes_version> taint_value=<key=value:effect>"
+```
+
+example:
+
+```bash
+ansible-playbook create-aws-cluster.yml -vv --extra-vars "k8s_version=1.10.0 taint_value=ak=av:NoSchedule"
 ```
 
 ### Deleting AWS cluster

--- a/k8s/aws/k8s-installer/create-aws-cluster.yml
+++ b/k8s/aws/k8s-installer/create-aws-cluster.yml
@@ -7,6 +7,7 @@
 #3. Creating aws bucket for storing cluster information
 #4. Creating cluster in aws using exixting VPC
 #5. Creating a file which store cluster name
+#6. Taint node if taint_value is defined
 ########################################################################################################################################################################
 
 ---
@@ -52,7 +53,24 @@
         
         - name: Checking Cluster availability
           shell: python ../../utils/health/cluster_health_check.py -n {{ node_count | int + 1 }}
-      
+
+        - block:
+            - name: Getting nodes name
+              shell: kubectl get nodes -o jsonpath='{.items[?(@.metadata.labels.kubernetes\.io/role=="node")].metadata.name}' | awk '{print $1}'
+              register: node_name
+
+            - name: Taint node using key and value
+              shell: kubectl taint nodes {{ node_name.stdout }} {{ taint_value }}
+
+            - name: Create a file for store taint node property
+              lineinfile:
+                create: yes
+                state: present
+                path: "/tmp/aws/node_property"
+                line: 'taint_node_name: {{ node_name.stdout }}, taint_value: {{ taint_value }}'
+                mode: 0755
+          when: taint_value is defined
+
         - name: Set Test Status
           set_fact:
             flag: "Test Passed"


### PR DESCRIPTION
Signed-off-by: Chandan Kumar <chandan.kr404@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Node taint task only execute only when taint_value is passed in
extra_vars


**Special notes for your reviewer**:

```
TASK [Getting nodes name] ***********************************************************************************************************************************************
changed: [localhost] => {"changed": true, "cmd": "kubectl get nodes -o jsonpath='{.items[?(@.metadata.labels.kubernetes\\.io/role==\"node\")].metadata.name}' | awk '{print $1}'", "delta": "0:00:00.855251", "end": "2018-10-29 15:15:23.405501", "rc": 0, "start": "2018-10-29 15:15:22.550250", "stderr": "", "stderr_lines": [], "stdout": "ip-10-0-1-119.eu-west-2.compute.internal", "stdout_lines": ["ip-10-0-1-119.eu-west-2.compute.internal"]}

TASK [Taint node using key and value] ***********************************************************************************************************************************
changed: [localhost] => {"changed": true, "cmd": "kubectl taint nodes ip-10-0-1-119.eu-west-2.compute.internal ak=av:NoSchedule", "delta": "0:00:00.898104", "end": "2018-10-29 15:15:24.438642", "rc": 0, "start": "2018-10-29 15:15:23.540538", "stderr": "", "stderr_lines": [], "stdout": "node/ip-10-0-1-119.eu-west-2.compute.internal tainted", "stdout_lines": ["node/ip-10-0-1-119.eu-west-2.compute.internal tainted"]}

TASK [Create a file for store taint node property] **********************************************************************************************************************
changed: [localhost] => {"backup": "", "changed": true, "msg": "line added and ownership, perms or SE linux context changed"}
```
```
└─ $ ▶ kubectl describe nodes ip-10-0-1-119.eu-west-2.compute.internal
Name:               ip-10-0-1-119.eu-west-2.compute.internal
Roles:              node
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=t2.xlarge
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=eu-west-2
                    failure-domain.beta.kubernetes.io/zone=eu-west-2a
                    kops.k8s.io/instancegroup=nodes
                    kubernetes.io/hostname=ip-10-0-1-119.eu-west-2.compute.internal
                    kubernetes.io/role=node
                    node-role.kubernetes.io/node=
Annotations:        node.alpha.kubernetes.io/ttl=0
                    volumes.kubernetes.io/controller-managed-attach-detach=true
CreationTimestamp:  Sun, 28 Oct 2018 20:18:05 +0530
Taints:             ak=av:NoSchedule
Unschedulable:      false
```
