### PR TITLE
refactor(yaml) Update Openebs operator tag to CI and set memory benchmark as job ENV

### DIFF
--- a/apps/custom/tests/memcheck/run_litmus_test.yml
+++ b/apps/custom/tests/memcheck/run_litmus_test.yml
@@ -27,6 +27,9 @@ spec:
           - name: APP_NAMESPACE
             value: memleak
 
+          - name: MEMORY_BM
+            value: '800'
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./custom/tests/memcheck/test.yml -i /etc/ansible/hosts -v; exit 0"]
         volumeMounts:

--- a/apps/custom/tests/memcheck/test-mem.py
+++ b/apps/custom/tests/memcheck/test-mem.py
@@ -8,6 +8,7 @@ import subprocess
 import time, os, sys
 list = []
 namespace = sys.argv[1]
+benchmark = sys.argv[2]
 cmd_cntrl_name = "kubectl get pod -n %s -l openebs.io/controller=jiva-controller --no-headers | awk '{print $1}'" %(namespace)
 print cmd_cntrl_name
 out = subprocess.Popen(cmd_cntrl_name,stdout=subprocess.PIPE,shell=True)
@@ -29,7 +30,7 @@ while count < n:
     used_mem = out.communicate()
     mem_in_mb = int(used_mem[0])/1024
     print mem_in_mb, "MB"
-    if mem_in_mb < 800:
+    if mem_in_mb < benchmark:
         time.sleep(20)
     else:
         print "Fail"

--- a/apps/custom/tests/memcheck/test.yml
+++ b/apps/custom/tests/memcheck/test.yml
@@ -61,7 +61,7 @@
          retries: 10
 
        - name: Run python script for memory usage validation it takes couple of minutes
-         shell: python test-mem.py {{ app_ns }}
+         shell: python test-mem.py {{ app_ns }} {{ memory_bm }}
          args:
            executable: /bin/bash
          register: result

--- a/apps/custom/tests/memcheck/test_vars.yml
+++ b/apps/custom/tests/memcheck/test_vars.yml
@@ -4,3 +4,4 @@
 test_name: memleak-test
 memleak_yml: memleak.yml
 app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+memory_bm: "{{ lookup('env','MEMORY_BM') }}"

--- a/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
@@ -23,7 +23,7 @@ spec:
           - name: ANSIBLE_STDOUT_CALLBACK
             value: default
           - name: OPENEBS_VERSION
-            value: v0.7.x
+            value: master
           - name: MAYA_APISERVER_IMAGE
             value:
           - name: OPENEBS_PROVISIONER_IMAGE


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Update Openebs operator tag to CI 
- Set memory consumption for jiva's benchmark value via litmus job ENV

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
