### PR TITLE
Add a litmusbook for jenkins liveness

### DIFF
--- a/apps/jenkins/liveness/run_litmus_test.yml
+++ b/apps/jenkins/liveness/run_litmus_test.yml
@@ -1,0 +1,87 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: jenkins-liveness-
+  namespace: litmus
+spec:
+  activeDeadlineSeconds: 5400
+  template:
+    metadata:
+      name: jenkins-liveness
+      namespace: litmus
+      labels:
+        # label used to track percona liveness job by ci-tool/test
+        liveness: jenkins-liveness
+
+        # label used for mass-liveness check upon infra-chaos
+        infra-aid: liveness
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+
+      #nodeSelector:
+      #  kubernetes.io/hostname:
+
+      tolerations:
+        - key: "infra-aid"
+          value: "observer"
+          operator: "Equal"
+          effect: "NoSchedule"
+ 
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./jenkins/liveness/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+      - name: jenkins-liveness  
+        image: openebs/tests-custom-client
+        imagePullPolicy: Always
+
+        env:
+
+            # Time period (in sec) b/w retries for DB init check
+          - name: INIT_WAIT_DELAY
+            value: "30"
+
+            # No of retries for DB init check
+          - name: INIT_RETRY_COUNT
+            value: "10"
+
+            # Time period (in sec) b/w liveness checks
+          - name: LIVENESS_PERIOD_SECONDS
+            value: "10"
+
+            # Time period (in sec) b/w retries for db_connect failure
+          - name: LIVENESS_TIMEOUT_SECONDS
+            value: "10"
+
+            # No of retries after a db_connect failure before declaring liveness fail
+          - name: LIVENESS_RETRY_COUNT
+            value: "6"
+
+            # Namespace in which mongo is running
+          - name: NAMESPACE
+            value: app-jenkins-ns
+
+            # Servive name of cassandra
+          - name: SERVICE
+            value: jenkins-svc
+
+          - name: PORT
+            value: "80"  
+
+        command: ["/bin/bash"]
+        args: ["-c", "python ./liveness.py ; exit 0"]

--- a/apps/jenkins/liveness/test.yml
+++ b/apps/jenkins/liveness/test.yml
@@ -1,0 +1,65 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+        
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - name: Checking whether liveness container is running
+          shell: >
+            kubectl get pod {{ test_pod }} -n litmus 
+            -o jsonpath='{.status.containerStatuses[?(@.name=="jenkins-liveness")].state}'
+          register: container_status
+          until: "'running' in container_status.stdout"
+          delay: 60
+          retries: 10
+
+        - name: Verifying whether liveness check is started successfully  
+          shell: kubectl logs {{ test_pod }} -n litmus -c jenkins-liveness 
+          register: output
+          until: "liveness_log in output.stdout"
+          delay: 60 # Setting an upper bound that is >> general db init delays
+          retries: 20
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+        
+        ## if flag=fail, task exits immediately; if flag=pass, runs indefinitely until liveness check ends.
+        - name: Run until liveness container is terminated
+          shell: |
+            cmd="kubectl get pod {{ test_pod }} -n litmus -o jsonpath='{.status.containerStatuses[?(@.name==\"jenkins-liveness\")].state}'"
+            while true; do state=$(eval $cmd); rc=$?; if [[ $rc -eq 0 && ! $state =~ 'terminated' ]]; then sleep 1; else exit; fi; done
+          args:
+            executable: /bin/bash
+          register: output
+          when: flag == "Pass"

--- a/apps/jenkins/liveness/test_vars.yml
+++ b/apps/jenkins/liveness/test_vars.yml
@@ -1,0 +1,3 @@
+test_name: jenkins-liveness
+test_pod: "{{ lookup('env','MY_POD_NAME') }}"
+liveness_log: "Liveness Running" 


### PR DESCRIPTION
**Following is the log of the ansible-test container:**
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "c9af89d1c807c8adf39faaeeb058eeede023414d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "d88f69aa88be120eeddd9a188d4ea360", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1541684322.31-10474968114333/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.070314", "end": "2018-11-08 13:38:42.989506", "rc": 0, "start": "2018-11-08 13:38:42.919192", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jenkins-liveness \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jenkins-liveness ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.301218", "end": "2018-11-08 13:38:43.429867", "failed_when_result": false, "rc": 0, "start": "2018-11-08 13:38:43.128649", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/jenkins-liveness configured", "stdout_lines": ["litmusresult.litmus.io/jenkins-liveness configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking whether liveness container is running] **************************
FAILED - RETRYING: Checking whether liveness container is running (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod cassandra-liveness-sw2bx-cdbqp -n litmus -o jsonpath='{.status.containerStatuses[?(@.name==\"jenkins-liveness\")].state}'", "delta": "0:00:00.145803", "end": "2018-11-08 13:39:44.164579", "rc": 0, "start": "2018-11-08 13:39:44.018776", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2018-11-08T13:38:44Z]]", "stdout_lines": ["map[running:map[startedAt:2018-11-08T13:38:44Z]]"]}

TASK [Verifying whether liveness check is started successfully] ****************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl logs cassandra-liveness-sw2bx-cdbqp -n litmus -c jenkins-liveness", "delta": "0:00:00.162423", "end": "2018-11-08 13:39:44.485603", "rc": 0, "start": "2018-11-08 13:39:44.323180", "stderr": "", "stderr_lines": [], "stdout": "pass True\nLiveness Running\nLiveness Running\nLiveness Running", "stdout_lines": ["pass True", "Liveness Running", "Liveness Running", "Liveness Running"]}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "05222dce55a75300716c21fe205c0e5dc16d0128", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "b6bc608a6e29fbc6f5daae146a3b50ba", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1541684384.74-271373973353409/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.070167", "end": "2018-11-08 13:39:45.257138", "rc": 0, "start": "2018-11-08 13:39:45.186971", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: jenkins-liveness \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: jenkins-liveness ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.253558", "end": "2018-11-08 13:39:45.657497", "failed_when_result": false, "rc": 0, "start": "2018-11-08 13:39:45.403939", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/jenkins-liveness configured", "stdout_lines": ["litmusresult.litmus.io/jenkins-liveness configured"]}

TASK [Run until liveness container is terminated] ******************************
```
