### PR TITLE
(test): Litmus book to perform target network loss 

### DIFF
--- a/apps/percona/chaos/openebs_target_network_loss/chaosutil.j2
+++ b/apps/percona/chaos/openebs_target_network_loss/chaosutil.j2
@@ -1,0 +1,7 @@
+{% if stg_prov is defined and stg_prov == 'openebs.io/provisioner-iscsi' %}
+  {% if stg_engine is defined and stg_engine == 'cstor' %}
+    chaosutil: openebs/cstor_target_network_delay.yaml
+  {% else %}
+    chaosutil: openebs/jiva_controller_network_delay.yaml
+  {% endif %}
+{% endif %}

--- a/apps/percona/chaos/openebs_target_network_loss/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_target_network_loss/run_litmus_test.yml
@@ -1,0 +1,88 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: openebs-target-network-loss- 
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      labels:
+        name: openebs-target-network-loss
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: mockbot/ansible-runner:2
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+          - name: OPERATOR_NAMESPACE
+            value: openebs
+ 
+          - name: APP_NAMESPACE
+            value: app-percona-ns 
+
+          - name: APP_LABEL
+            value: 'name=percona'
+
+          - name: APP_PVC
+            value: percona-mysql-claim
+
+          - name: NETWORK_DELAY
+            value: "240000" # in milliseconds
+
+          - name: CHAOS_DURATION
+            value: "240" # in seconds
+
+          - name: LIVENESS_APP_LABEL
+            value: ""
+
+          - name: LIVENESS_APP_NAMESPACE
+            value: ""
+
+          - name: DATA_PERSISTENCY
+            value: 'enable'
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./percona/chaos/openebs_target_network_loss/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+          - name: logs 
+            mountPath: /var/log/ansible 
+        tty: true
+      - name: logger
+        image: openebs/logger
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # spec.volumes is not supported by downward API
+          - name: MY_POD_HOSTPATH
+            value: /mnt/chaos/openebs_target_network_loss
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,percona; exit 0"] 
+        volumeMounts:
+          - name: kubeconfig 
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt 
+        tty: true 
+      volumes: 
+        - name: kubeconfig
+          configMap: 
+            name: kubeconfig 
+        - name: logs 
+          hostPath:
+            path: /mnt/chaos/openebs_target_network_loss
+            type: ""
+

--- a/apps/percona/chaos/openebs_target_network_loss/test.yml
+++ b/apps/percona/chaos/openebs_target_network_loss/test.yml
@@ -1,0 +1,185 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+        ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE
+        - block:
+
+            - name: Checking status of liveness pod
+              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
+              register: liveness_pod
+              until: "'Running' in liveness_pod.stdout"
+              delay: 10
+              retries: 10
+
+          when: liveness_label != ''
+
+        - include: test_prerequisites.yml
+
+        - include_vars:
+            file: chaosutil.yml
+
+        - name: Record the chaos util path
+          set_fact:
+            chaos_util_path: "/chaoslib/{{ chaosutil }}"
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "{{ chaosutil.split('.')[0] }}"
+
+        ## DISPLAY APP INFORMATION
+
+        - name: Display the app information passed via the test job
+          debug:
+            msg:
+              - "The application info is as follows:"
+              - "Namespace    : {{ namespace }}"
+              - "Label        : {{ label }}"
+              - "PVC          : {{ pvc }}"
+              - "StorageClass : {{ sc }}"
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify that the AUT (Application Under Test) is running
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          delay: 10
+          retries: 12
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
+        - name: Create some test data in the mysql database
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'
+          when: data_persistance != ''
+
+        ## STORAGE FAULT INJECTION
+
+        - include: "{{ chaos_util_path }}"
+          app_ns: "{{ namespace }}"
+          app_pvc: "{{ pvc }}"
+          network_delay: "{{ n_delay }}"
+          chaos_duration: "{{ c_duration }}"
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+
+        - name: Verify AUT liveness post fault-injection
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} 
+            -o jsonpath='{.items[*].status.containerStatuses[].state.waiting.reason}'
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'CrashLoopBackOff' in app_status.stdout"
+          delay: 10
+          retries: 12
+
+        - name: Delete the previous application pod
+          shell: kubectl delete pod {{ app_pod_name.stdout }} -n {{ namespace }}
+          args:
+           executable: /bin/bash
+          register: app_pod
+
+        - name: Check whether the application pod is deleted 
+          shell: kubectl get pods -n {{ namespace }}
+          args:
+            executable: /bin/bash
+          register: pod_status
+          until: "app_pod_name.stdout not in pod_status.stdout"
+          delay: 20
+          retries: 15
+
+        - name: Check the application pod is rescheduled
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: new_app_status
+          until: "((new_app_status.stdout_lines|unique)|length) == 1 and 'Running' in new_app_status.stdout"
+          delay: 10
+          retries: 15
+
+        - name: Get the new application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: new_pod_name
+
+        - block:
+
+            - name: Checking status of liveness pod
+              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
+              register: liveness_pod
+              until: "'Running' in liveness_pod.stdout"
+              delay: 10
+              retries: 10
+
+          when: liveness_label != ''
+
+        - name: Verify mysql data persistence
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ new_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'
+          when: data_persistance != ''
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+            chaostype: "{{ chaosutil.split('.')[0] }}"

--- a/apps/percona/chaos/openebs_target_network_loss/test_prerequisites.yml
+++ b/apps/percona/chaos/openebs_target_network_loss/test_prerequisites.yml
@@ -1,0 +1,52 @@
+---
+- name: Identify the storage class used by the PVC
+  shell: >
+    kubectl get pvc {{ pvc }} -n {{ namespace }} 
+    --no-headers -o custom-columns=:spec.storageClassName
+  args:
+    executable: /bin/bash
+  register: storage_class
+
+- name: Identify the storage provisioner used by the SC
+  shell: >
+    kubectl get sc {{ storage_class.stdout }}
+    --no-headers -o custom-columns=:provisioner
+  args:
+    executable: /bin/bash
+  register: provisioner
+
+- name: Record the storage class name
+  set_fact: 
+    sc: "{{ storage_class.stdout }}"
+
+- name: Record the storage provisioner name
+  set_fact:
+    stg_prov: "{{ provisioner.stdout }}"
+
+- block:
+    - name: Derive PV name from PVC to query storage engine type (openebs)
+      shell: >
+        kubectl get pvc {{ pvc }} -n {{ namespace }}
+        --no-headers -o custom-columns=:spec.volumeName
+      args:
+        executable: /bin/bash
+      register: pv
+
+    - name: Check for presence & value of cas type annotation
+      shell: >
+        kubectl get pv {{ pv.stdout }} --no-headers
+        -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
+      args:
+        executable: /bin/bash
+      register: openebs_stg_engine
+
+    - name: Record the storage engine name
+      set_fact:
+        stg_engine: "{{ openebs_stg_engine.stdout }}"
+  when: stg_prov == "openebs.io/provisioner-iscsi"
+
+- name: Identify the chaos util to be invoked 
+  template:
+    src: chaosutil.j2
+    dest: chaosutil.yml
+

--- a/apps/percona/chaos/openebs_target_network_loss/test_vars.yml
+++ b/apps/percona/chaos/openebs_target_network_loss/test_vars.yml
@@ -1,0 +1,11 @@
+test_name: openebs-target-network-loss
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+label: "{{ lookup('env','APP_LABEL') }}"
+pvc: "{{ lookup('env','APP_PVC') }}"
+n_delay: "{{ lookup('env','NETWORK_DELAY') }}" 
+c_duration: "{{ lookup('env','CHAOS_DURATION') }}"
+operator_ns: "{{ lookup('env','OPERATOR_NAMESPACE') }}"
+liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
+data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
+


### PR DESCRIPTION
Signed-off-by: sathyaseelan <sathyaseelan.n@cloudbyte.com>


- Included a litmus book to perform target loss

```
ansible-playbook 2.7.2
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /percona/chaos/openebs_target_network_loss/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./percona/chaos/openebs_target_network_loss/test.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:2
ok: [127.0.0.1]
META: ran handlers

TASK [Checking status of liveness pod] *****************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /percona/chaos/openebs_target_network_loss/test_prerequisites.yml:2
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n percona-cstor --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:01.329374", "end": "2018-11-22 11:12:33.748448", "rc": 0, "start": "2018-11-22 11:12:32.419074", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-sparse", "stdout_lines": ["openebs-cstor-sparse"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /percona/chaos/openebs_target_network_loss/test_prerequisites.yml:10
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse --no-headers -o custom-columns=:provisioner", "delta": "0:00:00.978842", "end": "2018-11-22 11:12:34.910195", "rc": 0, "start": "2018-11-22 11:12:33.931353", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /percona/chaos/openebs_target_network_loss/test_prerequisites.yml:18
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-cstor-sparse"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /percona/chaos/openebs_target_network_loss/test_prerequisites.yml:22
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /percona/chaos/openebs_target_network_loss/test_prerequisites.yml:27
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n percona-cstor --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.946494", "end": "2018-11-22 11:12:36.168604", "rc": 0, "start": "2018-11-22 11:12:35.222110", "stderr": "", "stderr_lines": [], "stdout": "pvc-651f30d1-ee46-11e8-8d36-42010a800143", "stdout_lines": ["pvc-651f30d1-ee46-11e8-8d36-42010a800143"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /percona/chaos/openebs_target_network_loss/test_prerequisites.yml:35
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-651f30d1-ee46-11e8-8d36-42010a800143 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:00.928225", "end": "2018-11-22 11:12:37.298026", "rc": 0, "start": "2018-11-22 11:12:36.369801", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}

TASK [Record the storage engine name] ******************************************
task path: /percona/chaos/openebs_target_network_loss/test_prerequisites.yml:43
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "cstor"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /percona/chaos/openebs_target_network_loss/test_prerequisites.yml:48
changed: [127.0.0.1] => {"changed": true, "checksum": "7ca53b55dd148c2150224ec1125fbc53928c4b45", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "50c961263ae78c55b30340eb6d3711ae", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1542885157.44-104179097604054/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:25
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/cstor_target_network_delay.yaml"}, "ansible_included_var_files": ["/percona/chaos/openebs_target_network_loss/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:28
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_target_network_delay.yaml"}, "changed": false}

TASK [Record test instance/run ID] *********************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:36
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:40
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:46
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
changed: [127.0.0.1] => {"changed": true, "checksum": "d9860de79e81adfa6880e9749445e534e4d83205", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "7802862277f22fe3145e79fb5cb57dce", "mode": "0644", "owner": "root", "size": 462, "src": "/root/.ansible/tmp/ansible-tmp-1542885158.39-128180295888876/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.803797", "end": "2018-11-22 11:12:39.593465", "rc": 0, "start": "2018-11-22 11:12:38.789668", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.206650", "end": "2018-11-22 11:12:41.085551", "failed_when_result": false, "rc": 0, "start": "2018-11-22 11:12:39.878901", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-loss configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-loss configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /percona/chaos/openebs_target_network_loss/test.yml:53
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : percona-cstor", 
        "Label        : name=percona", 
        "PVC          : percona-mysql-claim", 
        "StorageClass : openebs-cstor-sparse"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /percona/chaos/openebs_target_network_loss/test.yml:64
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-cstor -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.968262", "end": "2018-11-22 11:12:42.460797", "rc": 0, "start": "2018-11-22 11:12:41.492535", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:75
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-cstor -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.957174", "end": "2018-11-22 11:12:43.632533", "rc": 0, "start": "2018-11-22 11:12:42.675359", "stderr": "", "stderr_lines": [], "stdout": "percona-7d9fcc477f-cpznk", "stdout_lines": ["percona-7d9fcc477f-cpznk"]}

TASK [Create some test data in the mysql database] *****************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:83
included: /common/utils/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /common/utils/mysql_data_persistence.yml:4
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;') => {"changed": true, "cmd": "kubectl exec percona-7d9fcc477f-cpznk -n percona-cstor -- mysql -uroot -pk8sDem0 -e 'create database tdb;'", "delta": "0:00:01.108382", "end": "2018-11-22 11:12:45.096242", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "rc": 0, "start": "2018-11-22 11:12:43.987860", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb) => {"changed": true, "cmd": "kubectl exec percona-7d9fcc477f-cpznk -n percona-cstor -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "delta": "0:00:02.196789", "end": "2018-11-22 11:12:47.450377", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "rc": 0, "start": "2018-11-22 11:12:45.253588", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb) => {"changed": true, "cmd": "kubectl exec percona-7d9fcc477f-cpznk -n percona-cstor -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "delta": "0:00:01.510165", "end": "2018-11-22 11:12:49.146885", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "rc": 0, "start": "2018-11-22 11:12:47.636720", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Checking for the Corrupted tables] ***************************************
task path: /common/utils/mysql_data_persistence.yml:21
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /common/utils/mysql_data_persistence.yml:30
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:96
included: /chaoslib/openebs/cstor_target_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:1
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n percona-cstor", "delta": "0:00:01.069824", "end": "2018-11-22 11:12:50.587046", "rc": 0, "start": "2018-11-22 11:12:49.517222", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:9
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n percona-cstor | sort | uniq", "delta": "0:00:00.869084", "end": "2018-11-22 11:13:13.038761", "rc": 0, "start": "2018-11-22 11:13:12.169677", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:21
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n percona-cstor --no-headers", "delta": "0:00:00.866215", "end": "2018-11-22 11:13:14.141984", "rc": 0, "start": "2018-11-22 11:13:13.275769", "stderr": "", "stderr_lines": [], "stdout": "pvc-651f30d1-ee46-11e8-8d36-42010a800143", "stdout_lines": ["pvc-651f30d1-ee46-11e8-8d36-42010a800143"]}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:30
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/target=cstor-target -n openebs --no-headers | grep pvc-651f30d1-ee46-11e8-8d36-42010a800143 | shuf -n1 | awk '{print $1}'", "delta": "0:00:00.937106", "end": "2018-11-22 11:13:15.283381", "rc": 0, "start": "2018-11-22 11:13:14.346275", "stderr": "", "stderr_lines": [], "stdout": "pvc-651f30d1-ee46-11e8-8d36-42010a800143-target-778795f744blt48", "stdout_lines": ["pvc-651f30d1-ee46-11e8-8d36-42010a800143-target-778795f744blt48"]}

TASK [Record the cstor target container name] **********************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:39
ok: [127.0.0.1] => {"ansible_facts": {"cstor_target_name": "pvc-651f30d1-ee46-11e8-8d36-42010a800143"}, "changed": false}

TASK [Get the node on which the cstor target is scheduled] *********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:44
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-651f30d1-ee46-11e8-8d36-42010a800143-target-778795f744blt48 -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.970225", "end": "2018-11-22 11:13:16.519768", "rc": 0, "start": "2018-11-22 11:13:15.549543", "stderr": "", "stderr_lines": [], "stdout": "gke-e2e-cluster-2-default-pool-4ba8b47d-zv0h", "stdout_lines": ["gke-e2e-cluster-2-default-pool-4ba8b47d-zv0h"]}

TASK [Identify the pumba pod that co-exists with cstor target] *****************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:52
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n percona-cstor -o jsonpath='{.items[?(@.spec.nodeName==''\"gke-e2e-cluster-2-default-pool-4ba8b47d-zv0h\"'')].metadata.name}'", "delta": "0:00:00.946298", "end": "2018-11-22 11:13:17.675280", "rc": 0, "start": "2018-11-22 11:13:16.728982", "stderr": "", "stderr_lines": [], "stdout": "pumba-zc8sm", "stdout_lines": ["pumba-zc8sm"]}

TASK [Inject egress delay of 240000ms on cstor target for 240s] ****************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:60
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-zc8sm -n percona-cstor -- pumba netem --interface eth0 --duration 240s delay --time 240000 re2:k8s_cstor-istgt_pvc-651f30d1-ee46-11e8-8d36-42010a800143", "delta": "0:04:02.037578", "end": "2018-11-22 11:17:19.923630", "rc": 0, "start": "2018-11-22 11:13:17.886052", "stderr": "time=\"2018-11-22T11:13:19Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2018-11-22T11:13:19Z\" level=info msg=\"Running netem command '[delay 240000ms 10ms 20.00]' on container 5f14b16717ba0d17cd916bf3ca28724f3e0289642ef5be0704116693a7145b5f for 4m0s\" \ntime=\"2018-11-22T11:13:19Z\" level=info msg=\"Start netem for container 5f14b16717ba0d17cd916bf3ca28724f3e0289642ef5be0704116693a7145b5f on 'eth0' with command '[delay 240000ms 10ms 20.00]'\" \ntime=\"2018-11-22T11:17:19Z\" level=info msg=\"Stopping netem on container 5f14b16717ba0d17cd916bf3ca28724f3e0289642ef5be0704116693a7145b5f\" \ntime=\"2018-11-22T11:17:19Z\" level=info msg=\"Stop netem for container 5f14b16717ba0d17cd916bf3ca28724f3e0289642ef5be0704116693a7145b5f on 'eth0'\" ", "stderr_lines": ["time=\"2018-11-22T11:13:19Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2018-11-22T11:13:19Z\" level=info msg=\"Running netem command '[delay 240000ms 10ms 20.00]' on container 5f14b16717ba0d17cd916bf3ca28724f3e0289642ef5be0704116693a7145b5f for 4m0s\" ", "time=\"2018-11-22T11:13:19Z\" level=info msg=\"Start netem for container 5f14b16717ba0d17cd916bf3ca28724f3e0289642ef5be0704116693a7145b5f on 'eth0' with command '[delay 240000ms 10ms 20.00]'\" ", "time=\"2018-11-22T11:17:19Z\" level=info msg=\"Stopping netem on container 5f14b16717ba0d17cd916bf3ca28724f3e0289642ef5be0704116693a7145b5f\" ", "time=\"2018-11-22T11:17:19Z\" level=info msg=\"Stop netem for container 5f14b16717ba0d17cd916bf3ca28724f3e0289642ef5be0704116693a7145b5f on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Wait for 10s post fault injection] ***************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:68
ok: [127.0.0.1] => {"changed": false, "elapsed": 10, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:72
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n percona-cstor", "delta": "0:00:00.879879", "end": "2018-11-22 11:17:31.432028", "rc": 0, "start": "2018-11-22 11:17:30.552149", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/cstor_target_network_delay.yaml:78
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n percona-cstor", "delta": "0:00:00.908886", "end": "2018-11-22 11:17:32.563132", "rc": 0, "start": "2018-11-22 11:17:31.654246", "stderr": "", "stderr_lines": [], "stdout": "pumba-nmzfb   0/1   Terminating   0     4m\npumba-wz4dl   0/1   Terminating   0     4m\npumba-zc8sm   1/1   Terminating   0     4m", "stdout_lines": ["pumba-nmzfb   0/1   Terminating   0     4m", "pumba-wz4dl   0/1   Terminating   0     4m", "pumba-zc8sm   1/1   Terminating   0     4m"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:104
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-cstor -l name=percona -o jsonpath='{.items[*].status.containerStatuses[].state.waiting.reason}'", "delta": "0:00:00.954661", "end": "2018-11-22 11:17:33.723521", "rc": 0, "start": "2018-11-22 11:17:32.768860", "stderr": "", "stderr_lines": [], "stdout": "CrashLoopBackOff", "stdout_lines": ["CrashLoopBackOff"]}

TASK [Delete the previous application pod] *************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:115
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pod percona-7d9fcc477f-cpznk -n percona-cstor", "delta": "0:00:42.938390", "end": "2018-11-22 11:18:16.861553", "rc": 0, "start": "2018-11-22 11:17:33.923163", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-7d9fcc477f-cpznk\" deleted", "stdout_lines": ["pod \"percona-7d9fcc477f-cpznk\" deleted"]}

TASK [Check whether the application pod is deleted] ****************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:121
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-cstor", "delta": "0:00:00.916803", "end": "2018-11-22 11:18:18.040724", "rc": 0, "start": "2018-11-22 11:18:17.123921", "stderr": "", "stderr_lines": [], "stdout": "NAME                       READY   STATUS    RESTARTS   AGE\npercona-7d9fcc477f-9lvc5   1/1     Running   0          44s", "stdout_lines": ["NAME                       READY   STATUS    RESTARTS   AGE", "percona-7d9fcc477f-9lvc5   1/1     Running   0          44s"]}

TASK [Check the application pod is rescheduled] ********************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:130
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n percona-cstor -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.012263", "end": "2018-11-22 11:18:19.293554", "rc": 0, "start": "2018-11-22 11:18:18.281291", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the new application pod name] ***************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:141
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n percona-cstor -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.138958", "end": "2018-11-22 11:18:20.736936", "rc": 0, "start": "2018-11-22 11:18:19.597978", "stderr": "", "stderr_lines": [], "stdout": "percona-7d9fcc477f-9lvc5", "stdout_lines": ["percona-7d9fcc477f-9lvc5"]}

TASK [Checking status of liveness pod] *****************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:151
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:160
included: /common/utils/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /common/utils/mysql_data_persistence.yml:4
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /common/utils/mysql_data_persistence.yml:21
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7d9fcc477f-9lvc5 -n percona-cstor -- mysqlcheck -c tdb -uroot -pk8sDem0", "delta": "0:00:01.281324", "end": "2018-11-22 11:18:22.628182", "failed_when_result": false, "rc": 0, "start": "2018-11-22 11:18:21.346858", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "tdb.ttbl                                           OK", "stdout_lines": ["tdb.ttbl

TASK [Verify mysql data persistence] *******************************************
task path: /common/utils/mysql_data_persistence.yml:30
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-7d9fcc477f-9lvc5 -n percona-cstor -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' tdb;", "delta": "0:00:01.319893", "end": "2018-11-22 11:18:24.248515", "failed_when_result": false, "rc": 0, "start": "2018-11-22 11:18:22.928622", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [set_fact] ****************************************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:171
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_target_network_loss/test.yml:182
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
changed: [127.0.0.1] => {"changed": true, "checksum": "cd521ba3834fdc7ebdaaaf2b9d1245702cd7227c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "40fdc05ee57c44d3b9159f71bf44c775", "mode": "0644", "owner": "root", "size": 460, "src": "/root/.ansible/tmp/ansible-tmp-1542885504.69-170477459259887/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.843732", "end": "2018-11-22 11:18:27.883977", "rc": 0, "start": "2018-11-22 11:18:27.040245", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-loss \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/cstor_target_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-loss ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/cstor_target_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.145514", "end": "2018-11-22 11:18:29.394076", "failed_when_result": false, "rc": 0, "start": "2018-11-22 11:18:28.248562", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-loss configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-loss configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=45   changed=30   unreachable=0    failed=0
```