### PR TITLE
test(yaml):Litmusbook to schedule persistent volumes with dedicated storage pool

### DIFF
--- a/apps/custom-storagepool/run_litmus_test.yml
+++ b/apps/custom-storagepool/run_litmus_test.yml
@@ -1,0 +1,57 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-sp-test-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: sp-test
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+ 
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-storageclass
+
+          - name: APP_PVC
+            value: storagepool-claim
+
+          - name: APP_NAMESPACE
+            value: sp
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./custom-storagepool/test.yml -i /etc/ansible/hosts -v; exit 0"]
+        volumeMounts:
+          - name: logs 
+            mountPath: /var/log/ansible 
+        tty: true
+      - name: logger
+        image: openebs/logger
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d 10 -r maya,openebs,pvc,memleak; exit 0"] 
+        volumeMounts:
+          - name: kubeconfig 
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt 
+        tty: true 
+      volumes: 
+        - name: kubeconfig
+          configMap: 
+            name: kubeconfig 
+        - name: logs 
+          hostPath:
+            path: /mnt/storagepool
+            type: "" 

--- a/apps/custom-storagepool/test.yml
+++ b/apps/custom-storagepool/test.yml
@@ -1,0 +1,123 @@
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+   - block:
+
+       - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+         when: lookup('env','RUN_ID')
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+       - include_tasks: /common/utils/update_litmus_result_resource.yml
+         vars:
+           status: 'SOT'
+
+       ## VERIFY AVAILABILITY OF SELECTED STORAGE CLASS
+
+       - name: Check whether the provider storageclass is applied
+         shell: kubectl get sc {{ lookup('env','PROVIDER_STORAGE_CLASS') }}
+         args:
+           executable: /bin/bash
+         register: result
+
+       - name: Replace the pvc placeholder with provider
+         replace:
+           path: "{{ test_pvc_yaml }}"
+           regexp: "testclaim"
+           replace: "{{ lookup('env','APP_PVC') }}"
+
+       - name: Create test specific namespace.
+         shell: kubectl create ns {{ app_ns }}
+         args:
+          executable: /bin/bash
+         when: app_ns != 'litmus'
+
+       - name: Checking the status  of test specific namespace.
+         shell: kubectl get ns {{ app_ns }} -o custom-columns=:status.phase --no-headers
+         args:
+          executable: /bin/bash
+         register: npstatus
+         until: "'Active' in npstatus.stdout"
+         delay: 30
+         retries: 10
+
+       - name: Replace the storageclass placeholder with provider
+         replace:
+           path: "{{ test_pvc_yaml }}"
+           regexp: "testclass"
+           replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+       - name: Deploy OpenEBS volume and run dd Load
+         shell: kubectl apply -f {{ test_pvc_yaml }} -n {{ app_ns }}
+         args:
+           executable: /bin/bash
+
+       - name: Confirm volume status is running
+         shell: >
+           kubectl get pods -n {{ app_ns }} -l openebs.io/persistent-volume-claim="{{app_pvc}}" -o custom-columns=:status.phase --no-headers
+         args:
+           executable: /bin/bash
+         register: result
+         until: "((result.stdout_lines|unique)|length) == 1 and 'Running' in result.stdout"
+         delay: 30
+         retries: 10
+
+       - name: Obtain the storage pool name from storageclass
+         shell: >
+           kubectl get sc {{ storageclass }} -o jsonpath="{.metadata.annotations.cas\\.openebs\\.io/config}" 
+           | grep -A1 "name: StoragePool" | awk NR==2 | cut -d ":" -f 2 | tr -d " "
+         args:
+           executable: /bin/bash
+         register: result_sp
+
+       - name: Get the mount path 
+         shell: kubectl get sp {{ result_sp.stdout }} -o jsonpath='{.spec.path}'
+         args:
+           executable: /bin/bash
+         register: mountpath
+
+       - name: Obtain the PV name
+         shell: kubectl get pvc -n {{ app_ns }} {{ app_pvc }} -o jsonpath='{.spec.volumeName}'
+         args: 
+           executable: /bin/bash
+         register: pv_name
+
+       - name: set the mountpath and pv name as variable
+         set_fact:
+           name: "{{ mountpath.stdout}}/{{pv_name.stdout }}"
+      
+       - name: Obtain the replica deployment hostpath
+         shell: kubectl get deployment -n {{ app_ns }} -l openebs.io/replica=jiva-replica -o jsonpath='{..path}'
+         args:
+           executable: /bin/bash
+         register: hostpath
+      
+       - debug:
+           msg: "PV scheduled in {{ mountpath.stdout }}"
+         when: "hostpath.stdout  ==  name"
+    
+       - set_fact:
+           flag: "Pass"
+
+     rescue:
+       - set_fact:
+           flag: "Fail"
+
+     always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+       - include_tasks: /common/utils/update_litmus_result_resource.yml
+         vars:
+           status: 'EOT'
+

--- a/apps/custom-storagepool/test_pvc.yml
+++ b/apps/custom-storagepool/test_pvc.yml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+spec:
+  storageClassName: testclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G

--- a/apps/custom-storagepool/test_vars.yml
+++ b/apps/custom-storagepool/test_vars.yml
@@ -1,0 +1,9 @@
+---
+## TEST-SPECIFIC PARAMS
+
+test_name: sp-test
+test_pvc_yaml: test_pvc.yml
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+storageclass: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+


### PR DESCRIPTION
Signed-off-by: sathyaseelan <sathyaseelan.n@cloudbyte.com>

- This PR will schedule the Persistent volumes with dedicated storage pool
- The dedicated storage pool and custom storage classes will be created by the litmus book storage-class setup.


```
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "a2e2a18ae412820034020770799f4bbf7cfc1fc5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "dd0e4de479471be5a4f5fb2707eb99e1", "mode": "0644", "owner": "root", "size": 408, "src": "/root/.ansible/tmp/ansible-tmp-1540892536.53-251066336753560/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "apply", "-f", "litmus-result.yaml"], "delta": "0:00:01.420152", "end": "2018-10-30 09:42:18.758421", "failed_when_result": false, "rc": 0, "start": "2018-10-30 09:42:17.338269", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/sp-test configured", "stdout_lines": ["litmusresult.litmus.io/sp-test configured"]}

TASK [Check whether the provider storageclass is applied] **********************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-storageclass", "delta": "0:00:00.948250", "end": "2018-10-30 09:42:19.905365", "rc": 0, "start": "2018-10-30 09:42:18.957115", "stderr": "", "stderr_lines": [], "stdout": "NAME                   PROVISIONER                    AGE\nopenebs-storageclass   openebs.io/provisioner-iscsi   1d", "stdout_lines": ["NAME                   PROVISIONER                    AGE", "openebs-storageclass   openebs.io/provisioner-iscsi   1d"]}

TASK [Replace the pvc placeholder with provider] *******************************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Create test specific namespace.] *****************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns sp", "delta": "0:00:00.908972", "end": "2018-10-30 09:42:21.308622", "rc": 0, "start": "2018-10-30 09:42:20.399650", "stderr": "", "stderr_lines": [], "stdout": "namespace/sp created", "stdout_lines": ["namespace/sp created"]}

TASK [Checking the status  of test specific namespace.] ************************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns sp -o custom-columns=:status.phase --no-headers", "delta": "0:00:00.909911", "end": "2018-10-30 09:42:22.402829", "rc": 0, "start": "2018-10-30 09:42:21.492918", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Replace the storageclass placeholder with provider] **********************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Deploy OpenEBS volume and run dd Load] ***********************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f test-pvc.yaml -n sp", "delta": "0:00:01.770812", "end": "2018-10-30 09:42:24.549033", "rc": 0, "start": "2018-10-30 09:42:22.778221", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/storagepool-claim-sp created", "stdout_lines": ["persistentvolumeclaim/storagepool-claim-sp created"]}

TASK [Confirm volume status is running] ****************************************
FAILED - RETRYING: Confirm volume status is running (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n sp -l openebs.io/persistent-volume-claim=\"storagepool-claim-sp\" -o custom-columns=:status.phase --no-headers", "delta": "0:00:00.924468", "end": "2018-10-30 09:42:56.881714", "rc": 0, "start": "2018-10-30 09:42:55.957246", "stderr": "", "stderr_lines": [], "stdout": "Running\nRunning\nRunning\nRunning", "stdout_lines": ["Running", "Running", "Running", "Running"]}

TASK [Obtain the storage pool name from storageclass] **************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-storageclass -o jsonpath=\"{.metadata.annotations.cas\\\\.openebs\\\\.io/config}\" | grep -A1 \"name: StoragePool\" | awk NR==2 | cut -d \":\" -f 2 | tr -d \" \"", "delta": "0:00:00.927368", "end": "2018-10-30 09:42:58.031926", "rc": 0, "start": "2018-10-30 09:42:57.104558", "stderr": "", "stderr_lines": [], "stdout": "openebs-mntdir", "stdout_lines": ["openebs-mntdir"]}

TASK [Get the mount path] ******************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sp openebs-mntdir -o jsonpath='{.spec.path}'", "delta": "0:00:00.922271", "end": "2018-10-30 09:42:59.142466", "rc": 0, "start": "2018-10-30 09:42:58.220195", "stderr": "", "stderr_lines": [], "stdout": "/mnt/openebs", "stdout_lines": ["/mnt/openebs"]}

TASK [Obtain the PV name] ******************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n sp storagepool-claim-sp -o jsonpath='{.spec.volumeName}'", "delta": "0:00:00.950172", "end": "2018-10-30 09:43:00.288292", "rc": 0, "start": "2018-10-30 09:42:59.338120", "stderr": "", "stderr_lines": [], "stdout": "pvc-1b05667f-dc28-11e8-a386-42010a800083", "stdout_lines": ["pvc-1b05667f-dc28-11e8-a386-42010a800083"]}

TASK [set the variable] ********************************************************
ok: [127.0.0.1] => {"ansible_facts": {"name": "/mnt/openebs/pvc-1b05667f-dc28-11e8-a386-42010a800083"}, "changed": false}

TASK [Obtain the replica deployment hostpath] **********************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deployment -n sp -l openebs.io/replica=jiva-replica -o jsonpath='{..path}'", "delta": "0:00:00.925832", "end": "2018-10-30 09:43:01.474085", "rc": 0, "start": "2018-10-30 09:43:00.548253", "stderr": "", "stderr_lines": [], "stdout": "/mnt/openebs/pvc-1b05667f-dc28-11e8-a386-42010a800083", "stdout_lines": ["/mnt/openebs/pvc-1b05667f-dc28-11e8-a386-42010a800083"]}

TASK [debug] *******************************************************************
ok: [127.0.0.1] => {
    "msg": "PV scheduled in /mnt/openebs"
}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "967a12b97c29fc2a4dcd689444c525cdb3379cec", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "7869196806608987867565c787eac734", "mode": "0644", "owner": "root", "size": 406, "src": "/root/.ansible/tmp/ansible-tmp-1540892581.68-106631101045949/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "apply", "-f", "litmus-result.yaml"], "delta": "0:00:01.044164", "end": "2018-10-30 09:43:04.798779", "failed_when_result": false, "rc": 0, "start": "2018-10-30 09:43:03.754615", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/sp-test configured", "stdout_lines": ["litmusresult.litmus.io/sp-test configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=19   changed=15   unreachable=0    failed=0
```
@ksatchit @dargasudarshan @gprasath  can you please review this PR