### PR TITLE
testcase(svc_chaos): util for restarting kubelet/docker services, and, job for app pod to use this util

### DIFF
--- a/apps/percona/chaos/openebs_app_svc_chaos/chaosutil.j2
+++ b/apps/percona/chaos/openebs_app_svc_chaos/chaosutil.j2
@@ -1,0 +1,7 @@
+{% if stg_prov is defined and stg_prov == 'openebs.io/provisioner-iscsi' %}
+  {% if stg_engine is defined and stg_engine == 'cstor' %}
+    chaosutil: service_chaos/svc_chaos.yml
+  {% else %}
+    chaosutil: service_chaos/svc_chaos.yml
+  {% endif %}
+{% endif %}

--- a/apps/percona/chaos/openebs_app_svc_chaos/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_app_svc_chaos/run_litmus_test.yml
@@ -1,0 +1,85 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: openebs-app-svc-chaos-
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      labels:
+        name: openebs-app-svc-chaos-
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+          - name: OPERATOR_NAMESPACE
+            value: openebs
+ 
+          - name: APP_NAMESPACE
+            value: app-percona-ns 
+
+          - name: APP_LABEL
+            value: 'name=percona'
+
+          - name: APP_PVC
+            value: percona-mysql-claim
+
+          - name: SVC_CHAOS
+            value: docker
+
+          - name: CHAOS_DURATION
+            value: "60" # in seconds
+
+          - name: LIVENESS_APP_LABEL
+            value: ""
+
+          - name: LIVENESS_APP_NAMESPACE
+            value: ""
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./percona/chaos/openebs_app_svc_chaos/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+          - name: logs 
+            mountPath: /var/log/ansible 
+        tty: true
+      - name: logger
+        image: openebs/logger
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # spec.volumes is not supported by downward API
+          - name: MY_POD_HOSTPATH
+            value: /mnt/chaos/openebs_target_network_delay
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,percona; exit 0"] 
+        volumeMounts:
+          - name: kubeconfig 
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt 
+        tty: true 
+      volumes: 
+        - name: kubeconfig
+          configMap: 
+            name: kubeconfig 
+        - name: logs 
+          hostPath:
+            path: /mnt/chaos/openebs_app_svc_chaos
+            type: ""
+

--- a/apps/percona/chaos/openebs_app_svc_chaos/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_app_svc_chaos/run_litmus_test.yml
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       labels:
-        name: openebs-app-svc-chaos-
+        name: openebs-app-svc-chaos
     spec:
       serviceAccountName: litmus
       restartPolicy: Never

--- a/apps/percona/chaos/openebs_app_svc_chaos/test.yml
+++ b/apps/percona/chaos/openebs_app_svc_chaos/test.yml
@@ -1,0 +1,123 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+        ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE       
+        - block:
+
+            - name: Checking status of liveness pod
+              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
+              register: liveness_pod
+              until: "'Running' in liveness_pod.stdout"
+              delay: 10
+              retries: 10
+             
+          when: liveness_label != '' 
+
+        - include: test_prerequisites.yml
+  
+        - include_vars:
+            file: chaosutil.yml
+
+        - name: Record the chaos util path
+          set_fact: 
+            chaos_util_path: "/chaoslib/{{ chaosutil }}"
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "{{ chaosutil.split('.')[0] }}"
+
+        ## DISPLAY APP INFORMATION 
+ 
+        - name: Display the app information passed via the test job
+          debug: 
+            msg: 
+              - "The application info is as follows:"
+              - "Namespace    : {{ namespace }}"
+              - "Label        : {{ label }}"
+              - "PVC          : {{ pvc }}"  
+              - "StorageClass : {{ sc }}"
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify that the AUT (Application Under Test) is running 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          delay: 10
+          retries: 12
+
+        ## STORAGE FAULT INJECTION 
+
+        - include: "{{ chaos_util_path }}"
+          app_ns: "{{ namespace }}"
+          app_label: "{{ label }}"
+          app_pvc: "{{ pvc }}"
+          network_delay: "{{ n_delay }}"
+          chaos_duration: "{{ c_duration }}"
+          action: svc_chaos
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify AUT liveness post fault-injection
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          delay: 10
+          retries: 12
+
+        - block:
+
+            - name: Checking status of liveness pod
+              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
+              register: liveness_pod
+              until: "'Running' in liveness_pod.stdout"
+              delay: 10
+              retries: 10
+
+          when: liveness_label != ''
+          
+        - set_fact:
+            flag: "Pass"
+
+      rescue: 
+        - set_fact: 
+            flag: "Fail"
+
+      always: 
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+ 
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+            chaostype: "{{ chaosutil.split('.')[0] }}"

--- a/apps/percona/chaos/openebs_app_svc_chaos/test.yml
+++ b/apps/percona/chaos/openebs_app_svc_chaos/test.yml
@@ -75,12 +75,13 @@
         ## STORAGE FAULT INJECTION 
 
         - include: "{{ chaos_util_path }}"
-          app_ns: "{{ namespace }}"
-          app_label: "{{ label }}"
-          app_pvc: "{{ pvc }}"
-          network_delay: "{{ n_delay }}"
-          chaos_duration: "{{ c_duration }}"
-          action: svc_chaos
+          vars:
+            app_ns: "{{ namespace }}"
+            app_label: "{{ label }}"
+            app_pvc: "{{ pvc }}"
+            network_delay: "{{ n_delay }}"
+            chaos_duration: "{{ c_duration }}"
+            action: "svc_chaos"
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 

--- a/apps/percona/chaos/openebs_app_svc_chaos/test_prerequisites.yml
+++ b/apps/percona/chaos/openebs_app_svc_chaos/test_prerequisites.yml
@@ -1,0 +1,52 @@
+---
+- name: Identify the storage class used by the PVC
+  shell: >
+    kubectl get pvc {{ pvc }} -n {{ namespace }} 
+    --no-headers -o custom-columns=:spec.storageClassName
+  args:
+    executable: /bin/bash
+  register: storage_class
+
+- name: Identify the storage provisioner used by the SC
+  shell: >
+    kubectl get sc {{ storage_class.stdout }}
+    --no-headers -o custom-columns=:provisioner
+  args:
+    executable: /bin/bash
+  register: provisioner
+
+- name: Record the storage class name
+  set_fact: 
+    sc: "{{ storage_class.stdout }}"
+
+- name: Record the storage provisioner name
+  set_fact:
+    stg_prov: "{{ provisioner.stdout }}"
+
+- block:
+    - name: Derive PV name from PVC to query storage engine type (openebs)
+      shell: >
+        kubectl get pvc {{ pvc }} -n {{ namespace }}
+        --no-headers -o custom-columns=:spec.volumeName
+      args:
+        executable: /bin/bash
+      register: pv
+
+    - name: Check for presence & value of cas type annotation
+      shell: >
+        kubectl get pv {{ pv.stdout }} --no-headers
+        -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
+      args:
+        executable: /bin/bash
+      register: openebs_stg_engine
+
+    - name: Record the storage engine name
+      set_fact:
+        stg_engine: "{{ openebs_stg_engine.stdout }}"
+  when: stg_prov == "openebs.io/provisioner-iscsi"
+
+- name: Identify the chaos util to be invoked 
+  template:
+    src: chaosutil.j2
+    dest: chaosutil.yml
+

--- a/apps/percona/chaos/openebs_app_svc_chaos/test_vars.yml
+++ b/apps/percona/chaos/openebs_app_svc_chaos/test_vars.yml
@@ -1,0 +1,11 @@
+test_name: openebs-app-svc-chaos
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+label: "{{ lookup('env','APP_LABEL') }}"
+pvc: "{{ lookup('env','APP_PVC') }}"
+n_delay: "{{ lookup('env','NETWORK_DELAY') }}" 
+c_duration: "{{ lookup('env','CHAOS_DURATION') }}"
+svc_chaos: "{{ lookup('env','SVC_CHAOS') }}"
+operator_ns: "{{ lookup('env','OPERATOR_NAMESPACE') }}"
+liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
+

--- a/chaoslib/service_chaos/svc_chaos.yml
+++ b/chaoslib/service_chaos/svc_chaos.yml
@@ -1,7 +1,7 @@
 - block:
     - name: Setup svc chaos infra
       shell: >
-        kubectl apply -f /chaoslib/service_chaos/svc_chaos_kube.yml 
+        kubectl create -f /chaoslib/service_chaos/svc_chaos_kube.yml 
         -n {{ namespace }}
       args:
         executable: /bin/bash
@@ -21,15 +21,15 @@
 
     - name: Obtaining the application pod name using its label.
       shell: >
-        kubectl get pods -n {{ app_ns }} -l {{ app_label }}
-        --no-headers -o custom-columns=:metadata.name
+        kubectl get pods -n {{ app_ns }} -l {{ app_label }} | grep
+        -w Running | awk '{print $1}'
       args:
         executable: /bin/bash
       register: app_pod
 
     - name: Identify the application node
       shell: >
-        kubectl get pod {{ app_pod }} -n {{ namespace }}
+        kubectl get pod {{ app_pod.stdout }} -n {{ namespace }}
         --no-headers -o custom-columns=:spec.nodeName
       args: 
         executable: /bin/bash
@@ -65,7 +65,7 @@
 
     - name: Delete svc chaos infra
       shell: >
-        kubectl delete -f /chaoslib/service_chaos/svc_chaos_kube.yml 
+        kubectl delete ds -l app=svc-chaos
         -n {{ namespace }}
       args:
         executable: /bin/bash

--- a/chaoslib/service_chaos/svc_chaos.yml
+++ b/chaoslib/service_chaos/svc_chaos.yml
@@ -1,0 +1,87 @@
+- block:
+    - name: Setup svc chaos infra
+      shell: >
+        kubectl apply -f /chaoslib/service_chaos/svc_chaos_kube.yml 
+        -n {{ namespace }}
+      args:
+        executable: /bin/bash
+      register: result
+    
+    - name: Confirm that the svc chaos ds is running on all nodes
+      shell: >
+        kubectl get pod -l app=svc-chaos
+        --no-headers -o custom-columns=:status.phase
+        -n {{ namespace }} | sort | uniq
+      args: 
+        executable: /bin/bash
+      register: result
+      until: "result.stdout == 'Running'"
+      delay: 20
+      retries: 15
+
+    - name: Obtaining the application pod name using its label.
+      shell: >
+        kubectl get pods -n {{ app_ns }} -l {{ app_label }}
+        --no-headers -o custom-columns=:metadata.name
+      args:
+        executable: /bin/bash
+      register: app_pod
+
+    - name: Identify the application node
+      shell: >
+        kubectl get pod {{ app_pod }} -n {{ namespace }}
+        --no-headers -o custom-columns=:spec.nodeName
+      args: 
+        executable: /bin/bash
+      register: result 
+               
+    - name: Record the application node name 
+      set_fact:
+        app_node: "{{ result.stdout }}"
+ 
+    - name: Record the svc chaos pod on given app node 
+      shell: >
+        kubectl get pod -l app=svc-chaos -o wide 
+        -n {{ namespace }} | grep {{ app_node }} 
+        | awk '{print $1}'
+      args:
+        executable: /bin/bash
+      register: svc_chaos_pod
+
+    - name: do svc restart
+      shell: >
+        kubectl exec -it {{ svc_chaos_pod.stdout}} -n {{ namespace }} 
+        -- bash -c "systemctl stop kube-docker-monitor && systemctl stop kubelet-monitor && systemctl stop {{ svc_chaos }} && sleep {{ c_duration }} && systemctl start {{ svc_chaos }} && systemctl start kube-docker-monitor && systemctl start kubelet-monitor"
+      args:
+        executable: /bin/bash
+      ignore_errors: true 
+      register: result
+
+    - name: wait for svc chaos duration time
+      shell: >
+        sleep {{ c_duration }} 
+      args:
+        executable: /bin/bash
+
+    - name: Delete svc chaos infra
+      shell: >
+        kubectl delete -f /chaoslib/service_chaos/svc_chaos_kube.yml 
+        -n {{ namespace }}
+      args:
+        executable: /bin/bash
+      register: result
+ 
+    - name: Confirm that the svc chaos ds is stopped on all nodes
+      shell: >
+        kubectl get pod -l app=svc-chaos
+        --no-headers -o custom-columns=:status.phase
+        -n {{ namespace }} | sort | uniq
+      args: 
+        executable: /bin/bash
+      register: result
+      until: "'Running' not in result.stdout"
+      delay: 20
+      retries: 15
+ 
+  when: action == "svc_chaos"
+

--- a/chaoslib/service_chaos/svc_chaos.yml
+++ b/chaoslib/service_chaos/svc_chaos.yml
@@ -50,7 +50,7 @@
 
     - name: do svc restart
       shell: >
-        kubectl exec -it {{ svc_chaos_pod.stdout}} -n {{ namespace }} 
+        timeout 10 kubectl exec -it {{ svc_chaos_pod.stdout}} -n {{ namespace }} 
         -- bash -c "systemctl stop kube-docker-monitor && systemctl stop kubelet-monitor && systemctl stop {{ svc_chaos }} && sleep {{ c_duration }} && systemctl start {{ svc_chaos }} && systemctl start kube-docker-monitor && systemctl start kubelet-monitor"
       args:
         executable: /bin/bash

--- a/chaoslib/service_chaos/svc_chaos_kube.yml
+++ b/chaoslib/service_chaos/svc_chaos_kube.yml
@@ -1,0 +1,32 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  generateName: svc-chaos-
+spec:
+  template:
+    metadata:
+      labels:
+        app: svc-chaos
+    spec:
+      containers:
+      - name: svc-chaos
+        image: ubuntu:16.04
+        command: ["/bin/bash"]
+        args: ["-c", "sleep 100000"]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 5M
+          limits:
+            cpu: 100m
+            memory: 20M
+        volumeMounts:
+          - name: bus
+            mountPath: /var/run
+        tty: true
+      volumes: 
+        - name: bus
+          hostPath:
+            path: /var/run
+


### PR DESCRIPTION
This PR contains util to restart node level services using a daemonset, and, have an env to set the chaos duration.
Also, this PR have litmus job to restart docker service in the node where application pod resides.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>