### PR TITLE
refactor(yaml): Updated application pod failure litmus book for statefulset applicaions (xfs)

### DIFF
--- a/apps/crunchy-postgres/deployers/test.yml
+++ b/apps/crunchy-postgres/deployers/test.yml
@@ -35,7 +35,8 @@
                 executable: /bin/bash
               register: result_service
               failed_when: "'pgset-primary' and 'pgset-replica' not in result_service.stdout"
-              when: "'deprovision' not in action"
+
+          when: "'deprovision' not in action"
 
         - block:
 

--- a/apps/jenkins/chaos/app_pod_failure/run_litmus_test.yml
+++ b/apps/jenkins/chaos/app_pod_failure/run_litmus_test.yml
@@ -33,6 +33,9 @@ spec:
           - name: LIVENESS_APP_NAMESPACE
             value: ""
 
+          - name: DEPLOY_TYPE
+            value: deployment
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./jenkins/chaos/app_pod_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]
         volumeMounts:

--- a/apps/jenkins/chaos/app_pod_failure/run_litmus_test.yml
+++ b/apps/jenkins/chaos/app_pod_failure/run_litmus_test.yml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: mockbot/ansible-runner:a6
+        image: openebs/ansible-runner:ci
         env:
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays

--- a/apps/jenkins/chaos/app_pod_failure/run_litmus_test.yml
+++ b/apps/jenkins/chaos/app_pod_failure/run_litmus_test.yml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: openebs/ansible-runner:ci
+        image: mockbot/ansible-runner:a6
         env:
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays

--- a/apps/jenkins/chaos/app_pod_failure/test.yml
+++ b/apps/jenkins/chaos/app_pod_failure/test.yml
@@ -19,12 +19,6 @@
              
           when: liveness_label != ''  
 
-        ## Record the chaosutil path ##
-
-        - name: Record the chaosutil  path
-          set_fact:
-            chaosutil_path: "/chaoslib/kubectl/app_pod_failure.yaml"
-
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
 
         - block:
@@ -68,46 +62,58 @@
 
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
 
-        - name: Verify that the AUT (Application Under Test) is running 
-          shell: >
-            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+        - block:
+            - name: Verify that the AUT is running
+              include_tasks: /common/utils/check_deployment_status.yml
 
-        - name: Get application pod name 
-          shell: >
-            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: app_pod_name
+            - name: Get application pod name 
+              shell: >
+                kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
+                -o=custom-columns=NAME:".metadata.name"
+              args:
+                executable: /bin/bash
+              register: app_pod_name
 
-        ## APPLICATION FAULT INJECTION 
+        ## APPLICATION FAULT INJECTION
 
-        - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml 
-          vars:
-            action: "killapp"
-            app_pod: "{{ app_pod_name.stdout }}"
-            namespace: "{{ app_ns }}"
+            - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
+              vars:
+                action: "killapp"
+                app_pod: "{{ app_pod_name.stdout }}"
+                namespace: "{{ app_ns }}"
+                label: "{{ app_label }}"
+
+          when: lookup('env','DEPLOY_TYPE') == 'deployment'
+
+        - block:
+
+            - name: Verify that the AUT is running
+              include_tasks: /common/utils/check_deployment_status.yml
+
+            - name: Get application pod name
+              shell: >
+                kubectl get pod  -n {{ app_ns }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
+              args:
+                executable: /bin/bash
+              register: app_pod_name
+
+
+        ## APPLICATION FAULT INJECTION
+
+            - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
+              vars:
+                action: "killapp"
+                app_pod: "{{ app_pod_name.stdout }}"
+                namespace: "{{ app_ns }}"
+                label: "{{ app_label }}"
+
+          when: lookup('env','DEPLOY_TYPE') == 'statefulset'
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
-
+          include_tasks: /common/utils/check_deployment_status.yml
+  
         - block:
 
             - name: Checking status of liveness pod

--- a/apps/jenkins/chaos/app_pod_failure/test.yml
+++ b/apps/jenkins/chaos/app_pod_failure/test.yml
@@ -61,11 +61,10 @@
               - "Label        : {{ app_label }}"
 
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - name: Verify that the AUT is running
+          include_tasks: /common/utils/check_deployment_status.yml
 
         - block:
-            - name: Verify that the AUT is running
-              include_tasks: /common/utils/check_deployment_status.yml
-
             - name: Get application pod name 
               shell: >
                 kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
@@ -73,8 +72,8 @@
               args:
                 executable: /bin/bash
               register: app_pod_name
-
-        ## APPLICATION FAULT INJECTION
+  
+             ## APPLICATION FAULT INJECTION
 
             - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
               vars:
@@ -87,9 +86,6 @@
 
         - block:
 
-            - name: Verify that the AUT is running
-              include_tasks: /common/utils/check_deployment_status.yml
-
             - name: Get application pod name
               shell: >
                 kubectl get pod  -n {{ app_ns }} -l {{ app_label }} -o jsonpath='{.items[0].metadata.name}'
@@ -97,8 +93,7 @@
                 executable: /bin/bash
               register: app_pod_name
 
-
-        ## APPLICATION FAULT INJECTION
+            ## APPLICATION FAULT INJECTION
 
             - include_tasks: /chaoslib/pumba/pod_failure_by_sigkill.yaml
               vars:

--- a/chaoslib/pumba/pod_failure_by_sigkill.yaml
+++ b/chaoslib/pumba/pod_failure_by_sigkill.yaml
@@ -2,33 +2,33 @@
 
     - name: Setup pumba chaos infrastructure
       shell: >
-        kubectl apply -f /chaoslib/pumba/pumba_kube.yaml 
+        kubectl apply -f /chaoslib/pumba/pumba_kube.yaml
         -n {{ namespace }}
       args:
         executable: /bin/bash
       register: result
-    
+
     - name: Confirm that the pumba ds is running on all nodes
       shell: >
-        kubectl get pod -l app=pumba 
+        kubectl get pod -l app=pumba
         --no-headers -o custom-columns=:status.phase
         -n {{ namespace }} | sort | uniq
-      args: 
+      args:
         executable: /bin/bash
       register: result
       until: "result.stdout == 'Running'"
       delay: 20
       retries: 15
-    
+
     - name: Identify the application node
       shell: >
         kubectl get pod {{ app_pod }} -n {{ namespace }}
         --no-headers -o custom-columns=:spec.nodeName
-      args: 
+      args:
         executable: /bin/bash
-      register: result 
-               
-    - name: Record the application node name 
+      register: result
+
+    - name: Record the application node name
       set_fact:
         app_node: "{{ result.stdout }}"
 
@@ -36,9 +36,7 @@
 
       - name: Record the application container
         shell: >
-          kubectl get pod {{ app_pod }}
-          --no-headers -o jsonpath={.spec.containers[*].name}
-          -n {{ namespace }}
+          kubectl get pods -l {{ label }} -n {{ namespace }} -o jsonpath='{.items[0].spec.containers[0].name}'
         args:
           executable: /bin/bash
         register: container
@@ -49,49 +47,49 @@
 
       when: app_container is undefined
 
-    - name: Record the pumba pod on app node 
+    - name: Record the pumba pod on app node
       shell: >
-        kubectl get pod -l app=pumba -o wide 
-        -n {{ namespace }} | grep {{ app_node }} 
+        kubectl get pod -l app=pumba -o wide
+        -n {{ namespace }} | grep {{ app_node }}
         | awk '{print $1}'
       args:
         executable: /bin/bash
       register: pumba_pod
-        
-    - name: Force kill the application pod using pumba 
+
+    - name: Force kill the application pod using pumba
       shell: >
         kubectl exec {{ pumba_pod.stdout}} -n {{ namespace }}
         -- timeout -t 40 pumba --interval 15s kill
         --signal SIGKILL re2:k8s_{{ app_container }};
       args:
         executable: /bin/bash
-      ignore_errors: true 
+      ignore_errors: true
       register: result
-    
+
     - name: Wait for application pod reschedule
       wait_for:
         timeout: 30
-  
+
   when: action == "killapp"
- 
+
 - block:
 
-    - name: Delete the pumba daemonset 
+    - name: Delete the pumba daemonset
       shell: >
         kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n {{ namespace }}
       args:
         executable: /bin/bash
       register: result
-      
+
     - name: Confirm that the pumba ds is deleted successfully
       shell: >
-        kubectl get pod -l app=pumba 
+        kubectl get pod -l app=pumba
         --no-headers -n {{ namespace }}
-      args: 
+      args:
         executable: /bin/bash
       register: result
       until: "'Running' not in result.stdout"
       delay: 20
       retries: 15
-      
+
   when: action == "deletepumba"

--- a/common/utils/check_deployment_status.yml
+++ b/common/utils/check_deployment_status.yml
@@ -4,11 +4,33 @@
 #     - app_ns ( namespace where the application is deployed)
 #     - app_label ( Label of application in the form 'key=value'))
 
-- name: Check the pod status
-  shell: kubectl get pods -n {{ app_ns }} -l {{ app_label }}
-  args:
-    executable: /bin/bash
-  register: result
-  until: "'Running' in result.stdout"
-  delay: 30
-  retries: 15
+- block:
+    - name: Check the pod status
+      shell: >
+        kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
+        -o custom-columns=:status.phase
+      args:
+        executable: /bin/bash
+      register: result
+      until: "'Running' in result.stdout"
+      delay: 30
+      retries: 15
+      
+  when: lookup('env','DEPLOY_TYPE') == 'deployment'
+
+- block:
+    - name: obtain the number of replicas.
+      shell: kubectl get statefulset -n {{ app_ns }} -l {{ app_label }} -o custom-columns=:spec.replicas
+      register: rep_count 
+      until: "rep_count.rc ==0"
+      delay: 60
+      retries: 15
+
+    - name: Obtain the ready replica count and compare with the replica count.
+      shell: kubectl get statefulset -n {{ app_ns }} -l {{ app_label }} -o custom-columns=:..readyReplicas
+      register: ready_rep
+      until: "ready_rep.rc == 0 and ready_rep.stdout|int == rep_count.stdout|int"
+      delay: 60
+      retries: 30
+
+  when: lookup('env','DEPLOY_TYPE') == 'statefulset'


### PR DESCRIPTION
Signed-off-by: sathyaseelan <sathyaseelan.n@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Updated application pod kill using pumba util to perform app container kill bot deployment and statefulset applications 
- performed this test against mongo statefulset

@dargasudarshan  @gprasath  can you please review this PR

```
ansible-playbook 2.7.2
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./jenkins/chaos/app_pod_failure/test.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:2
ok: [127.0.0.1]
META: ran handlers

TASK [Checking status of liveness pod] *****************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:13
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record test instance/run ID] *********************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:26
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /jenkins/chaos/app_pod_failure/test.yml:30
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /jenkins/chaos/app_pod_failure/test.yml:36
changed: [127.0.0.1] => {"changed": true, "checksum": "5fe1146a580fd6acf0752c700a95682556398039", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "3bef689f91088e63943b725c797d2914", "mode": "0644", "owner": "root", "size": 424, "src": "/root/.ansible/tmp/ansible-tmp-1542624621.63-192821858390520/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:47
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.381738", "end": "2018-11-19 10:50:23.850461", "failed_when_result": false, "rc": 0, "start": "2018-11-19 10:50:22.468723", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/application-pod-failure configured", "stdout_lines": ["litmusresult.litmus.io/application-pod-failure configured"]}

TASK [Display the app information passed via the test job] *********************
task path: /jenkins/chaos/app_pod_failure/test.yml:56
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : app-mongo-ns", 
        "Label        : app=mongo"
    ]
}

TASK [Verify that the AUT is running] ******************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:66
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get application pod name] ************************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:69
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:79
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify that the AUT is running] ******************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:90
included: /common/utils/check_deployment_status.yml for 127.0.0.1

TASK [Check the pod status] ****************************************************
task path: /common/utils/check_deployment_status.yml:8
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [obtain the number of replicas.] ******************************************
task path: /common/utils/check_deployment_status.yml:22
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-mongo-ns -l app=mongo -o custom-columns=:spec.replicas", "delta": "0:00:00.958843", "end": "2018-11-19 10:50:25.328089", "rc": 0, "start": "2018-11-19 10:50:24.369246", "stderr": "", "stderr_lines": [], "stdout": "\n3", "stdout_lines": ["", "3"]}

TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /common/utils/check_deployment_status.yml:29
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-mongo-ns -l app=mongo -o custom-columns=:..readyReplicas", "delta": "0:00:00.908712", "end": "2018-11-19 10:50:26.424994", "rc": 0, "start": "2018-11-19 10:50:25.516282", "stderr": "", "stderr_lines": [], "stdout": "\n3", "stdout_lines": ["", "3"]}

TASK [Get application pod name] ************************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:93
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n app-mongo-ns -l app=mongo -o jsonpath='{.items[0].metadata.name}'", "delta": "0:00:00.935797", "end": "2018-11-19 10:50:27.547852", "rc": 0, "start": "2018-11-19 10:50:26.612055", "stderr": "", "stderr_lines": [], "stdout": "mongo-0", "stdout_lines": ["mongo-0"]}

TASK [include_tasks] ***********************************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:103
included: /chaoslib/pumba/pod_failure_by_sigkill.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:3
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n app-mongo-ns", "delta": "0:00:01.096256", "end": "2018-11-19 10:50:28.924571", "rc": 0, "start": "2018-11-19 10:50:27.828315", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:11
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n app-mongo-ns | sort | uniq", "delta": "0:00:00.864796", "end": "2018-11-19 10:50:51.312589", "rc": 0, "start": "2018-11-19 10:50:50.447793", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Identify the application node] *******************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:23
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod mongo-0 -n app-mongo-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.880618", "end": "2018-11-19 10:50:52.377981", "rc": 0, "start": "2018-11-19 10:50:51.497363", "stderr": "", "stderr_lines": [], "stdout": "gke-e2e-cluster-2-default-pool-4ba8b47d-m699", "stdout_lines": ["gke-e2e-cluster-2-default-pool-4ba8b47d-m699"]}

TASK [Record the application node name] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:31
ok: [127.0.0.1] => {"ansible_facts": {"app_node": "gke-e2e-cluster-2-default-pool-4ba8b47d-m699"}, "changed": false}

TASK [Record the application container] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:37
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=mongo -n app-mongo-ns -o jsonpath='{.items[0].spec.containers[0].name}' #kubectl get pod mongo-0 #--no-headers -o jsonpath={.spec.containers[*].name} #-n app-mongo-ns", "delta": "0:00:00.962573", "end": "2018-11-19 10:50:53.610963", "rc": 0, "start": "2018-11-19 10:50:52.648390", "stderr": "", "stderr_lines": [], "stdout": "mongo", "stdout_lines": ["mongo"]}

TASK [Record the app_container] ************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:47
ok: [127.0.0.1] => {"ansible_facts": {"app_container": "mongo"}, "changed": false}

TASK [Record the pumba pod on app node] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:53
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l app=pumba -o wide -n app-mongo-ns | grep gke-e2e-cluster-2-default-pool-4ba8b47d-m699 | awk '{print $1}'", "delta": "0:00:00.929752", "end": "2018-11-19 10:50:54.817558", "rc": 0, "start": "2018-11-19 10:50:53.887806", "stderr": "", "stderr_lines": [], "stdout": "pumba-rdp24", "stdout_lines": ["pumba-rdp24"]}

TASK [Force kill the application pod using pumba] ******************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:62
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-rdp24 -n app-mongo-ns -- timeout -t 40 pumba --interval 15s kill --signal SIGKILL re2:k8s_mongo;", "delta": "0:00:41.260265", "end": "2018-11-19 10:51:36.276785", "rc": 0, "start": "2018-11-19 10:50:55.016520", "stderr": "time=\"2018-11-19T10:50:56Z\" level=info msg=\"Kill containers\" \ntime=\"2018-11-19T10:50:56Z\" level=info msg=\"Killing /k8s_mongo-sidecar_mongo-0_app-mongo-ns_43000a53-ebbd-11e8-8d36-42010a800143_0 (55cfd1c783af7e79c72dd4300c930379024bea7da7c52913da5a8bbcf196711d) with signal SIGKILL\" \ntime=\"2018-11-19T10:50:57Z\" level=info msg=\"Killing /k8s_mongo_mongo-0_app-mongo-ns_43000a53-ebbd-11e8-8d36-42010a800143_0 (e2cd2efeb7772c5ab6f8f26053fe6251376c991083eeca3edc886fe3a37ef25a) with signal SIGKILL\" \ntime=\"2018-11-19T10:51:11Z\" level=info msg=\"Kill containers\" \ntime=\"2018-11-19T10:51:11Z\" level=info msg=\"Killing /k8s_mongo-sidecar_mongo-0_app-mongo-ns_43000a53-ebbd-11e8-8d36-42010a800143_1 (cfdfa8c97b35e51ce5c8e383e1ec51549af899774fc6de57f17fc49bdf62302e) with signal SIGKILL\" \ntime=\"2018-11-19T10:51:11Z\" level=info msg=\"Killing /k8s_mongo_mongo-0_app-mongo-ns_43000a53-ebbd-11e8-8d36-42010a800143_1 (6c4cf087dc9a202b0ee3c4923919da0d6d36904f7de7cc40dc138e706719233c) with signal SIGKILL\" \ntime=\"2018-11-19T10:51:26Z\" level=info msg=\"Kill containers\" ", "stderr_lines": ["time=\"2018-11-19T10:50:56Z\" level=info msg=\"Kill containers\" ", "time=\"2018-11-19T10:50:56Z\" level=info msg=\"Killing /k8s_mongo-sidecar_mongo-0_app-mongo-ns_43000a53-ebbd-11e8-8d36-42010a800143_0 (55cfd1c783af7e79c72dd4300c930379024bea7da7c52913da5a8bbcf196711d) with signal SIGKILL\" ", "time=\"2018-11-19T10:50:57Z\" level=info msg=\"Killing /k8s_mongo_mongo-0_app-mongo-ns_43000a53-ebbd-11e8-8d36-42010a800143_0 (e2cd2efeb7772c5ab6f8f26053fe6251376c991083eeca3edc886fe3a37ef25a) with signal SIGKILL\" ", "time=\"2018-11-19T10:51:11Z\" level=info msg=\"Kill containers\" ", "time=\"2018-11-19T10:51:11Z\" level=info msg=\"Killing /k8s_mongo-sidecar_mongo-0_app-mongo-ns_43000a53-ebbd-11e8-8d36-42010a800143_1 (cfdfa8c97b35e51ce5c8e383e1ec51549af899774fc6de57f17fc49bdf62302e) with signal SIGKILL\" ", "time=\"2018-11-19T10:51:11Z\" level=info msg=\"Killing /k8s_mongo_mongo-0_app-mongo-ns_43000a53-ebbd-11e8-8d36-42010a800143_1 (6c4cf087dc9a202b0ee3c4923919da0d6d36904f7de7cc40dc138e706719233c) with signal SIGKILL\" ", "time=\"2018-11-19T10:51:26Z\" level=info msg=\"Kill containers\" "], "stdout": "", "stdout_lines": []}

TASK [Wait for application pod reschedule] *************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:72
ok: [127.0.0.1] => {"changed": false, "elapsed": 30, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:80
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:87
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /jenkins/chaos/app_pod_failure/test.yml:114
included: /common/utils/check_deployment_status.yml for 127.0.0.1

TASK [Check the pod status] ****************************************************
task path: /common/utils/check_deployment_status.yml:8
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [obtain the number of replicas.] ******************************************
task path: /common/utils/check_deployment_status.yml:22
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-mongo-ns -l app=mongo -o custom-columns=:spec.replicas", "delta": "0:00:00.870704", "end": "2018-11-19 10:52:07.938059", "rc": 0, "start": "2018-11-19 10:52:07.067355", "stderr": "", "stderr_lines": [], "stdout": "\n3", "stdout_lines": ["", "3"]}

TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /common/utils/check_deployment_status.yml:29
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-mongo-ns -l app=mongo -o custom-columns=:..readyReplicas", "delta": "0:00:00.925093", "end": "2018-11-19 10:52:09.080594", "rc": 0, "start": "2018-11-19 10:52:08.155501", "stderr": "", "stderr_lines": [], "stdout": "\n3", "stdout_lines": ["", "3"]}

TASK [Checking status of liveness pod] *****************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:119
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:128
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /jenkins/chaos/app_pod_failure/test.yml:139
changed: [127.0.0.1] => {"changed": true, "checksum": "aeb9292d9ee23fa35ed460339f012b46a02512e4", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "7f4dd582dd4d3f7d7e8d6ac97ad4045f", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1542624729.31-190494205820814/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:150
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.089076", "end": "2018-11-19 10:52:12.448328", "failed_when_result": false, "rc": 0, "start": "2018-11-19 10:52:11.359252", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/application-pod-failure configured", "stdout_lines": ["litmusresult.litmus.io/application-pod-failure configured"]}

TASK [include_tasks] ***********************************************************
task path: /jenkins/chaos/app_pod_failure/test.yml:157
included: /chaoslib/pumba/pod_failure_by_sigkill.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:11
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the application node] *******************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:23
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the application node name] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:31
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the application container] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:37
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the app_container] ************************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:47
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the pumba pod on app node] ****************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:53
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Force kill the application pod using pumba] ******************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:62
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Wait for application pod reschedule] *************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:72
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:80
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n app-mongo-ns", "delta": "0:00:00.988132", "end": "2018-11-19 10:52:14.070849", "rc": 0, "start": "2018-11-19 10:52:13.082717", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:87
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -n app-mongo-ns", "delta": "0:00:01.020826", "end": "2018-11-19 10:52:15.367429", "rc": 0, "start": "2018-11-19 10:52:14.346603", "stderr": "", "stderr_lines": [], "stdout": "pumba-22ftp   0/1   Terminating   0     1m\npumba-mdzbm   0/1   Terminating   0     1m\npumba-rdp24   0/1   Terminating   0     1m", "stdout_lines": ["pumba-22ftp   0/1   Terminating   0     1m", "pumba-mdzbm   0/1   Terminating   0     1m", "pumba-rdp24   0/1   Terminating   0     1m"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=27   changed=17   unreachable=0    failed=0
```
https://gitlab.openebs.ci/openebs/e2e-gcp/pipelines/4779