### PR TITLE
(refactor)(percona workload): make tpcc run duration configurable

### DIFF
--- a/apps/percona/workload/run_litmus_test.yml
+++ b/apps/percona/workload/run_litmus_test.yml
@@ -43,5 +43,10 @@ spec:
           - name: DB_PASSWORD
             value: k8sDem0
 
+            # Bench duration (in min) 
+            # TODO: Use a tpcc-template to define workload w/ more granularity
+          - name: LOAD_DURATION
+            value: "600"
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./percona/workload/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/percona/workload/test.yml
+++ b/apps/percona/workload/test.yml
@@ -56,14 +56,20 @@
         - name: Replace the db-user placeholder in tpcc-config file
           replace:
             path: "{{ tpcc_conf }}"
-            regexp: "testuser"
+            regexp: "test_user"
             replace: "{{ db_user }}"
 
         - name: Replace the password placeholder in tpcc-config file
           replace:
             path: "{{ tpcc_conf }}"
-            regexp: "password"
+            regexp: "test_password"
             replace: "{{ db_password }}"
+
+        - name: Replace the duration placeholder in tpcc-config file
+          replace:
+            path: "{{ tpcc_conf }}"
+            regexp: "test_duration"
+            replace: "{{ load_duration }}"
 
         - name: Getting the Service IP of Application
           shell: kubectl get svc -n {{ namespace }} -l {{ app_service_label }} -o jsonpath='{.items[0].spec.clusterIP}'

--- a/apps/percona/workload/test_vars.yml
+++ b/apps/percona/workload/test_vars.yml
@@ -6,4 +6,5 @@ loadgen_label: "{{ lookup('env','LOADGEN_LABEL') }}"
 db_user: "{{ lookup('env','DB_USER') }}"
 db_password: "{{ lookup('env','DB_PASSWORD') }}"
 app_label: "{{ lookup('env','APP_LABEL') }}"
+load_duration: "{{ lookup('env','LOAD_DURATION') }}"
 tpcc_conf: tpcc.conf

--- a/apps/percona/workload/tpcc.conf
+++ b/apps/percona/workload/tpcc.conf
@@ -1,9 +1,9 @@
 {
-  "db_user": "testuser",
-  "db_password": "password",
+  "db_user": "test_user",
+  "db_password": "test_password",
   "warehouses": "1",
   "connections": "18",
   "warmup_period": "10",
-  "run_duration": "60",
+  "run_duration": "test_duration",
   "interval": "10" 
 }


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Make the workload duration configurable
- Update the placeholders in tpcc.conf to ensure they aren't used as is

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
