### PR TITLE
[openebs/litmus] (test): Include a litmus book to perform node maintenance (via kubectl drain).

### DIFF
--- a/apps/percona/chaos/drain_node/run_litmus_test.yml
+++ b/apps/percona/chaos/drain_node/run_litmus_test.yml
@@ -1,0 +1,82 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: node-failure-drain-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: node-failure-drain
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      #nodeSelector:
+      #  kubernetes.io/hostname: 
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+          - name: APP_NAMESPACE
+            value: app-percona-ns 
+
+          - name: APP_LABEL
+            value: 'name=percona'
+
+          - name: LIVENESS_APP_LABEL
+            value: "liveness=node-chaos"
+
+          - name: LIVENESS_APP_NAMESPACE
+            value: "litmus"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./percona/chaos/drain_node/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+          - name: logs
+            mountPath: /var/log/ansible
+        tty: true
+
+      - name: logger
+        image: openebs/logger
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # spec.volumes is not supported via downward API
+          - name: MY_POD_HOSTPATH
+            value: /mnt/chaos/node-failure-drain
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,percona; exit 0"]
+        volumeMounts:
+          - name: kubeconfig
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt
+        tty: true
+      volumes:
+        - name: kubeconfig
+          configMap:
+            name: kubeconfig
+        - name: logs
+          hostPath:
+            path: /mnt/chaos/node-failure-drain
+            type: ""
+
+      tolerations:
+      - key: "infra-aid"
+        operator: "Equal"
+        value: "observer"
+        effect: "NoSchedule"

--- a/apps/percona/chaos/drain_node/run_litmus_test.yml
+++ b/apps/percona/chaos/drain_node/run_litmus_test.yml
@@ -36,6 +36,9 @@ spec:
           - name: LIVENESS_APP_NAMESPACE
             value: "litmus"
 
+          - name: DATA_PERSISTENCY
+            value: ""
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./percona/chaos/drain_node/test.yml -i /etc/ansible/hosts -vv; exit 0"]
         volumeMounts:

--- a/apps/percona/chaos/drain_node/test.yml
+++ b/apps/percona/chaos/drain_node/test.yml
@@ -39,23 +39,11 @@
 
           when: lookup('env','RUN_ID')
 
-        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
-          template: 
-            src: /litmus-result.j2
-            dest: litmus-result.yaml
-          vars: 
-            test: "{{ test_name }}"
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
             chaostype: "drain-node"
             app: "percona"
-            phase: in-progress
-            verdict: none
-
-        - name: Apply the litmus result CR
-          shell: kubectl apply -f litmus-result.yaml
-          args:
-            executable: /bin/bash
-          register: lr_status 
-          failed_when: "lr_status.rc != 0"
 
         ## DISPLAY APP INFORMATION 
  
@@ -84,6 +72,17 @@
           args:
             executable: /bin/bash
           register: app_pod_name
+
+        - name: Create some test data in the mysql database
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'
+          when: data_persistance != ''
 
         ## STORAGE FAULT INJECTION 
 
@@ -121,6 +120,25 @@
              
           when: liveness_label != ''  
 
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: rescheduled_app_pod
+
+        - name: Verify mysql data persistence
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ rescheduled_app_pod.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: 'tdb'
+          when: data_persistance != ''
+
         - set_fact:
             flag: "Pass"
 
@@ -131,6 +149,7 @@
       always: 
 
         ## RECORD END-OF-TEST IN LITMUS RESULT CR
+
         - name: Uncordon the application node
           shell: >
             kubectl uncordon {{ app_node }}
@@ -141,21 +160,9 @@
           delay: 20
           retries: 12 
 
-        - name: Generate the litmus result CR to reflect EOT (End of Test) 
-          template: 
-            src: /litmus-result.j2
-            dest: litmus-result.yaml
-          vars: 
-            test: "{{ test_name }}"
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
             chaostype: "drain-node"
             app: "percona"
-            phase: completed
-            verdict: "{{ flag }}"
-           
-        - name: Apply the litmus result CR
-          shell: kubectl apply -f litmus-result.yaml
-          args:
-            executable: /bin/bash
-          register: lr_status 
-          failed_when: "lr_status.rc != 0"
            

--- a/apps/percona/chaos/drain_node/test.yml
+++ b/apps/percona/chaos/drain_node/test.yml
@@ -1,0 +1,161 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - block:
+
+            - name: Get the liveness pods
+              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o=custom-columns=NAME:".metadata.name" --no-headers
+              register: liveness_pods_before_drain
+
+            - name: Checking status of liveness pods
+              shell: kubectl get pods {{ item }} -n {{ liveness_namespace }} -o=custom-columns=NAME:".status.phase" --no-headers
+              register: result
+              with_items: "{{ liveness_pods_before_drain.stdout_lines }}"
+              until: "'Running' in result.stdout"
+              delay: 10
+              retries: 10
+             
+          when: liveness_label != ''  
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+
+        - block:
+ 
+            - name: Record test instance/run ID 
+              set_fact: 
+                run_id: "{{ lookup('env','RUN_ID') }}"
+           
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+
+        - name: Generate the litmus result CR to reflect SOT (Start of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            chaostype: "drain-node"
+            app: "percona"
+            phase: in-progress
+            verdict: none
+
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"
+
+        ## DISPLAY APP INFORMATION 
+ 
+        - name: Display the app information passed via the test job
+          debug: 
+            msg: 
+              - "The application info is as follows:"
+              - "Namespace    : {{ namespace }}"
+              - "Label        : {{ label }}"
+
+        - name: Verify that the AUT (Application Under Test) is running
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          delay: 10
+          retries: 12
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
+        ## STORAGE FAULT INJECTION 
+
+        - include_tasks: /chaoslib/kubectl/cordon_drain_node.yaml
+          vars:
+            action: "drain"      
+            app_ns: "{{ namespace }}"
+            app: "{{ app_pod_name.stdout }}"
+
+        - name: Verify AUT liveness post fault-injection
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          delay: 10
+          retries: 12
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+        - block:
+
+            - name: Get the liveness pods
+              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o=custom-columns=NAME:".metadata.name" --no-headers
+              register: liveness_pods_after_drain
+
+            - name: Checking status of liveness pods
+              shell: kubectl get pods {{ item }} -n {{ liveness_namespace }} -o=custom-columns=NAME:".status.phase" --no-headers
+              register: result
+              with_items: "{{ liveness_pods_after_drain.stdout_lines }}"
+              until: "'Running' in result.stdout"
+              delay: 10
+              retries: 10
+             
+          when: liveness_label != ''  
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue: 
+        - set_fact: 
+            flag: "Fail"
+
+      always: 
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - name: Uncordon the application node
+          shell: >
+            kubectl uncordon {{ app_node }}
+          args:
+            executable: /bin/bash
+          register: result
+          until: "'uncordoned' in result.stdout"
+          delay: 20
+          retries: 12 
+
+        - name: Generate the litmus result CR to reflect EOT (End of Test) 
+          template: 
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars: 
+            test: "{{ test_name }}"
+            chaostype: "drain-node"
+            app: "percona"
+            phase: completed
+            verdict: "{{ flag }}"
+           
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status 
+          failed_when: "lr_status.rc != 0"
+           

--- a/apps/percona/chaos/drain_node/test_vars.yml
+++ b/apps/percona/chaos/drain_node/test_vars.yml
@@ -1,0 +1,7 @@
+test_name: node-failure-drain
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+label: "{{ lookup('env','APP_LABEL') }}"
+liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
+
+

--- a/apps/percona/chaos/drain_node/test_vars.yml
+++ b/apps/percona/chaos/drain_node/test_vars.yml
@@ -3,5 +3,5 @@ namespace: "{{ lookup('env','APP_NAMESPACE') }}"
 label: "{{ lookup('env','APP_LABEL') }}"
 liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
 liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
-
+data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
 

--- a/apps/percona/deployers/run_litmus_test.yml
+++ b/apps/percona/deployers/run_litmus_test.yml
@@ -45,4 +45,4 @@ spec:
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./percona/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]
-
+     

--- a/apps/percona/liveness/run_litmus_test.yml
+++ b/apps/percona/liveness/run_litmus_test.yml
@@ -22,7 +22,7 @@ spec:
       restartPolicy: Never
 
       #nodeSelector:
-      #  kubernetes.io/hostname:
+      #  kubernetes.io/hostname: 
 
       tolerations:
         - key: "infra-aid"

--- a/chaoslib/kubectl/cordon_drain_node.yaml
+++ b/chaoslib/kubectl/cordon_drain_node.yaml
@@ -12,16 +12,6 @@
       set_fact:
         app_node: "{{ result.stdout }}"
     
-    - name: Cordon the application node
-      shell: >
-        kubectl cordon {{ app_node }}
-      args:
-        executable: /bin/bash
-      register: result
-      until: "'cordoned' in result.stdout"
-      delay: 20
-      retries: 12
-    
     - name: Drain the application node
       shell: >
         kubectl drain {{ app_node }}
@@ -29,7 +19,7 @@
       args:
         executable: /bin/bash
       register: result
-      until: "'drained' in result.stdout"
+      until: "'cordoned' in result.stdout"
       delay: 20
       retries: 12
     


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Include a litmus book to perform node maintenance
- This test requires a cluster with 4 nodes and one node tainted to run only liveness and litmus pods.
- Pre-chaos and post chaos will verify the application pod status by verifying the liveness pod status

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
