### PR TITLE
Add a litmusbook and util for cstor-pool network delay

### DIFF
--- a/apps/percona/chaos/openebs_cstor-pool_network_delay/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_cstor-pool_network_delay/run_litmus_test.yml
@@ -1,0 +1,84 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: openebs-cstor-pool-network-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: openebs-cstor-pool-network
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+          - name: APP_NAMESPACE
+            value: app-percona-ns 
+
+          - name: TARGET_NAMESPACE
+            value: openebs
+
+          - name: APP_LABEL
+            value: 'name=percona'
+
+          - name: APP_PVC
+            value: percona-mysql-claim
+
+          - name: CHAOS_DURATION
+            value: '15'
+
+          - name: NETWORK_DELAY
+            value: '20'    
+
+          - name: LIVENESS_APP_LABEL
+            value: ""
+
+          - name: LIVENESS_APP_NAMESPACE
+            value: ""
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./percona/chaos/openebs_cstor-pool_network_delay/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+          - name: logs
+            mountPath: /var/log/ansible
+        tty: true
+      - name: logger
+        image: openebs/logger
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # spec.volumes is not supported via downward API
+          - name: MY_POD_HOSTPATH
+            value: /mnt/chaos/openebs-cstor-target-failure
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,percona; exit 0"]
+        volumeMounts:
+          - name: kubeconfig
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt
+        tty: true
+      volumes:
+        - name: kubeconfig
+          configMap:
+            name: kubeconfig
+        - name: logs
+          hostPath:
+            path: /mnt/chaos/openebs_cstorpool_failure
+            type: ""

--- a/apps/percona/chaos/openebs_cstor-pool_network_delay/test.yml
+++ b/apps/percona/chaos/openebs_cstor-pool_network_delay/test.yml
@@ -1,0 +1,115 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+        ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE       
+        - block:
+
+            - name: Checking status of liveness pod
+              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
+              register: liveness_pod
+              until: "'Running' in liveness_pod.stdout"
+              delay: 10
+              retries: 10
+             
+          when: liveness_label != ''  
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+
+        - block: 
+          
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')     
+
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "{{ test_name }}"
+
+        ## DISPLAY APP INFORMATION 
+ 
+        - name: Display the app information passed via the test job
+          debug: 
+            msg: 
+              - "The application info is as follows:"
+              - "Namespace           : {{ namespace }}"
+              - "Target Namespace    : {{ target_namespace }}"
+              - "Label               : {{ label }}"
+              - "PVC                 : {{ pvc }}"  
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify that the AUT (Application Under Test) is running 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          delay: 10
+          retries: 12
+
+        ## STORAGE FAULT INJECTION 
+
+        - include: "/chaoslib/openebs/cstor_pool_network_delay.yml"
+          vars:
+            ns: "{{ namespace }}"
+            app_label: "{{ label }}"
+            target_ns: "{{ target_namespace }}"
+            chaos_duration: "{{ lookup('env','CHAOS_DURATION') }}"
+            network_delay: "{{ lookup('env','NETWORK_DELAY') }}"
+          
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify AUT liveness post fault-injection
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          delay: 10
+          retries: 12
+        
+        - block:
+
+            - name: Checking status of liveness pod
+              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
+              register: liveness_pod
+              until: "'Running' in liveness_pod.stdout"
+              delay: 10
+              retries: 10
+
+          when: liveness_label != ''
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue: 
+        - set_fact: 
+            flag: "Fail"
+
+      always: 
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+ 
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+            chaostype: "{{ test_name }}"

--- a/apps/percona/chaos/openebs_cstor-pool_network_delay/test_vars.yml
+++ b/apps/percona/chaos/openebs_cstor-pool_network_delay/test_vars.yml
@@ -1,0 +1,7 @@
+test_name: openebs-cstor-pool-network-delay
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+target_namespace: "{{ lookup('env','TARGET_NAMESPACE') }}"
+label: "{{ lookup('env','APP_LABEL') }}"
+pvc: "{{ lookup('env','APP_PVC') }}"
+liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"

--- a/chaoslib/openebs/cstor_pool_network_delay.yml
+++ b/chaoslib/openebs/cstor_pool_network_delay.yml
@@ -1,0 +1,77 @@
+- name: Setup pumba chaos infrastructure
+  shell: >
+    kubectl apply -f /chaoslib/pumba/pumba_kube.yaml
+    -n {{ ns }}
+  args:
+    executable: /bin/bash
+  register: result 
+
+- name: Confirm that the pumba ds is running on all nodes
+  shell: >
+    kubectl get pod -l app=pumba 
+    --no-headers -o custom-columns=:status.phase
+    -n {{ ns }} | sort | uniq
+  args: 
+    executable: /bin/bash
+  register: result
+  until: "result.stdout == 'Running'"
+  delay: 20
+  retries: 15  
+
+- name: Getting the Application pod name
+  shell:  kubectl get pods -n {{ ns }} -l {{ app_label }} --no-headers -o=custom-columns=NAME:".metadata.name"  
+  register: pod_name
+
+- name: Getting the node on which Application pod is scheduled
+  shell: kubectl get pod {{ pod_name.stdout }} -n {{ ns }} -o jsonpath='{.spec.nodeName}'
+  register: node
+
+- name: Getting pool-pod on derived node
+  shell: kubectl get pods -n {{ target_ns }} -l app=cstor-pool -o jsonpath='{.items[?(@.spec.nodeName=="{{ node.stdout }}")].metadata.name}'  
+  register: pool_pod
+
+- name: Installing tc package in cstor-pool container
+  shell: kubectl exec -it {{ pool_pod.stdout }} -n {{ target_ns }} -c cstor-pool -- apt-get install iproute2 -y 
+  register: install_status
+  failed_when: "'Setting up iproute2' not in install_status.stdout"
+
+- name: Getting the pumba pod name on derived node
+  shell: >
+    kubectl get pods -l app=pumba -n {{ ns }} 
+    -o jsonpath='{.items[?(@.spec.nodeName==''"{{ node.stdout }}"'')].metadata.name}'
+  args:
+    executable: /bin/bash
+  register: pumba_pod 
+
+- name: Inject egress delay of {{network_delay}}ms on cstor target for {{ chaos_duration }}s
+  shell: >
+    kubectl exec {{ pumba_pod.stdout }} -n {{ ns }} 
+    -- pumba netem --interface eth0 --duration {{ chaos_duration }}s delay
+    --time {{ network_delay }} re2:k8s_cstor-pool_cstor-sparse-pool; 
+  args:
+    executable: /bin/bash  
+
+- name: Wait for 10s post fault injection 
+  wait_for:
+    timeout: 10
+
+- name: Delete the pumba daemonset 
+  shell: kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n {{ ns }} 
+  args:
+    executable: /bin/bash
+  register: result     
+
+- name: Confirm that the pumba ds is deleted successfully
+  shell: >
+    kubectl get pods -l app=pumba --no-headers -n {{ ns }}
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'Running' not in result.stdout"
+  delay: 20
+  retries: 15      
+
+- name: Removing the tc package from cstor-pool
+  shell: kubectl exec -it {{ pool_pod.stdout }} -n {{ target_ns }} -c cstor-pool -- apt-get purge iproute2 -y
+  register: remove
+  failed_when: "'Removing iproute2' not in remove.stdout"     


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a litmusbook and a util for **cstot-pool_network_delay**.
**Following is the log of ansible-test container:**
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /percona/chaos/openebs_cstor-pool_network_delay/test.yml:2
ok: [127.0.0.1]
META: ran handlers

TASK [Checking status of liveness pod] *****************************************
task path: /percona/chaos/openebs_cstor-pool_network_delay/test.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record test instance/run ID] *********************************************
task path: /percona/chaos/openebs_cstor-pool_network_delay/test.yml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /percona/chaos/openebs_cstor-pool_network_delay/test.yml:31
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_cstor-pool_network_delay/test.yml:37
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
changed: [127.0.0.1] => {"changed": true, "checksum": "fbccdb7b1800fc9b7ea19db65d7aa4350784bfb9", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "21f97a5c74c0bc4751b33c53c71224fe", "mode": "0644", "owner": "root", "size": 465, "src": "/root/.ansible/tmp/ansible-tmp-1542094675.67-165854370407436/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.088346", "end": "2018-11-13 07:37:56.398005", "rc": 0, "start": "2018-11-13 07:37:56.309659", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-cstor-pool-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs-cstor-pool-network-delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-cstor-pool-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs-cstor-pool-network-delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.339738", "end": "2018-11-13 07:37:56.884288", "failed_when_result": false, "rc": 0, "start": "2018-11-13 07:37:56.544550", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-cstor-pool-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-cstor-pool-network-delay configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /percona/chaos/openebs_cstor-pool_network_delay/test.yml:44
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace           : app-percona-ns", 
        "Target Namespace    : openebs", 
        "Label               : name=percona", 
        "PVC                 : percona-mysql-claim"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /percona/chaos/openebs_cstor-pool_network_delay/test.yml:55
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.155663", "end": "2018-11-13 07:37:57.390422", "rc": 0, "start": "2018-11-13 07:37:57.234759", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:1
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n app-percona-ns", "delta": "0:00:00.203095", "end": "2018-11-13 07:37:57.762489", "rc": 0, "start": "2018-11-13 07:37:57.559394", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:9
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n app-percona-ns | sort | uniq", "delta": "0:00:00.144578", "end": "2018-11-13 07:38:18.512725", "rc": 0, "start": "2018-11-13 07:38:18.368147", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Getting the Application pod name] ****************************************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:21
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.164572", "end": "2018-11-13 07:38:18.838610", "rc": 0, "start": "2018-11-13 07:38:18.674038", "stderr": "", "stderr_lines": [], "stdout": "percona-786c6b7c7f-qdmx9", "stdout_lines": ["percona-786c6b7c7f-qdmx9"]}

TASK [Getting the node on which Application pod is scheduled] ******************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:25
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod percona-786c6b7c7f-qdmx9 -n app-percona-ns -o jsonpath='{.spec.nodeName}'", "delta": "0:00:00.149758", "end": "2018-11-13 07:38:19.165126", "rc": 0, "start": "2018-11-13 07:38:19.015368", "stderr": "", "stderr_lines": [], "stdout": "kubeminion-02", "stdout_lines": ["kubeminion-02"]}

TASK [Getting pool-pod on derived node] ****************************************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:29
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l app=cstor-pool -o jsonpath='{.items[?(@.spec.nodeName==\"kubeminion-02\")].metadata.name}'", "delta": "0:00:00.188672", "end": "2018-11-13 07:38:19.514876", "rc": 0, "start": "2018-11-13 07:38:19.326204", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-3udm-f4958d7c9-kk5h8", "stdout_lines": ["cstor-sparse-pool-3udm-f4958d7c9-kk5h8"]}

TASK [Installing tc package in cstor-pool container] ***************************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:33
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-3udm-f4958d7c9-kk5h8 -n openebs -c cstor-pool -- apt-get install iproute2 -y", "delta": "0:00:05.513130", "end": "2018-11-13 07:38:25.205473", "failed_when_result": false, "rc": 0, "start": "2018-11-13 07:38:19.692343", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\ndebconf: unable to initialize frontend: Dialog\ndebconf: (TERM is not set, so the dialog frontend is not usable.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Readline\ndebconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7, <> line 1.)\ndebconf: falling back to frontend: Teletype\ndpkg-preconfigure: unable to re-open stdin: ", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "debconf: unable to initialize frontend: Dialog", "debconf: (TERM is not set, so the dialog frontend is not usable.)", "debconf: falling back to frontend: Readline", "debconf: unable to initialize frontend: Readline", "debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.22.1 /usr/local/share/perl/5.22.1 /usr/lib/x86_64-linux-gnu/perl5/5.22 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.22 /usr/share/perl/5.22 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7, <> line 1.)", "debconf: falling back to frontend: Teletype", "dpkg-preconfigure: unable to re-open stdin: "], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSuggested packages:\n  iproute2-doc\nThe following NEW packages will be installed:\n  iproute2\n0 upgraded, 1 newly installed, 0 to remove and 4 not upgraded.\nNeed to get 522 kB of archives.\nAfter this operation, 1522 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.3 [522 kB]\nFetched 522 kB in 1s (449 kB/s)\nSelecting previously unselected package iproute2.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 10601 files and directories currently installed.)\r\nPreparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.3_amd64.deb ...\r\nUnpacking iproute2 (4.3.0-1ubuntu3.16.04.3) ...\r\nSetting up iproute2 (4.3.0-1ubuntu3.16.04.3) ...", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Suggested packages:", "  iproute2-doc", "The following NEW packages will be installed:", "  iproute2", "0 upgraded, 1 newly installed, 0 to remove and 4 not upgraded.", "Need to get 522 kB of archives.", "After this operation, 1522 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.3 [522 kB]", "Fetched 522 kB in 1s (449 kB/s)", "Selecting previously unselected package iproute2.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 10601 files and directories currently installed.)", "Preparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.3_amd64.deb ...", "Unpacking iproute2 (4.3.0-1ubuntu3.16.04.3) ...", "Setting up iproute2 (4.3.0-1ubuntu3.16.04.3) ..."]}

TASK [Getting the pumba pod name on derived node] ******************************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:38
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n app-percona-ns -o jsonpath='{.items[?(@.spec.nodeName==''\"kubeminion-02\"'')].metadata.name}'", "delta": "0:00:00.192464", "end": "2018-11-13 07:38:25.568957", "rc": 0, "start": "2018-11-13 07:38:25.376493", "stderr": "", "stderr_lines": [], "stdout": "pumba-gzqrn", "stdout_lines": ["pumba-gzqrn"]}

TASK [Inject egress delay of 20ms on cstor target for 15s] *********************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:46
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-gzqrn -n app-percona-ns -- pumba netem --interface eth0 --duration 15s delay --time 20 re2:k8s_cstor-pool_cstor-sparse-pool;", "delta": "0:00:15.986128", "end": "2018-11-13 07:38:41.718210", "rc": 0, "start": "2018-11-13 07:38:25.732082", "stderr": "time=\"2018-11-13T07:38:25Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2018-11-13T07:38:26Z\" level=info msg=\"Running netem command '[delay 20ms 10ms 20.00]' on container d1089ef84595cb1340855bc21035271fdfb0f7dc0ab2395c2d23ae333cdadf72 for 15s\" \ntime=\"2018-11-13T07:38:26Z\" level=info msg=\"Start netem for container d1089ef84595cb1340855bc21035271fdfb0f7dc0ab2395c2d23ae333cdadf72 on 'eth0' with command '[delay 20ms 10ms 20.00]'\" \ntime=\"2018-11-13T07:38:41Z\" level=info msg=\"Stopping netem on container d1089ef84595cb1340855bc21035271fdfb0f7dc0ab2395c2d23ae333cdadf72\" \ntime=\"2018-11-13T07:38:41Z\" level=info msg=\"Stop netem for container d1089ef84595cb1340855bc21035271fdfb0f7dc0ab2395c2d23ae333cdadf72 on 'eth0'\" ", "stderr_lines": ["time=\"2018-11-13T07:38:25Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2018-11-13T07:38:26Z\" level=info msg=\"Running netem command '[delay 20ms 10ms 20.00]' on container d1089ef84595cb1340855bc21035271fdfb0f7dc0ab2395c2d23ae333cdadf72 for 15s\" ", "time=\"2018-11-13T07:38:26Z\" level=info msg=\"Start netem for container d1089ef84595cb1340855bc21035271fdfb0f7dc0ab2395c2d23ae333cdadf72 on 'eth0' with command '[delay 20ms 10ms 20.00]'\" ", "time=\"2018-11-13T07:38:41Z\" level=info msg=\"Stopping netem on container d1089ef84595cb1340855bc21035271fdfb0f7dc0ab2395c2d23ae333cdadf72\" ", "time=\"2018-11-13T07:38:41Z\" level=info msg=\"Stop netem for container d1089ef84595cb1340855bc21035271fdfb0f7dc0ab2395c2d23ae333cdadf72 on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:54
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:58
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n app-percona-ns", "delta": "0:00:00.155880", "end": "2018-11-13 07:38:52.350839", "rc": 0, "start": "2018-11-13 07:38:52.194959", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:64
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n app-percona-ns", "delta": "0:00:00.179483", "end": "2018-11-13 07:38:52.776225", "rc": 0, "start": "2018-11-13 07:38:52.596742", "stderr": "", "stderr_lines": [], "stdout": "pumba-4wwmc   1/1   Terminating   0     55s\npumba-gzqrn   1/1   Terminating   0     55s\npumba-jk4zz   1/1   Terminating   0     55s", "stdout_lines": ["pumba-4wwmc   1/1   Terminating   0     55s", "pumba-gzqrn   1/1   Terminating   0     55s", "pumba-jk4zz   1/1   Terminating   0     55s"]}

TASK [Removing the tc package from cstor-pool] *********************************
task path: /chaoslib/openebs/cstor_pool_network_delay.yml:74
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-3udm-f4958d7c9-kk5h8 -n openebs -c cstor-pool -- apt-get purge iproute2 -y", "delta": "0:00:04.079126", "end": "2018-11-13 07:38:57.027725", "failed_when_result": false, "rc": 0, "start": "2018-11-13 07:38:52.948599", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following packages were automatically installed and are no longer required:\n  libatm1 libmnl0 libxtables11\nUse 'apt autoremove' to remove them.\nThe following packages will be REMOVED:\n  iproute2*\n0 upgraded, 0 newly installed, 1 to remove and 4 not upgraded.\nAfter this operation, 1522 kB disk space will be freed.\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 10711 files and directories currently installed.)\r\nRemoving iproute2 (4.3.0-1ubuntu3.16.04.3) ...\r\nPurging configuration files for iproute2 (4.3.0-1ubuntu3.16.04.3) ...", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following packages were automatically installed and are no longer required:", "  libatm1 libmnl0 libxtables11", "Use 'apt autoremove' to remove them.", "The following packages will be REMOVED:", "  iproute2*", "0 upgraded, 0 newly installed, 1 to remove and 4 not upgraded.", "After this operation, 1522 kB disk space will be freed.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 10711 files and directories currently installed.)", "Removing iproute2 (4.3.0-1ubuntu3.16.04.3) ...", "Purging configuration files for iproute2 (4.3.0-1ubuntu3.16.04.3) ..."]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /percona/chaos/openebs_cstor-pool_network_delay/test.yml:79
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.181296", "end": "2018-11-13 07:38:57.375275", "rc": 0, "start": "2018-11-13 07:38:57.193979", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking status of liveness pod] *****************************************
task path: /percona/chaos/openebs_cstor-pool_network_delay/test.yml:92
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /percona/chaos/openebs_cstor-pool_network_delay/test.yml:101
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_cstor-pool_network_delay/test.yml:112
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
changed: [127.0.0.1] => {"changed": true, "checksum": "5a301c2fbf8f0796985251ff5d7d942ff4652556", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c6d8077decd461415ed0f1e238c50560", "mode": "0644", "owner": "root", "size": 463, "src": "/root/.ansible/tmp/ansible-tmp-1542094737.78-75514016874488/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.069818", "end": "2018-11-13 07:38:58.313266", "rc": 0, "start": "2018-11-13 07:38:58.243448", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-cstor-pool-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs-cstor-pool-network-delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-cstor-pool-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs-cstor-pool-network-delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.324710", "end": "2018-11-13 07:38:58.801050", "failed_when_result": false, "rc": 0, "start": "2018-11-13 07:38:58.476340", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-cstor-pool-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-cstor-pool-network-delay configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=25   changed=19   unreachable=0    failed=0   
```

