### PR TITLE
(refactor)(yaml): update the pool chaos litmus book w/ env for chaos type

### DIFF
--- a/apps/percona/chaos/cstor_pool_failure/run_litmus_test.yml
+++ b/apps/percona/chaos/cstor_pool_failure/run_litmus_test.yml
@@ -12,6 +12,16 @@ spec:
     spec:
       serviceAccountName: litmus
       restartPolicy: Never
+
+      #nodeSelector:
+      #  kubernetes.io/hostname:
+
+      tolerations:
+        - key: "infra-aid"
+          value: "observer"
+          operator: "Equal"
+          effect: "NoSchedule"
+
       containers:
       - name: ansibletest
         image: openebs/ansible-runner:ci
@@ -38,6 +48,9 @@ spec:
 
           - name: DATA_PERSISTENCY
             value: "enable"  
+
+          - name: CHAOS_TYPE
+            value: "pool-delete" 
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./percona/chaos/cstor_pool_failure/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/apps/percona/chaos/cstor_pool_failure/test_vars.yml
+++ b/apps/percona/chaos/cstor_pool_failure/test_vars.yml
@@ -6,5 +6,5 @@ liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
 data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
 liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
 operator_ns: openebs
-chaos_type: pool-kill
+chaos_type: "{{ lookup('env','CHAOS_TYPE') }}" 
 


### PR DESCRIPTION

Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- More than one chaoslib/test can be invoked via the pool chaos litmusbook. 
- Use a `CHAOS_TYPE` env to select the type of pool chaos

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
