### PR TITLE
Add a util for Data Persistence

### DIFF
--- a/apps/percona/chaos/cstor_pool_failure/test.yml
+++ b/apps/percona/chaos/cstor_pool_failure/test.yml
@@ -20,9 +20,27 @@
           when: liveness_label != ''  
 
         - include: test_prerequisites.yml
-  
+
+        - name: Get application pod name 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name 
+
+        - name: Create some test data in the mysql database
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'
+
         - include_vars:
-            file: chaosutil.yml
+            file: chaosutil.yml    
 
         - name: Record the chaos util path
           set_fact: 
@@ -89,6 +107,16 @@
           until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
           delay: 10
           retries: 12
+
+        - name: Verify mysql data persistence  
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'
 
         - block:
 

--- a/apps/percona/chaos/openebs_replica_network_delay/test.yml
+++ b/apps/percona/chaos/openebs_replica_network_delay/test.yml
@@ -62,6 +62,24 @@
           delay: 10
           retries: 12
 
+        - name: Get application pod name 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name  
+
+        - name: Create some test data in the mysql database
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'       
+
         ## STORAGE FAULT INJECTION 
 
         - include: "{{ chaos_util_path }}"
@@ -82,6 +100,16 @@
           until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
           delay: 10
           retries: 12
+
+        - name: Verify mysql data persistence  
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'  
 
         - set_fact:
             flag: "Pass"

--- a/apps/percona/chaos/openebs_target_failure/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_target_failure/run_litmus_test.yml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: openebs/ansible-runner:test
+        image: openebs/ansible-runner:ci
         env:
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays

--- a/apps/percona/chaos/openebs_target_failure/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_target_failure/run_litmus_test.yml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: openebs/ansible-runner:ci
+        image: openebs/ansible-runner:test
         env:
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays

--- a/apps/percona/chaos/openebs_target_failure/test.yml
+++ b/apps/percona/chaos/openebs_target_failure/test.yml
@@ -73,6 +73,24 @@
           delay: 10
           retries: 12
 
+        - name: Get application pod name 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name  
+
+        - name: Create some test data in the mysql database
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'      
+
         ## STORAGE FAULT INJECTION 
 
         - include: "{{ chaos_util_path }}"
@@ -103,6 +121,16 @@
               retries: 10
 
           when: liveness_label != ''
+
+        - name: Verify mysql data persistence  
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'      
 
         - set_fact:
             flag: "Pass"

--- a/apps/percona/chaos/openebs_target_network_delay/test.yml
+++ b/apps/percona/chaos/openebs_target_network_delay/test.yml
@@ -72,6 +72,24 @@
           delay: 10
           retries: 12
 
+        - name: Get application pod name 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
+        - name: Create some test data in the mysql database
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'     
+
         ## STORAGE FAULT INJECTION 
 
         - include: "{{ chaos_util_path }}"
@@ -103,6 +121,16 @@
               retries: 10
 
           when: liveness_label != ''
+
+        - name: Verify mysql data persistence  
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'    
           
         - set_fact:
             flag: "Pass"

--- a/apps/percona/chaos/openebs_volume_replica_failure/test.yml
+++ b/apps/percona/chaos/openebs_volume_replica_failure/test.yml
@@ -72,6 +72,24 @@
           delay: 10
           retries: 12
 
+        - name: Get application pod name 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
+        - name: Create some test data in the mysql database
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'      
+
         ## STORAGE FAULT INJECTION 
 
         - include: "{{ chaos_util_path }}"
@@ -101,6 +119,16 @@
               retries: 10
              
           when: liveness_label != ''  
+
+        - name: Verify mysql data persistence  
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'  
 
         - set_fact:
             flag: "Pass"

--- a/apps/percona/tests/mysql_data_persistence/test.yml
+++ b/apps/percona/tests/mysql_data_persistence/test.yml
@@ -76,17 +76,14 @@
          retries: 30 
 
        - name: Create some test data in the mysql database
-         shell: >
-           kubectl exec {{ percona_pod_name }} -n litmus 
-           -- {{ item }}
-         args:
-           executable: /bin/bash
-         register: result
-         failed_when: "result.rc != 0"
-         with_items:
-           - mysql -uroot -pk8sDem0 -e 'create database tdb;'
-           - mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb
-           - mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb
+         include_tasks: "/common/utils/mysql_data_persistence.yml"
+         vars:
+           status: 'LOAD'
+           ns: 'litmus'
+           pod_name: "{{ percona_pod_name }}"
+           dbuser: 'root'
+           dbpassword: 'k8sDem0'
+           dbname: 'tdb'
 
        - include: /chaoslib/kubectl/pod_evict_by_taint.yaml
          app: "{{ percona_pod_name }}"
@@ -122,13 +119,15 @@
            percona_pod_name: "{{ result.stdout.split()[0] }}"
        
        - name: Verify mysql data persistence  
-         shell: > 
-           kubectl exec {{ percona_pod_name }} -n litmus
-           -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' tdb;
-         args:
-           executable: /bin/bash
-         register: result 
-         failed_when: "'tdata' not in result.stdout"
+         include_tasks: "/common/utils/mysql_data_persistence.yml"
+         vars:
+           status: 'VERIFY'
+           ns: 'litmus'
+           pod_name: "{{ percona_pod_name }}"
+           dbuser: 'root'
+           dbpassword: 'k8sDem0'
+           dbname: 'tdb'
+
 
        - set_fact:
            flag: "Pass"

--- a/common/utils/mysql_data_persistence.yml
+++ b/common/utils/mysql_data_persistence.yml
@@ -1,0 +1,39 @@
+---
+- block:
+
+   - name: Create some test data in the mysql database
+     shell: >
+       kubectl exec {{ pod_name }} -n {{ ns }} 
+       -- {{ item }}
+     args:
+       executable: /bin/bash
+     register: result
+     failed_when: "result.rc != 0"
+     with_items:
+       - mysql -u{{ dbuser }} -p{{ dbpassword }} -e 'create database {{ dbname }};'
+       - mysql -u{{ dbuser }} -p{{ dbpassword }} -e 'create table ttbl (Data VARCHAR(20));' {{ dbname }}
+       - mysql -u{{ dbuser }} -p{{ dbpassword }} -e 'insert into ttbl (Data) VALUES ("tdata");' {{ dbname }}
+
+  when: status == "LOAD"
+
+- block:
+
+   - name: Checking for the Corrupted tables
+     shell: > 
+       kubectl exec {{ pod_name }} -n {{ ns }}
+       -- mysqlcheck -c {{ dbname }} -u{{ dbuser }} -p{{ dbpassword }}
+     args:
+       executable: /bin/bash
+     register: status 
+     failed_when: "'OK' not in status.stdout"
+
+   - name: Verify mysql data persistence 
+     shell: > 
+           kubectl exec {{ pod_name }} -n {{ ns }}
+           -- mysql -u{{ dbuser }} -p{{ dbpassword }} -e 'select * from ttbl' tdb;
+     args:
+       executable: /bin/bash
+     register: result 
+     failed_when: "'tdata' not in result.stdout"   
+
+  when: status == "VERIFY"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add a util for data persistence.
- Include data-persistence check in the following chaos:
 1. cstor-pool failure
 2. target-failure
 3. target-network delay
 4. volume-replica failure
 5. replica-network delay

**Special notes for your reviewer**:
- Use for **mysqlcheck** command is been included for checking the data-persistence. It check for all the corrupted tables in the database. 
**Following is the log for target_network_delay:**
```

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:2
ok: [127.0.0.1]
META: ran handlers

TASK [Checking status of liveness pod] *****************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:2
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:00.174745", "end": "2018-11-11 16:56:43.778214", "rc": 0, "start": "2018-11-11 16:56:43.603469", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-sparse", "stdout_lines": ["openebs-cstor-sparse"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:10
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse --no-headers -o custom-columns=:provisioner", "delta": "0:00:00.138768", "end": "2018-11-11 16:56:44.062617", "rc": 0, "start": "2018-11-11 16:56:43.923849", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:18
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-cstor-sparse"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:22
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:27
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.163240", "end": "2018-11-11 16:56:44.481676", "rc": 0, "start": "2018-11-11 16:56:44.318436", "stderr": "", "stderr_lines": [], "stdout": "pvc-984acb67-e5c7-11e8-9413-02b983f0a4db", "stdout_lines": ["pvc-984acb67-e5c7-11e8-9413-02b983f0a4db"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:35
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-984acb67-e5c7-11e8-9413-02b983f0a4db --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:00.137638", "end": "2018-11-11 16:56:44.790192", "rc": 0, "start": "2018-11-11 16:56:44.652554", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:43
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:48
changed: [127.0.0.1] => {"changed": true, "checksum": "7ca53b55dd148c2150224ec1125fbc53928c4b45", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "50c961263ae78c55b30340eb6d3711ae", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1541955404.96-90206920762977/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:25
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_network_delay.yaml"}, "ansible_included_var_files": ["/percona/chaos/openebs_target_network_delay/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:28
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_network_delay.yaml"}, "changed": false}

TASK [Record test instance/run ID] *********************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:36
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:40
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:46
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
changed: [127.0.0.1] => {"changed": true, "checksum": "d033ea974d5ef085c993c50e7a6f965c34548b8d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "847944374d12ae8e25882f4315d7c96c", "mode": "0644", "owner": "root", "size": 463, "src": "/root/.ansible/tmp/ansible-tmp-1541955405.62-161771001933940/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.067299", "end": "2018-11-11 16:56:46.002252", "rc": 0, "start": "2018-11-11 16:56:45.934953", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.226242", "end": "2018-11-11 16:56:46.370866", "failed_when_result": false, "rc": 0, "start": "2018-11-11 16:56:46.144624", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-delay created", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-delay created"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /percona/chaos/openebs_target_network_delay/test.yml:53
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : app-percona-ns", 
        "Label        : name=percona", 
        "PVC          : percona-mysql-claim", 
        "StorageClass : openebs-cstor-sparse"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /percona/chaos/openebs_target_network_delay/test.yml:64
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.200292", "end": "2018-11-11 16:56:46.956403", "rc": 0, "start": "2018-11-11 16:56:46.756111", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:75
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.155800", "end": "2018-11-11 16:56:47.285392", "rc": 0, "start": "2018-11-11 16:56:47.129592", "stderr": "", "stderr_lines": [], "stdout": "percona-786c6b7c7f-4cnnw", "stdout_lines": ["percona-786c6b7c7f-4cnnw"]}

TASK [Create some test data in the mysql database] *****************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:83
included: /common/utils/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /common/utils/mysql_data_persistence.yml:4
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;') => {"changed": true, "cmd": "kubectl exec percona-786c6b7c7f-4cnnw -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database tdb;'", "delta": "0:00:00.267057", "end": "2018-11-11 16:56:47.780739", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "rc": 0, "start": "2018-11-11 16:56:47.513682", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb) => {"changed": true, "cmd": "kubectl exec percona-786c6b7c7f-4cnnw -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "delta": "0:00:00.681652", "end": "2018-11-11 16:56:48.622965", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "rc": 0, "start": "2018-11-11 16:56:47.941313", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb) => {"changed": true, "cmd": "kubectl exec percona-786c6b7c7f-4cnnw -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "delta": "0:00:00.303067", "end": "2018-11-11 16:56:49.096421", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "rc": 0, "start": "2018-11-11 16:56:48.793354", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Verify mysql data persistence] *******************************************
task path: /common/utils/mysql_data_persistence.yml:21
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:95
included: /chaoslib/openebs/cstor_target_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:1
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n app-percona-ns", "delta": "0:00:00.261416", "end": "2018-11-11 16:56:49.616559", "rc": 0, "start": "2018-11-11 16:56:49.355143", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:9
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n app-percona-ns | sort | uniq", "delta": "0:00:00.153557", "end": "2018-11-11 16:57:10.322721", "rc": 0, "start": "2018-11-11 16:57:10.169164", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:21
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n app-percona-ns --no-headers", "delta": "0:00:00.145688", "end": "2018-11-11 16:57:10.634812", "rc": 0, "start": "2018-11-11 16:57:10.489124", "stderr": "", "stderr_lines": [], "stdout": "pvc-984acb67-e5c7-11e8-9413-02b983f0a4db", "stdout_lines": ["pvc-984acb67-e5c7-11e8-9413-02b983f0a4db"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:30
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-984acb67-e5c7-11e8-9413-02b983f0a4db | shuf -n1 | awk '{print $1}'", "delta": "0:00:00.151781", "end": "2018-11-11 16:57:10.939641", "rc": 0, "start": "2018-11-11 16:57:10.787860", "stderr": "", "stderr_lines": [], "stdout": "pvc-984acb67-e5c7-11e8-9413-02b983f0a4db-target-7f4f97b59b559hm", "stdout_lines": ["pvc-984acb67-e5c7-11e8-9413-02b983f0a4db-target-7f4f97b59b559hm"]}

TASK [Record the cstor target container name] **********************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:39
ok: [127.0.0.1] => {"ansible_facts": {"cstor_target_name": "pvc-984acb67-e5c7-11e8-9413-02b983f0a4db"}, "changed": false}

TASK [Get the node on which the cstor target is scheduled] *********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:44
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-984acb67-e5c7-11e8-9413-02b983f0a4db-target-7f4f97b59b559hm -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.148134", "end": "2018-11-11 16:57:11.314147", "rc": 0, "start": "2018-11-11 16:57:11.166013", "stderr": "", "stderr_lines": [], "stdout": "kubeminion-02", "stdout_lines": ["kubeminion-02"]}

TASK [Identify the pumba pod that co-exists with cstor target] *****************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:52
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n app-percona-ns -o jsonpath='{.items[?(@.spec.nodeName==''\"kubeminion-02\"'')].metadata.name}'", "delta": "0:00:00.144398", "end": "2018-11-11 16:57:11.611104", "rc": 0, "start": "2018-11-11 16:57:11.466706", "stderr": "", "stderr_lines": [], "stdout": "pumba-pq5mt", "stdout_lines": ["pumba-pq5mt"]}

TASK [Inject egress delay of 3000ms on cstor target for 60s] *******************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:60
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-pq5mt -n app-percona-ns -- pumba netem --interface eth0 --duration 60s delay --time 3000 re2:k8s_cstor-istgt_pvc-984acb67-e5c7-11e8-9413-02b983f0a4db", "delta": "0:01:00.863168", "end": "2018-11-11 16:58:12.640917", "rc": 0, "start": "2018-11-11 16:57:11.777749", "stderr": "time=\"2018-11-11T16:57:12Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2018-11-11T16:57:12Z\" level=info msg=\"Running netem command '[delay 3000ms 10ms 20.00]' on container dc6ed65aa4ce816f13d226887efade78e6add298fd3da85c38fff5056d2a9560 for 1m0s\" \ntime=\"2018-11-11T16:57:12Z\" level=info msg=\"Start netem for container dc6ed65aa4ce816f13d226887efade78e6add298fd3da85c38fff5056d2a9560 on 'eth0' with command '[delay 3000ms 10ms 20.00]'\" \ntime=\"2018-11-11T16:58:12Z\" level=info msg=\"Stopping netem on container dc6ed65aa4ce816f13d226887efade78e6add298fd3da85c38fff5056d2a9560\" \ntime=\"2018-11-11T16:58:12Z\" level=info msg=\"Stop netem for container dc6ed65aa4ce816f13d226887efade78e6add298fd3da85c38fff5056d2a9560 on 'eth0'\" ", "stderr_lines": ["time=\"2018-11-11T16:57:12Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2018-11-11T16:57:12Z\" level=info msg=\"Running netem command '[delay 3000ms 10ms 20.00]' on container dc6ed65aa4ce816f13d226887efade78e6add298fd3da85c38fff5056d2a9560 for 1m0s\" ", "time=\"2018-11-11T16:57:12Z\" level=info msg=\"Start netem for container dc6ed65aa4ce816f13d226887efade78e6add298fd3da85c38fff5056d2a9560 on 'eth0' with command '[delay 3000ms 10ms 20.00]'\" ", "time=\"2018-11-11T16:58:12Z\" level=info msg=\"Stopping netem on container dc6ed65aa4ce816f13d226887efade78e6add298fd3da85c38fff5056d2a9560\" ", "time=\"2018-11-11T16:58:12Z\" level=info msg=\"Stop netem for container dc6ed65aa4ce816f13d226887efade78e6add298fd3da85c38fff5056d2a9560 on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:68
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:72
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n app-percona-ns", "delta": "0:00:00.155883", "end": "2018-11-11 16:58:23.263943", "rc": 0, "start": "2018-11-11 16:58:23.108060", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:78
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n app-percona-ns", "delta": "0:00:00.155129", "end": "2018-11-11 16:58:23.665830", "rc": 0, "start": "2018-11-11 16:58:23.510701", "stderr": "", "stderr_lines": [], "stdout": "pumba-9skt2   1/1   Terminating   0     1m\npumba-pq5mt   1/1   Terminating   0     1m\npumba-v4xs4   1/1   Terminating   0     1m", "stdout_lines": ["pumba-9skt2   1/1   Terminating   0     1m", "pumba-pq5mt   1/1   Terminating   0     1m", "pumba-v4xs4   1/1   Terminating   0     1m"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:103
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.246435", "end": "2018-11-11 16:58:24.068622", "rc": 0, "start": "2018-11-11 16:58:23.822187", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking status of liveness pod] *****************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:116
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:125
included: /common/utils/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /common/utils/mysql_data_persistence.yml:4
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /common/utils/mysql_data_persistence.yml:21
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-786c6b7c7f-4cnnw -n app-percona-ns -- mysqlcheck -c tdb -uroot -pk8sDem0", "delta": "0:00:00.306549", "end": "2018-11-11 16:58:24.695824", "failed_when_result": false, "rc": 0, "start": "2018-11-11 16:58:24.389275", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "tdb.ttbl                                           OK", "stdout_lines": ["tdb.ttbl                                           OK"]}

TASK [set_fact] ****************************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:135
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:146
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
changed: [127.0.0.1] => {"changed": true, "checksum": "e7f0f790b1fb82156ee809c231d7445cd5cd07b5", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "89296e59cc89d49e5b7cbb6d0f0c8848", "mode": "0644", "owner": "root", "size": 461, "src": "/root/.ansible/tmp/ansible-tmp-1541955505.01-75557486560926/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.069397", "end": "2018-11-11 16:58:25.588755", "rc": 0, "start": "2018-11-11 16:58:25.519358", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.202363", "end": "2018-11-11 16:58:25.985640", "failed_when_result": false, "rc": 0, "start": "2018-11-11 16:58:25.783277", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-delay configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=40   changed=25   unreachable=0    failed=0  
```