### PR TITLE
(fix)(yaml): make svc_chaos util compatible w/ statefulset pods

### DIFF
--- a/chaoslib/service_chaos/svc_chaos.yml
+++ b/chaoslib/service_chaos/svc_chaos.yml
@@ -22,7 +22,7 @@
     - name: Obtaining the application pod name using its label.
       shell: >
         kubectl get pods -n {{ app_ns }} -l {{ app_label }} | grep
-        -w Running | awk '{print $1}'
+        -w Running | awk '{print $1}' | head -1 
       args:
         executable: /bin/bash
       register: app_pod


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- The svc chaos util uses app label to select the pod whose node will be injected w/ the svc chaos. Currently it is built for stateful deployments (which will always be single replica)
- This PR introduces a minor workaround to make this chaos util work (in its current state) for statefulsets 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- Will always use ordinality `-0` for pod selection (mostly master pods). It is a quick fix to ensure CD scripts can use this chaos test against statefulset apps. Future enhancements will be made to include better statefulset checks  
