### PR TITLE
fix(pool_chaos): selecting the pool pod on node where app resides

### DIFF
--- a/chaoslib/openebs/cstor_pool_network.yml
+++ b/chaoslib/openebs/cstor_pool_network.yml
@@ -19,7 +19,9 @@
   retries: 30  
 
 - name: Getting the Application pod name
-  shell:  kubectl get pods -n {{ ns }} -l {{ app_label }} --no-headers -o=custom-columns=NAME:".metadata.name"
+  shell: >
+    kubectl get pods -n {{ ns }} -l {{ app_label }} | grep
+    -w Running | awk '{print $1}' | head -1
   register: pod_name
 
 - name: Getting the node on which Application pod is scheduled

--- a/chaoslib/openebs/cstor_pool_network.yml
+++ b/chaoslib/openebs/cstor_pool_network.yml
@@ -18,6 +18,14 @@
   delay: 10
   retries: 30  
 
+- name: Getting the Application pod name
+  shell:  kubectl get pods -n {{ ns }} -l {{ app_label }} --no-headers -o=custom-columns=NAME:".metadata.name"
+  register: pod_name
+
+- name: Getting the node on which Application pod is scheduled
+  shell: kubectl get pod {{ pod_name.stdout }} -n {{ ns }} -o jsonpath='{.spec.nodeName}'
+  register: node
+
 - name: Derive PV name from PVC
   shell: >
     kubectl get pvc {{ pvc_name }} -n {{ ns }}
@@ -30,8 +38,9 @@
   shell: >
     kubectl get cvr -n {{ operator_ns }}
     -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
-    -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}' |
-    shuf -n 1 | awk '{print $1}'
+    -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}
+    {"\t"}{.metadata.annotations.cstorpool\.openebs\.io/hostname}{"\n"}{end}' |
+    grep {{node.stdout}} | awk '{print $1}'
   args:
     executable: /bin/bash
   register: pool_deployment
@@ -43,10 +52,6 @@
   args:
     executable: /bin/bash
   register: pool_pod
-
-- name: Getting the node on which above pool pod is scheduled
-  shell: kubectl get pod {{ pool_pod.stdout }} -n {{ operator_ns }} -o jsonpath='{.spec.nodeName}'
-  register: node
 
 - name: Installing tc package in cstor-pool container
   shell: kubectl exec -it {{ pool_pod.stdout }} -n {{ target_ns }} -c cstor-pool -- apt-get install iproute2 -y 


### PR DESCRIPTION
This PR is to pick the pool pod for doing network chaos which is on the node where application resides.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>