### PR TITLE
(refactor)(yaml): convert liveness probe as a configurable in percona deploy litmus job 

### DIFF
--- a/apps/percona/deployers/percona.yml
+++ b/apps/percona/deployers/percona.yml
@@ -34,12 +34,14 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: data-vol
+          #<!-- BEGIN ANSIBLE MANAGED BLOCK -->
           livenessProbe:
             exec:
               command: ["bash", "sql-test.sh"]
             initialDelaySeconds: 60
             periodSeconds: 1
             timeoutSeconds: 10
+          #<!-- END ANSIBLE MANAGED BLOCK --> 
       volumes:
         - name: data-vol
           persistentVolumeClaim:

--- a/apps/percona/deployers/run_litmus_test.yml
+++ b/apps/percona/deployers/run_litmus_test.yml
@@ -43,6 +43,10 @@ spec:
           - name: ACTION
             value: provision
 
+            # Enable storage i/o based liveness probe
+          - name: IO_PROBE
+            value: enabled
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./percona/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]
 

--- a/common/utils/pre_create_app_deploy.yml
+++ b/common/utils/pre_create_app_deploy.yml
@@ -32,4 +32,13 @@
         regexp: "lkey: lvalue"
         replace: "{{ app_lkey }}: {{ app_lvalue }}"
 
+    - name: Enable/Disable I/O based liveness probe 
+      shell: >
+        sed -i '/#<!-- BEGIN ANSIBLE MANAGED BLOCK -->/
+        ,/#<!-- END ANSIBLE MANAGED BLOCK -->/d' 
+        {{ application_deployment }}
+      args:
+        executable: /bin/bash
+      when: lookup('env', 'IO_PROBE') is defined and lookup('env', 'IO_PROBE') == "disabled"
+
     - include_tasks: /common/utils/create_ns.yml


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Liveness probes in percona deployment should be a configurable param

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
- `blockinfile` & `lineinfile` were sub-optimal in this case/or needed undesired additions to job spec. Since the job is a one-time playbook-run - sed's lack of idempotency should not matter.