### PR TITLE
fix for failing replica-count task in cstor-verify-pool-provision.yaml

### DIFF
--- a/chaoslib/openebs/cstor_verify_pool_provisioning.yml
+++ b/chaoslib/openebs/cstor_verify_pool_provisioning.yml
@@ -20,7 +20,7 @@
   shell: >
     kubectl get sc {{ sc.stdout }} -n {{ operator_ns }} --no-headers
     -o jsonpath='{.metadata.annotations}' |
-    grep -A 1 -w "name: ReplicaCount" | grep -w value | awk '{print $2}'
+    grep -A 1 -w "name: ReplicaCount" | grep -w value | awk '{print $2}' | cut -d '"' -f 2
   args:
     executable: /bin/bash
   register: replicacount
@@ -32,7 +32,7 @@
 
 - name: Set default value for replicacount if it is non-empty
   set_fact:
-    replicacnt: "{{ replicacount.stdout | int }}"
+    replicacnt: "{{ replicacount.stdout }}"
   when: "replicacount.stdout != \"\""
 
 - name: Get CVR count from pv


### PR DESCRIPTION
**What this PR does / why we need it**:
- It fixes the failing task derive-rep-count task in *chaoslib/openebs/verify_pool_provision.yml*.

*Following is the output after the fix:*
```
TASK [Derive PV from application PVC] ********************************************************************************************************************************
task path: /test.yml:6
changed: [localhost] => {"changed": true, "cmd": "kubectl get pvc percona-claim -o custom-columns=:spec.volumeName -n app-percona-ns --no-headers", "delta": "0:00:00.486980", "end": "2018-11-30 13:22:18.995685", "rc": 0, "start": "2018-11-30 13:22:18.508705", "stderr": "", "stderr_lines": [], "stdout": "pvc-18264d99-f3de-11e8-92f5-005056ba22b1", "stdout_lines": ["pvc-18264d99-f3de-11e8-92f5-005056ba22b1"]}

TASK [Derive SC from application PVC] ********************************************************************************************************************************
task path: /test.yml:13
changed: [localhost] => {"changed": true, "cmd": "kubectl get pvc percona-claim -o custom-columns=:spec.storageClassName -n app-percona-ns --no-headers", "delta": "0:00:00.534842", "end": "2018-11-30 13:22:20.528056", "rc": 0, "start": "2018-11-30 13:22:19.993214", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-sparse", "stdout_lines": ["openebs-cstor-sparse"]}

TASK [Derive ReplicaCount from SC] ***********************************************************************************************************************************
task path: /test.yml:20
changed: [localhost] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse -n openebs --no-headers -o jsonpath='{.metadata.annotations}' | grep -A 1 -w \"name: ReplicaCount\" | grep -w value | awk '{print $2}' | cut -d '\"' -f 2", "delta": "0:00:00.477244", "end": "2018-11-30 13:22:22.159653", "rc": 0, "start": "2018-11-30 13:22:21.682409", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Set default value for replicacount if it is empty] *************************************************************************************************************
task path: /test.yml:27
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Set default value for replicacount if it is non-empty] *********************************************************************************************************
task path: /test.yml:32
ok: [localhost] => {"ansible_facts": {"replicacnt": "2"}, "changed": false}

TASK [Get CVR count from pv] *****************************************************************************************************************************************
task path: /test.yml:37
changed: [localhost] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-18264d99-f3de-11e8-92f5-005056ba22b1 --no-headers | wc -l", "delta": "0:00:00.531265", "end": "2018-11-30 13:22:24.756826", "rc": 0, "start": "2018-11-30 13:22:24.225561", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}

TASK [Compare ReplicaCount and cvr_count to verify provisioning] *****************************************************************************************************
task path: /test.yml:44
ok: [localhost] => {
    "msg": [
        "replicaCount: 2", 
        "replicaCountInt: 2", 
        "replicacnt: 2", 
        "cvr_count: 2"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP ***********************************************************************************************************************************************************
localhost                  : ok=7    changed=4    unreachable=0    failed=0   

```
