### PR TITLE
feat(yaml)(liveness): Add external liveness litmus job for percona application

### DIFF
--- a/apps/percona/liveness/db-cred.cnf
+++ b/apps/percona/liveness/db-cred.cnf
@@ -1,5 +1,0 @@
-{
-  "db_server_ip": "10.105.68.234",
-  "db_user": "root",
-  "db_password": "k8sDem0"
-}

--- a/apps/percona/liveness/run_litmus_test.yml
+++ b/apps/percona/liveness/run_litmus_test.yml
@@ -1,57 +1,85 @@
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
-  generateName: mysql-liveness-check-
-  labels:
-    name: mysql-liveness-check
+  generateName: percona-liveness-
+  namespace: litmus
 spec:
+  template:
+    metadata:
+      name: percona-liveness
+      namespace: litmus
+      labels:
+        # label used to track percona liveness job by ci-tool/test
+        liveness: percona-liveness
 
-  restartPolicy: Never
+        # label used for mass-liveness check upon infra-chaos
+        infra-aid: liveness
 
-  #affinity:
-  #  podAffinity: # (/podAntiAffinity)
-  #    requiredDuringSchedulingIgnoredDuringExecution:
-  #    - labelSelector:
-  #        matchExpressions:
-  #        - key: name
-  #          operator: In
-  #          values: 
-  #          - litmus # (/percona) 
-  #      topologyKey: kubernetes.io/hostname
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
 
-  containers:
-  - name: mysql-liveness-check
-    image: openebs/tests-mysql-client
-    env:
-        # Time period (in sec) b/w retries for DB init check
-      - name: INIT_WAIT_DELAY
-        value: "30"
+      #nodeSelector:
+      #  kubernetes.io/hostname:
 
-        # No of retries for DB init check 
-      - name: INIT_RETRY_COUNT
-        value: "10"
+      tolerations:
+        - key: "infra-aid"
+          value: "observer"
+          operator: "Equal"
+          effect: "NoSchedule"
+ 
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
 
-        # Time period (in sec) b/w liveness checks
-      - name: LIVENESS_PERIOD_SECONDS
-        value: "10"
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
 
-        # Time period (in sec) b/w retries for db_connect failure
-      - name: LIVENESS_TIMEOUT_SECONDS
-        value: "10"
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./percona/liveness/test.yml -i /etc/ansible/hosts -v; exit 0"]
 
-        # No of retries after a db_connect failure before declaring liveness fail
-      - name: LIVENESS_RETRY_COUNT
-        value: "6"
+      - name: percona-liveness  
+        image: openebs/tests-mysql-client
+        env:
+          # Time period (in sec) b/w retries for DB init check
+          - name: INIT_WAIT_DELAY
+            value: "30"
+ 
+          # No of retries for DB init check
+          - name: INIT_RETRY_COUNT
+            value: "10"
 
-    command: ["/bin/bash"]
-    args: ["-c", "bash mysql-liveness-check.sh db-cred.cnf ; exit 0"]
-    tty: true 
-    volumeMounts:
-      - mountPath: /db-cred.cnf
-        subPath: db-cred.cnf
-        name: db-cred
-  volumes:
-    - name: db-cred
-      configMap:
-        name: db-cred  
+          # Time period (in sec) b/w liveness checks
+          - name: LIVENESS_PERIOD_SECONDS
+            value: "10"
+
+          # Time period (in sec) b/w retries for db_connect failure            
+          - name: LIVENESS_TIMEOUT_SECONDS
+            value: "10"
+
+          # No of retries after a db_connect failure before declaring liveness fail
+          - name: LIVENESS_RETRY_COUNT
+            value: "6"
+
+          # Application service label
+          - name: DB_SVC 
+            value: percona-mysql.app-percona-ns.svc.cluster.local 
+
+          # Database username  
+          - name: DB_USER
+            value: root
+ 
+          # Database password
+          - name: DB_PASSWORD
+            value: k8sDem0
+
+        command: ["/bin/bash"]
+        args: ["-c", "bash mysql-liveness-check.sh; exit 0"]
+        tty: true 

--- a/apps/percona/liveness/test.yml
+++ b/apps/percona/liveness/test.yml
@@ -1,0 +1,64 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+        
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - name: Checking whether liveness container is running
+          shell: >
+            kubectl get pod {{ test_pod }} -n litmus 
+            -o jsonpath='{.status.containerStatuses[?(@.name=="percona-liveness")].state}'
+          register: container_status
+          until: "'running' in container_status.stdout"
+          delay: 60
+          retries: 10
+
+        - name: Verifying whether liveness check is started successfully  
+          shell: kubectl logs {{ test_pod }} -n litmus -c percona-liveness 
+          register: output
+          until: "liveness_log in output.stdout"
+          delay: 60 # Setting an upper bound that is >> general db init delays
+          retries: 20
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+
+        ## if flag=fail, task exits immediately; if flag=pass, runs indefinitely until liveness check ends
+        - name: Run until liveness container is terminated
+          shell: |
+            cmd="kubectl get pod {{ test_pod }} -n litmus -o jsonpath='{.status.containerStatuses[?(@.name==\"percona-liveness\")].state}'"
+            while [[ ! $(eval $cmd) =~ 'terminated' ]]; do sleep 1; done
+          args:
+            executable: /bin/bash
+          register: output

--- a/apps/percona/liveness/test_vars.yml
+++ b/apps/percona/liveness/test_vars.yml
@@ -1,0 +1,3 @@
+test_name: percona-liveness
+test_pod: "{{ lookup('env','MY_POD_NAME') }}"
+liveness_log: "MySQL db server is alive"


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

The liveness jobs need to be enhanced in order to aid launch/monitor from CI tools such as gitlab & made consistent with other "test" job types in litmus (deploy/workload/functional/chaos) 

- Replace a plain K8s job with a litmus job
- Use env vars to accept database cred info (remove conf files, as this necessitates users to run an additional step to create configmap before they can execute the liveness job) 
- Launch liveness container as a sidecar to ansible runner
- Monitor liveness status via ansible runner & update result CRs
- Use placeholders for nodeselector & add taint-toleration to aid infra-chaos tests, where the liveness pod can be isolated by running them on non-participating nodes.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
