### PR TITLE
Litmusbook for percona deprovisioning

### DIFF
--- a/apps/percona/deployers/run_litmus_test.yml
+++ b/apps/percona/deployers/run_litmus_test.yml
@@ -38,6 +38,9 @@ spec:
             # Application namespace
           - name: APP_NAMESPACE
             value: app-percona-ns
+            # Use 'deprovision' for app-clean up
+          - name: ACTION
+            value: ''  
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./percona/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/percona/deployers/test.yml
+++ b/apps/percona/deployers/test.yml
@@ -12,36 +12,53 @@
         - include_tasks: /common/utils/create_testname.yml
 
          ## RECORD START-OF-TEST IN LITMUS RESULT CR
-        - include_tasks: /common/utils/update_litmus_result_resource.yml
+        - include_tasks: "/common/utils/update_litmus_result_resource.yml"
           vars:
             status: 'SOT'
+   
+        - block:
 
-         ##Actual test
+             ##Actual test
          ## Creating namespaces and making the application for deployment
-        - include_tasks: /common/utils/pre_create_app_deploy.yml
-
+            - include_tasks: /common/utils/pre_create_app_deploy.yml
+        
         ## Deploying the application
-        - include_tasks: /common/utils/deploy_single_app.yml
-          vars:
-            check_app_pod: 'yes'
-            delay: 10
-            retries: 100
+            - include_tasks: /common/utils/deploy_single_app.yml
+              vars:
+                check_app_pod: 'yes'
+                delay: 10
+                retries: 100
+    
+            ## Fetching the pod name
+            - include_tasks: /common/utils/fetch_app_pod.yml
+    
+            ## Checking the db is ready for connection
+            - include_tasks: /common/utils/check_db_connection.yml
+    
+            - set_fact:
+                flag: "Pass"  
 
-        ## Fetching the pod name
-        - include_tasks: /common/utils/fetch_app_pod.yml
+          when: "'deprovision' not in action"  
 
-        ## Checking the db is ready for connection
-        - include_tasks: /common/utils/check_db_connection.yml
+        - block:
 
-        - set_fact:
-            flag: "Pass"
+            - name: Deprovisioning the Application
+              include_tasks: "/common/utils/deprovision_deployment.yml"
+              vars:
+                app_deployer: "{{ application_deployment }}"
+
+            - set_fact:
+                flag: "Pass"  
+
+          when: "'deprovision' is in action"        
 
       rescue:
         - set_fact:
-            flag: "Fail"
+            flag: "Fail"     
 
       always:
             ## RECORD END-OF-TEST IN LITMUS RESULT CR
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
             status: 'EOT'
+              

--- a/apps/percona/deployers/test_vars.yml
+++ b/apps/percona/deployers/test_vars.yml
@@ -5,3 +5,6 @@ app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
 app_label: "{{ lookup('env','APP_LABEL') }}"
 test_name: percona-deployment
 application_name: "percona"
+action: "{{ lookup('env','ACTION') }}"
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a litmusbook for percona deprovisioning.
- This litmubook uses the common util for deprovisioning.

**Special notes for your reviewer**:
- Deprovision of is done based on the **ACTION**(env-variable) in litmusbook.
- When actions is defined(ACTION: 'deprovision') then apllication deprovisioner block is executed.
 - When action is not defined(ACTION: ' ') then application deployment block is executed. 
**Following is the log of ansible-test container:**
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
changed: [127.0.0.1] => {"changed": true, "checksum": "2fb43d87dfb4bba2e2fd205f2e69415962b85fac", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "8988f4be16232bf55e019321913ae47e", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1542183197.78-275540901390477/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.716354", "end": "2018-11-14 08:13:19.135025", "rc": 0, "start": "2018-11-14 08:13:18.418671", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: percona-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: percona-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.408755", "end": "2018-11-14 08:13:19.750811", "failed_when_result": false, "rc": 0, "start": "2018-11-14 08:13:19.342056", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/percona-deployment configured", "stdout_lines": ["litmusresult.litmus.io/percona-deployment configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovisioning the Application] ******************************************
included: /common/utils/deprovision.yml for 127.0.0.1

TASK [Check if the application to be deleted is running.] **********************
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.150197", "end": "2018-11-14 08:13:20.417849", "rc": 0, "start": "2018-11-14 08:13:20.267652", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtaining the PVC name using application label.] *************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona -o custom-columns=:..claimName --no-headers", "delta": "0:00:00.155799", "end": "2018-11-14 08:13:20.734178", "rc": 0, "start": "2018-11-14 08:13:20.578379", "stderr": "", "stderr_lines": [], "stdout": "percona-mysql-claim", "stdout_lines": ["percona-mysql-claim"]}

TASK [Obtaining the PV name from PVC name.] ************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns -o custom-columns=:spec.volumeName --no-headers", "delta": "0:00:00.138184", "end": "2018-11-14 08:13:21.026905", "rc": 0, "start": "2018-11-14 08:13:20.888721", "stderr": "", "stderr_lines": [], "stdout": "pvc-ac7d7215-e7e0-11e8-9be5-02b983f0a4db", "stdout_lines": ["pvc-ac7d7215-e7e0-11e8-9be5-02b983f0a4db"]}

TASK [Replace the PVC name in application deployer spec.] **********************
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Get the application label values from env] *******************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the application label placeholder] *******************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the application deployment.] **************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f percona.yml -n app-percona-ns", "delta": "0:00:04.095206", "end": "2018-11-14 08:13:25.736509", "rc": 0, "start": "2018-11-14 08:13:21.641303", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps \"percona\" deleted\npersistentvolumeclaim \"percona-mysql-claim\" deleted\nservice \"percona-mysql\" deleted", "stdout_lines": ["deployment.apps \"percona\" deleted", "persistentvolumeclaim \"percona-mysql-claim\" deleted", "service \"percona-mysql\" deleted"]}

TASK [Check if the application namespace doesn't have any resources.] **********
FAILED - RETRYING: Check if the application namespace doesn't have any resources. (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get all -n app-percona-ns --no-headers", "delta": "0:00:00.201863", "end": "2018-11-14 08:13:57.202222", "rc": 0, "start": "2018-11-14 08:13:57.000359", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Delete the namespace.] ***************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete ns app-percona-ns", "delta": "0:00:05.368606", "end": "2018-11-14 08:14:02.745676", "rc": 0, "start": "2018-11-14 08:13:57.377070", "stderr": "", "stderr_lines": [], "stdout": "namespace \"app-percona-ns\" deleted", "stdout_lines": ["namespace \"app-percona-ns\" deleted"]}

TASK [Check if the PV is deleted.] *********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-ac7d7215-e7e0-11e8-9be5-02b983f0a4db", "delta": "0:00:00.149882", "end": "2018-11-14 08:14:03.060484", "failed_when_result": false, "msg": "non-zero return code", "rc": 1, "start": "2018-11-14 08:14:02.910602", "stderr": "Error from server (NotFound): persistentvolumes \"pvc-ac7d7215-e7e0-11e8-9be5-02b983f0a4db\" not found", "stderr_lines": ["Error from server (NotFound): persistentvolumes \"pvc-ac7d7215-e7e0-11e8-9be5-02b983f0a4db\" not found"], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
changed: [127.0.0.1] => {"changed": true, "checksum": "6bdd1ff2d018e616e50bff842ad05cafa7ec7f38", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "5d64f6c678b53bfda23b3b57fa0d82ad", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1542183243.4-53928460512510/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.069530", "end": "2018-11-14 08:14:04.425772", "rc": 0, "start": "2018-11-14 08:14:04.356242", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: percona-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: percona-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.292809", "end": "2018-11-14 08:14:04.873863", "failed_when_result": false, "rc": 0, "start": "2018-11-14 08:14:04.581054", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/percona-deployment configured", "stdout_lines": ["litmusresult.litmus.io/percona-deployment configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=21   changed=15   unreachable=0    failed=0 
```
