### PR TITLE
(refactor)(yaml): update percona deployment template to include liveness probe

### DIFF
--- a/apps/percona/deployers/percona.yml
+++ b/apps/percona/deployers/percona.yml
@@ -20,7 +20,7 @@ spec:
             limits:
               cpu: 0.5
           name: percona
-          image: percona
+          image: openebs/tests-custom-percona:latest
           imagePullPolicy: IfNotPresent
           args:
             - "--ignore-db-dir"
@@ -34,6 +34,12 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: data-vol
+          livenessProbe:
+            exec:
+              command: ["bash", "sql-test.sh"]
+            initialDelaySeconds: 60
+            periodSeconds: 1
+            timeoutSeconds: 10
       volumes:
         - name: data-vol
           persistentVolumeClaim:


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

In Litmus, currently, all stateful applications (i.e., databases) have a corresponding : 

a) "external liveness" check which will verify whether an application is accessible from a client-like end-application

b) "workload/loadgen" jobs which will ensure that application specific data is pumped into the stateful applications. They are being used in litmus/e2e for:

     i) Relative BM measurements
     ii) Fill apps with some data before running functional/chaos tests

However, (b) is short-lived - doesn't run through duration of test. To have active I/Os during chaos, we need "probes" on the application which can keep performing I/O & will accelerate RO conditions. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- Though named the same (a) is designed in cases where it is not known prior if app has a liveness probe configured or no, i.e., it is a way to ascertain cluster health when a user exposes a health endpoint. 