### PR TITLE
feat(litmus): Add capacity test cases

### DIFF
--- a/apps/fio/tests/capacity/fio.yml
+++ b/apps/fio/tests/capacity/fio.yml
@@ -15,9 +15,10 @@ spec:
         kubernetes.io/hostname: testNode
       containers:
       - name: perfrunner
-        image: openebs/tests-fio:ci
+        image: openebs/tests-fio
         command: ["/bin/bash"]
-        args: ["-c", "./fio_runner.sh --template file/basic-rw --size 256m --duration 60; exit 0"]
+        # value of testduration will be set to zero
+        args: ["-c", "./fio_runner.sh --template file/testtemplate --size testsize --duration testduration; exit 0"]
         volumeMounts:
            - mountPath: /datadir
              name: fio-vol

--- a/apps/fio/tests/capacity/fio.yml
+++ b/apps/fio/tests/capacity/fio.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fio
+spec:
+  template:
+    metadata:
+      name: fio
+      labels:
+        name: fio
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: testNode
+      containers:
+      - name: perfrunner
+        image: openebs/tests-fio:ci
+        command: ["/bin/bash"]
+        args: ["-c", "./fio_runner.sh --template file/basic-rw --size 256m --duration 60; exit 0"]
+        volumeMounts:
+           - mountPath: /datadir
+             name: fio-vol
+        tty: true
+      volumes:
+      - name: fio-vol
+        persistentVolumeClaim:
+          claimName: testclaim
+---

--- a/apps/fio/tests/capacity/run_litmus_test.yml
+++ b/apps/fio/tests/capacity/run_litmus_test.yml
@@ -1,0 +1,64 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-fio-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+       name: litmus
+       labels:
+         app: fio-benchmark-litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-standard
+            #value: local-storage
+
+          - name: APP_NODE_SELECTOR
+            value: kubeminion-01
+
+          - name: FIO_TEST_PROFILE
+            value: standard-ssd
+
+          - name: FIO_SAMPLE_SIZE
+            value: "1024m"
+
+          - name: FIO_TESTRUN_PERIOD
+            value: "240"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./fio/tests/capacity/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+          - name: logs
+            mountPath: /var/log/ansible
+        tty: true
+      - name: logger
+        image: openebs/logger
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d 10 -r maya,openebs,pvc,fio; exit 0"]
+        volumeMounts:
+          - name: kubeconfig
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt
+        tty: true
+      volumes:
+        - name: kubeconfig
+          configMap:
+            name: kubeconfig
+        - name: logs
+          hostPath:
+            path: /mnt/fio
+            type: ""
+

--- a/apps/fio/tests/capacity/run_litmus_test.yml
+++ b/apps/fio/tests/capacity/run_litmus_test.yml
@@ -27,17 +27,21 @@ spec:
           - name: APP_NODE_SELECTOR
             value: kubeminion-01
 
+          # this template is used for random write with sync
           - name: FIO_TEST_PROFILE
-            value: standard-ssd
+            value: basic-write
 
+          # 1024m data will be written randomly so that more
+          # extents will be generated and will delay adding replica
           - name: FIO_SAMPLE_SIZE
             value: "1024m"
 
+          # Setting to zero such that fio completes running load
           - name: FIO_TESTRUN_PERIOD
-            value: "240"
+            value: "0"
 
         command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./fio/tests/capacity/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        args: ["-c", "ansible-playbook ./fio/tests/capacity/test.yml -i /etc/ansible/hosts -v; exit 0"]
         volumeMounts:
           - name: logs
             mountPath: /var/log/ansible

--- a/apps/fio/tests/capacity/test.yml
+++ b/apps/fio/tests/capacity/test.yml
@@ -30,13 +30,17 @@
 
        - name: Confirm pvc status is bound
          shell: >
-           kubectl get pvc --no-headers -n litmus
+           kubectl get pvc --no-headers -n litmus -l app=test-capacity
          args:
            executable: /bin/bash
          register: result
          until: "'openebs-standard' and 'Bound' in result.stdout"
-         delay: 120
-         retries: 15
+         delay: 30
+         retries: 50
+
+       - name: Wait for controller to get ready
+         wait_for:
+           timeout: 60
 
        ## RUN FIO WORKLOAD TEST
        - name: Populate the iterator with the values to loop
@@ -45,6 +49,7 @@
          args:
            executable: /bin/bash
          register: iterator
+
        - include: test_capacity.yml
          with_items: "{{ iterator.stdout_lines }}"
 

--- a/apps/fio/tests/capacity/test.yml
+++ b/apps/fio/tests/capacity/test.yml
@@ -1,0 +1,59 @@
+# TODO 
+# Change pod status checks to container status checks (containerStatuses)
+# O/P result
+
+- hosts: localhost
+  connection: local  
+
+  vars_files:
+    - test_vars.yml
+ 
+  tasks:
+   - block:
+       - name: Replace the pvc placeholder with test param in pvc spec
+         replace:
+           path: "{{ pvc_yaml_alias }}"
+           regexp: "testclaim"
+           replace: "{{ test_name }}"
+
+       - name: Replace the storageclass placeholder with provider
+         replace:
+           path: "{{ pvc_yaml_alias }}"
+           regexp: "testclass"
+           replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+       - name: Create pvc 
+         shell: >
+           kubectl apply -f {{ pvc_yaml_alias }} -n litmus
+         args:
+           executable: /bin/bash
+
+       - name: Confirm pvc status is bound
+         shell: >
+           kubectl get pvc --no-headers -n litmus
+         args:
+           executable: /bin/bash
+         register: result
+         until: "'openebs-standard' and 'Bound' in result.stdout"
+         delay: 120
+         retries: 15
+
+       ## RUN FIO WORKLOAD TEST
+       - name: Populate the iterator with the values to loop
+         shell: >
+           shuf -i 1-50 -n 20
+         args:
+           executable: /bin/bash
+         register: iterator
+       - include: test_capacity.yml
+         with_items: "{{ iterator.stdout_lines }}"
+
+       - set_fact:
+           flag: "Pass"
+
+     rescue: 
+       - set_fact: 
+           flag: "Fail"
+
+     always:
+       - include: test_cleanup.yml

--- a/apps/fio/tests/capacity/test_capacity.yml
+++ b/apps/fio/tests/capacity/test_capacity.yml
@@ -1,0 +1,168 @@
+---
+## PRE-CONDITION THE APPLICATION DEPLOYMENT SPECS WITH TEST PARAMS
+
+- name: Replace the app node placeholder with perf-intensive node
+  replace:
+    path: "{{ pod_yaml_alias }}"
+    regexp: "testNode"
+    replace: "{{ lookup('env','APP_NODE_SELECTOR') }}"
+
+# FIO-SPECIFIC PRE-CONDITIONING
+
+- name: Replace the default fio profile with user-defined profile
+  replace:
+    path: "{{ pod_yaml_alias }}"
+    regexp: "basic-rw"
+    replace: "{{ lookup('env','FIO_TEST_PROFILE') }}"
+
+- name: Replace the default I/O sample size with user-defined profile
+  replace:
+    path: "{{ pod_yaml_alias }}"
+    regexp: "256m"
+    replace: "{{ lookup('env','FIO_SAMPLE_SIZE') }}"
+
+- name: Replace the default I/O test duration with user-defined period
+  replace:
+    path: "{{ pod_yaml_alias }}"
+    regexp: "60"
+    replace: "{{ lookup('env','FIO_TESTRUN_PERIOD') }}"
+
+- name: Replace the pvc placeholder with test param in app spec
+  replace:
+    path: "{{ pod_yaml_alias }}"
+    regexp: "testclaim"
+    replace: "{{ test_name }}"
+
+- name: Get controller svc
+  shell: >
+    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc
+    -n litmus --no-headers -o custom-columns=:spec.clusterIP
+  args:
+    executable: /bin/bash
+  register: controller_svc
+  failed_when: controller_svc.stdout == ""
+
+- name: Get controller response at /v1/volumes
+  vars:
+    volumes_endpoint: "9501/v1/volumes"
+  uri:
+    url: "http://{{ controller_svc.stdout }}:{{ volumes_endpoint }}"
+    method: GET
+    return_content: yes
+    status_code: 200
+    headers:
+      Content-Type: "application/json"
+    body_format: json
+  register: json_response
+  until: json_response.json.data[0].readOnly == "false"
+  retries: 30
+  delay: 60
+
+- name: Deploy fio test job
+  shell: >
+    kubectl apply -f {{ pod_yaml_alias }} -n litmus
+  args: 
+    executable: /bin/bash
+
+- name: Confirm fio pod status is running
+  shell: >
+     kubectl get pods -l name=fio -n litmus
+     --no-headers
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'fio' and 'Running' in result.stdout"
+  delay: 120
+  retries: 15
+
+- name: Obtain name of fio pod
+  set_fact:
+    fio_pod_name: "{{ result.stdout.split()[0] }}"
+
+- name: Wait for fio pod to proceed with workload
+  wait_for:
+    timeout: 60
+
+- name: Re-Check fio pod status
+  shell: >
+    kubectl get pod {{ fio_pod_name }} -n litmus
+    --no-headers -o custom-columns=:status.phase
+  args:
+    executable: /bin/bash
+  register: result
+  failed_when: "result.stdout not in ['Running', 'Succeeded']"
+
+- name: Confirm fio job completion status (poll & wait for upperbound of 60 min)
+  shell: >
+    kubectl get pod {{ fio_pod_name }} -n litmus
+    --no-headers -o custom-columns=:status.phase
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'Succeeded' in result.stdout"
+  delay: 120
+  retries: 30
+
+- name: Verify the fio logs to check if run is complete w/o errors
+  shell: >
+    kubectl logs {{ fio_pod_name }} -n litmus
+    | grep -i error | cut -d ":" -f 2
+    | sort | uniq
+  args:
+    executable: /bin/bash
+  register: result
+  failed_when: result.stdout != " 0,"
+
+- name: Get the name of replica pods
+  shell: >
+    kubectl get pods -l openebs.io/replica=jiva-replica
+    -n litmus --no-headers -o name | sed "s/^.\{4\}//"
+  args:
+    executable: /bin/bash
+  register: replica_pod
+
+- name: Set the replica pod names to variables
+  set_fact:
+    replica_name_one: "{{ replica_pod.stdout_lines[0].split()[0] }}"
+    replica_name_two: "{{ replica_pod.stdout_lines[1].split()[0] }}"
+
+- name: Delete fio job
+  shell: >
+    kubectl delete -f {{ pod_yaml_alias }} -n litmus
+  args:
+    executable: /bin/bash
+
+- name: Confirm fio pod has been deleted
+  shell: >
+    kubectl get pod -n litmus
+  args:
+    executable: /bin/bash
+  register: fio_pod_status
+  until: "'fio_pod_name' not in fio_pod_status.stdout"
+  delay: 30
+  retries: 12
+
+- name: Pick one replica randomly from list to two for deletion
+  set_fact:
+    random_replica: "{{ line_item }}"
+  with_random_choice:
+     - "{{ replica_name_one }}"
+     - "{{ replica_name_two }}"
+  loop_control:
+    loop_var: line_item
+
+- name: Delete one of the replica
+  shell: >
+    kubectl delete pod {{ random_replica }} -n litmus
+  args:
+    executable: /bin/bash
+
+- name: Confirm replica pod has been deleted
+  shell: >
+    kubectl get pods -n litmus
+  args:
+    executable: /bin/bash
+  register: replica_pod_status
+  until: "'random_replica' not in replica_pod_status.stdout"
+  delay: 30
+  retries: 12

--- a/apps/fio/tests/capacity/test_capacity.yml
+++ b/apps/fio/tests/capacity/test_capacity.yml
@@ -112,7 +112,7 @@
 - name: Get the name of replica pods
   shell: >
     kubectl get pods -l openebs.io/replica=jiva-replica
-    -n litmus --no-headers -o name | sed "s/^.\{4\}//"
+    -n litmus --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}'
   args:
     executable: /bin/bash
   register: replica_pod

--- a/apps/fio/tests/capacity/test_capacity.yml
+++ b/apps/fio/tests/capacity/test_capacity.yml
@@ -12,26 +12,26 @@
 - name: Replace the default fio profile with user-defined profile
   replace:
     path: "{{ pod_yaml_alias }}"
-    regexp: "basic-rw"
+    regexp: "testtemplate"
     replace: "{{ lookup('env','FIO_TEST_PROFILE') }}"
 
 - name: Replace the default I/O sample size with user-defined profile
   replace:
     path: "{{ pod_yaml_alias }}"
-    regexp: "256m"
+    regexp: "testsize"
     replace: "{{ lookup('env','FIO_SAMPLE_SIZE') }}"
-
-- name: Replace the default I/O test duration with user-defined period
-  replace:
-    path: "{{ pod_yaml_alias }}"
-    regexp: "60"
-    replace: "{{ lookup('env','FIO_TESTRUN_PERIOD') }}"
 
 - name: Replace the pvc placeholder with test param in app spec
   replace:
     path: "{{ pod_yaml_alias }}"
     regexp: "testclaim"
     replace: "{{ test_name }}"
+
+- name: Replace the default I/O test duration with user-defined period
+  replace:
+    path: "{{ pod_yaml_alias }}"
+    regexp: "testduration"
+    replace: "{{ lookup('env','FIO_TESTRUN_PERIOD') }}"
 
 - name: Get controller svc
   shell: >
@@ -55,16 +55,16 @@
     body_format: json
   register: json_response
   until: json_response.json.data[0].readOnly == "false"
-  retries: 30
+  retries: 100
   delay: 60
 
 - name: Deploy fio test job
   shell: >
     kubectl apply -f {{ pod_yaml_alias }} -n litmus
-  args: 
+  args:
     executable: /bin/bash
 
-- name: Confirm fio pod status is running
+- name: Get name of fio pod
   shell: >
      kubectl get pods -l name=fio -n litmus
      --no-headers
@@ -72,18 +72,14 @@
     executable: /bin/bash
   register: result
   until: "'fio' and 'Running' in result.stdout"
-  delay: 120
-  retries: 15
+  delay: 10
+  retries: 30
 
 - name: Obtain name of fio pod
   set_fact:
     fio_pod_name: "{{ result.stdout.split()[0] }}"
 
-- name: Wait for fio pod to proceed with workload
-  wait_for:
-    timeout: 60
-
-- name: Re-Check fio pod status
+- name: Check fio pod status
   shell: >
     kubectl get pod {{ fio_pod_name }} -n litmus
     --no-headers -o custom-columns=:status.phase
@@ -92,7 +88,7 @@
   register: result
   failed_when: "result.stdout not in ['Running', 'Succeeded']"
 
-- name: Confirm fio job completion status (poll & wait for upperbound of 60 min)
+- name: Confirm fio job completion status (poll and wait every 120 sec)
   shell: >
     kubectl get pod {{ fio_pod_name }} -n litmus
     --no-headers -o custom-columns=:status.phase
@@ -142,7 +138,7 @@
   delay: 30
   retries: 12
 
-- name: Pick one replica randomly from list to two for deletion
+- name: Pick one replica randomly from list of two for deletion
   set_fact:
     random_replica: "{{ line_item }}"
   with_random_choice:

--- a/apps/fio/tests/capacity/test_cleanup.yml
+++ b/apps/fio/tests/capacity/test_cleanup.yml
@@ -1,13 +1,4 @@
 ---
-- name: Get pvc name to verify successful pvc deletion
-  shell: >
-    kubectl get pvc {{ test_name }} 
-    -o custom-columns=:spec.volumeName -n litmus 
-    --no-headers
-  args:
-    executable: /bin/bash
-  register: pv
-
 - name: Confirm fio pod has been deleted
   shell: >
     kubectl get pods -n litmus
@@ -18,11 +9,17 @@
   delay: 30
   retries: 12
 
-- block:
-    - name: Remove the local persistent volume 
-      shell: kubectl delete pv {{ pv.stdout }}
-      args:
-        executable: /bin/bash
-      register: result
-      failed_when: "'persistentvolume' and 'deleted' not in result.stdout"
-  when: "'openebs-standard' in lookup('env','PROVIDER_STORAGE_CLASS')"
+- name: Remove the local persistent volume 
+  shell: >
+    kubectl delete -f {{ pvc_yaml_alias }} -n litmus
+  args:
+    executable: /bin/bash
+
+- name: Check if pvc is deleted
+  shell: >
+    kubectl get pvc -n litmus -l app=test-capacity
+  args:
+    executable: /bin/bash
+  until: "'No resources found' in result.stderr"
+  delay: 10
+  retries: 30

--- a/apps/fio/tests/capacity/test_cleanup.yml
+++ b/apps/fio/tests/capacity/test_cleanup.yml
@@ -1,0 +1,28 @@
+---
+- name: Get pvc name to verify successful pvc deletion
+  shell: >
+    kubectl get pvc {{ test_name }} 
+    -o custom-columns=:spec.volumeName -n litmus 
+    --no-headers
+  args:
+    executable: /bin/bash
+  register: pv
+
+- name: Confirm fio pod has been deleted
+  shell: >
+    kubectl get pods -n litmus
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'fio_pod_name' not in result.stdout"
+  delay: 30
+  retries: 12
+
+- block:
+    - name: Remove the local persistent volume 
+      shell: kubectl delete pv {{ pv.stdout }}
+      args:
+        executable: /bin/bash
+      register: result
+      failed_when: "'persistentvolume' and 'deleted' not in result.stdout"
+  when: "'openebs-standard' in lookup('env','PROVIDER_STORAGE_CLASS')"

--- a/apps/fio/tests/capacity/test_vars.yml
+++ b/apps/fio/tests/capacity/test_vars.yml
@@ -1,0 +1,6 @@
+---
+## TEST-SPECIFIC PARAMS
+
+test_name: fio-benchmark
+pod_yaml_alias: fio.yml
+pvc_yaml_alias: testclaim-pvc.yml

--- a/apps/fio/tests/capacity/testclaim-pvc.yml
+++ b/apps/fio/tests/capacity/testclaim-pvc.yml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: testclaim
+spec:
+  storageClassName: testclass
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "25G"

--- a/apps/fio/tests/capacity/testclaim-pvc.yml
+++ b/apps/fio/tests/capacity/testclaim-pvc.yml
@@ -2,6 +2,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: testclaim
+  labels:
+    app: test-capacity
 spec:
   storageClassName: testclass
   accessModes:


### PR DESCRIPTION
This commit add following test cases:
- Volume creation of 25GB
- Bringing one of the replicas down multiple times randomly
  to create autogenerated snapshots and writing data randomly.
- Ensure the replicas getting connected after and volume is
  in RW mode.

### Note:  
* As per the current build of jiva >= 0.7.0 this test will be failing due to bug in jiva (for random writes).

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>
