### PR TITLE
crunchy_postgres_loadgen.yml

### DIFF
--- a/apps/crunchy-postgres/workload/crunchy_postgres_loadgen.yml
+++ b/apps/crunchy-postgres/workload/crunchy_postgres_loadgen.yml
@@ -1,0 +1,54 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: crunchy-loadgen
+spec:
+  template:
+    metadata:
+      name: crunchy-loadgen
+      labels:
+        app: crunchy-loadgen
+      
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: postgres-loadgen
+        image: openebs/postgres-client
+        imagePullPolicy: Always
+
+        env: 
+            # Time period (in sec) b/w retries for DB init check
+          - name: NAMESPACE
+            value: litmus
+    
+            # Service name of postgres application 
+          - name: SERVICE_NAME
+            value: pgset
+    
+            # Database Name 
+          - name: DATABASE_NAME
+            value: postgres
+    
+           # Password to access Database
+          - name: PASSWORD
+            value: password
+    
+           # Database user
+          - name: DATABASE_USER
+            value: testuser
+          
+            #Port on which crunchy databse is listening
+          - name: PORT
+            value: "5432"
+            
+            #Number of parallel transactions to perform
+          - name: PARALLEL_TRANSACTION
+            value: "5"
+            
+            #Number of transaction to perform
+          - name: TRANSACTIONS
+            value: "200"
+
+        command: ["/bin/bash"]
+        args: ["-c", "./test.sh ; exit 0"] 

--- a/apps/crunchy-postgres/workload/run_litmus_test.yml
+++ b/apps/crunchy-postgres/workload/run_litmus_test.yml
@@ -1,0 +1,26 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cruncy-postgres-loadgen 
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: crunchy_postgres-loadgen
+      namespace: litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: loadgen
+        image: openebs/ansible-runner:test
+        imagePullPolicy: Always
+        env: 
+        
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: actionable
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./crunchy-postgres/workload/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/crunchy-postgres/workload/test.yml
+++ b/apps/crunchy-postgres/workload/test.yml
@@ -1,0 +1,88 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+        # RECORD START-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            app: ""
+            chaostype: ""
+            phase: in-progress
+            verdict: none
+        
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"
+
+        - name: Create test specific namespace.
+          shell: kubectl create ns {{ namespace }}
+          args:
+           executable: /bin/bash
+          when: namespace != 'litmus'
+
+        - name: Checking the status  of test specific namespace.
+          shell: kubectl get ns {{ namespace }} -o jsonpath='{.status.phase}'
+          args:
+           executable: /bin/bash
+          register: npstatus
+          until: "'Active' in npstatus.stdout"
+          delay: 30
+          retries: 10
+        
+        - name: Create Cassandra Loadgen Job
+          shell: kubectl apply -f {{ crunchy_loadgen }} -n {{ namespace }} 
+
+        - name: Verify loadgen pod is running 
+          shell: kubectl get pods -n litmus -l app=crunchy-loadgen -o jsonpath='{.items[0].status.phase}'
+          args:
+            executable: /bin/bash
+          register: result
+          until: "'Running' in result.stdout"
+          delay: 30
+          retries: 15
+
+        - name: Verifying Load-generation
+          shell: kubectl exec -it pgset-0 -n {{ namespace }} -- psql -c '\dt'
+          register: output
+          until: "'pgbench_accounts' in output.stdout"
+          delay: 30
+          retries: 15
+
+        - set_fact:
+            flag: "loadgen_started"
+
+      rescue:
+        - set_fact:
+            flag: "loadgen_failed"  
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR 
+        - name: Generate the litmus result CR to reflect EOT (End of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            app: ""
+            chaostype: ""
+            phase: completed
+            verdict: "{{ flag }}"
+           
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"

--- a/apps/crunchy-postgres/workload/test_vars.yml
+++ b/apps/crunchy-postgres/workload/test_vars.yml
@@ -1,0 +1,3 @@
+crunchy_loadgen: crunchy_postgres_loadgen.yml
+namespace: litmus
+test_name: crunchy-postgres-loadgen


### PR DESCRIPTION

apiVersion: batch/v1
kind: Job
metadata:
  name: crunchy-loadgen
spec:
  template:
    metadata:
      name: crunchy-loadgen
      labels:
        app: crunchy-loadgen
      
    spec:
      restartPolicy: Never
      containers:
      - name: postgres-loadgen
        image: openebs/postgres-client
        imagePullPolicy: Always
         env: 
            # Time period (in sec) b/w retries for DB init check
          - name: NAMESPACE
            value: litmus
    
            # Service name of postgres application 
          - name: SERVICE_NAME
            value: pgset
    
            # Database Name 
          - name: DATABASE_NAME
            value: postgres
    
           # Password to access Database
          - name: PASSWORD
            value: password
    
           # Database user
          - name: DATABASE_USER
            value: testuser
          
            #Port on which crunchy databse is listening
          - name: PORT
            value: "5432"
            
            #Number of parallel transactions to perform
          - name: PARALLEL_TRANSACTION
            value: "5"
            
            #Number of transaction to perform
          - name: TRANSACTIONS
            value: "200"
         command: ["/bin/bash"]
        args: ["-c", "./test.sh ; exit 0"] 