### PR TITLE
fix(status): pool chaos status lookup change from Online to Healthy

### DIFF
--- a/apps/percona/chaos/cstor_pool_failure/run_litmus_test.yml
+++ b/apps/percona/chaos/cstor_pool_failure/run_litmus_test.yml
@@ -32,7 +32,7 @@ spec:
             value: default
 
           - name: APP_NAMESPACE
-            value: percona-cstor
+            value: app-percona-ns
 
           - name: APP_LABEL
             value: 'name=percona'

--- a/chaoslib/openebs/cstor_verify_pool_provisioning.yml
+++ b/chaoslib/openebs/cstor_verify_pool_provisioning.yml
@@ -63,7 +63,7 @@
 
 - name: Check status of cvr
   command: echo "{{ item }}"
-  failed_when: "item != \"Online\""
+  failed_when: "item != \"Healthy\""
   with_items:
     - "{{ cvr_status_phase.stdout_lines }}"
 


### PR DESCRIPTION
This PR is to have default application namespace as app-percona-ns.
This also fixes the CVR status change from "Online" to "Healthy"

Signed-off-by: Vishnu Itta <vitta@mayadata.io>