### PR TITLE
(refactor)(yaml): adding liveness placeholders and enable data persistence check in infra chaos books 

### DIFF
--- a/apps/percona/chaos/cstor_pool_failure/run_litmus_test.yml
+++ b/apps/percona/chaos/cstor_pool_failure/run_litmus_test.yml
@@ -41,10 +41,10 @@ spec:
             value: percona-mysql-claim
 
           - name: LIVENESS_APP_LABEL
-            value: ""
+            value: "liveness=percona-liveness"
 
           - name: LIVENESS_APP_NAMESPACE
-            value: ""
+            value: "litmus"
 
           - name: DATA_PERSISTENCY
             value: "enable"  

--- a/apps/percona/chaos/drain_node/run_litmus_test.yml
+++ b/apps/percona/chaos/drain_node/run_litmus_test.yml
@@ -13,7 +13,14 @@ spec:
       serviceAccountName: litmus
       restartPolicy: Never
       #nodeSelector:
-      #  kubernetes.io/hostname: 
+      #  kubernetes.io/hostname:
+ 
+      tolerations:
+      - key: "infra-aid"
+        operator: "Equal"
+        value: "observer"
+        effect: "NoSchedule"
+
       containers:
       - name: ansibletest
         image: openebs/ansible-runner:ci
@@ -31,13 +38,13 @@ spec:
             value: 'name=percona'
 
           - name: LIVENESS_APP_LABEL
-            value: "liveness=node-chaos"
+            value: "liveness=percona-liveness"
 
           - name: LIVENESS_APP_NAMESPACE
             value: "litmus"
 
           - name: DATA_PERSISTENCY
-            value: ""
+            value: "enable"
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./percona/chaos/drain_node/test.yml -i /etc/ansible/hosts -vv; exit 0"]
@@ -78,8 +85,3 @@ spec:
             path: /mnt/chaos/node-failure-drain
             type: ""
 
-      tolerations:
-      - key: "infra-aid"
-        operator: "Equal"
-        value: "observer"
-        effect: "NoSchedule"


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- These placeholders refer to default liveness labels present in the percona liveness litmus job
- They will be replaced by desired values in the gitlab runner scripts 
- Enable data persistence checks on node drain chaos book

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
