### PR TITLE
(feat)(yaml)The litmusbook to test snapshot rebuilding.

### DIFF
--- a/apps/percona/functional/snapshot_rebuild/run_litmus_test.yml
+++ b/apps/percona/functional/snapshot_rebuild/run_litmus_test.yml
@@ -1,0 +1,41 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-k8s-snapshot-rebuild-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: k8s-snapshot-litmus-rebuild
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_LABEL
+            value: 'name=percona'
+
+            # Application pvc
+          - name: APP_PVC
+            value: percona-mysql-claim
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: percona-cstor
+
+          - name: SNAPSHOT
+            value: test-snapshot
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./percona/functional/snapshot_rebuild/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/apps/percona/functional/snapshot_rebuild/test.yml
+++ b/apps/percona/functional/snapshot_rebuild/test.yml
@@ -1,0 +1,185 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+      ## Generating the testname.
+        - include_tasks: /common/utils/create_testname.yml
+
+         ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/common/utils/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+         ## Check if the application is running.
+        - name: Checking if the application is up and running.
+          shell: kubectl get pods -n {{ namespace }} -l {{ application_label }} --no-headers -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "'Running' in app_status.stdout"
+          delay: 10
+          retries: 3
+
+        - name: Derive PV name from PVC
+          shell: >
+            kubectl get pvc {{ app_pvc }} -n {{ namespace }}
+            --no-headers -o custom-columns=:spec.volumeName
+          args:
+            executable: /bin/bash
+          register: pv
+
+        - name: Derive the cstor target using pv.
+          shell: >
+            kubectl get pods -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }} 
+            -l openebs.io/target=cstor-target -o custom-columns=:metadata.name --no-headers
+          args:
+            executable: /bin/bash
+          register: cstor_target
+
+        - name: Obtaining the consistency factor of cstor target.
+          shell: >
+            kubectl exec -it {{ cstor_target.stdout }} -n {{ operator_ns }} --container cstor-istgt 
+            -- cat /usr/local/etc/istgt/istgt.conf | grep -A8 "{{ pv.stdout }}" | grep ConsistencyFactor| cut -d ' ' -f 4
+          args:
+            executable: /bin/bash
+          register: consistency_factor
+
+        - name: Checking the number of healthy pods.
+          shell: >
+            kubectl exec -it {{ cstor_target.stdout }} -n {{ operator_ns }} --container  cstor-istgt 
+            -- istgtcontrol -q replica |json_pp |grep "\"replicaId" |awk -F ':' '{print $2}' | tr -d ',' |wc -l
+          args:
+            executable: /bin/bash
+          register: healthy_pods
+
+          ## Pre-requisite for creation of snapshot - healthy pods should be greater than or equal to consistency factor.  
+          # - name: Exit the playbook if the healthy pods are lesser than the consistency factor.
+          #meta: end_play
+          #when: "healthy_pods.stdout < consistency_factor.stdout"
+
+        - name: Create an empty list of replica pods.
+          set_fact:
+            cstor_replicas_pod : []
+
+        - name: Obtaining the pool deployments from cvr
+          shell: >
+            kubectl get cvr -n {{ operator_ns }}
+            -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
+            -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}'
+          args:
+            executable: /bin/bash
+          register: pool_deployment
+
+        - name: Obtaining the replicasets corresponding to pool deployements.
+          shell: >
+            kubectl get rs --selector=app=cstor-pool -n {{ operator_ns }} --no-headers
+            -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item}}")].metadata.name}'
+          register: rs_list
+          with_items:
+            - "{{ pool_deployment.stdout_lines }}"
+
+        - name: Obtaining the pool pods
+          shell: >
+            kubectl get pod --selector=app=cstor-pool -n {{ operator_ns }} --no-headers
+            -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item.stdout}}")].metadata.name}'
+          register: pool_pods
+          with_items:
+            - "{{ rs_list.results }}"
+
+        - name: Build a list of replica pods.
+          set_fact:
+            cstor_replicas_pod : "{{ cstor_replicas_pod }} + [ '{{ item.stdout }}' ]"
+          with_items: "{{ pool_pods.results }}"
+
+        # #Select any cstor replica pod to inject packet loss
+        - set_fact:
+            replica_pod: "{{ cstor_replicas_pod | list | first }}"
+
+        - block:
+
+        ## Inducing the packet drop on the above pool pod.
+            - include_tasks: "/common/utils/inject_packet_loss_tc.yml"
+              vars:
+                status: "induce"
+                target_pod: "{{ replica_pod }}"
+                operator_namespace: "{{ operator_ns }}"
+
+            - name: Check if the targeted replica is disconnected.
+              shell: >
+                kubectl exec -it {{ cstor_target.stdout }} -n {{ operator_ns }} --container  cstor-istgt 
+                -- istgtcontrol -q replica |json_pp |grep "\"replicaId" |awk -F ':' '{print $2}' | tr -d ',' |wc -l
+              register: connected_replica
+              until: "connected_replica.stdout == \"2\""
+              delay: 30
+              retries: 15
+        
+            - name: Creating snapshot.
+              include_tasks: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml 
+              vars:
+                app_ns: "{{ namespace }}"
+                snapshot_name: "{{ snap_name }}"
+                pvc_name: "{{ app_pvc }}"
+
+            - name: Checking if the snapshot is not created in the degraded replica.
+              shell: kubectl exec -ti {{ replica_pod }} -n {{ operator_ns }} --container cstor-pool -- zfs list -t snapshot
+              args:
+                executable: /bin/bash
+              register: list_snap
+              until: "snap_name not in list_snap.stdout"
+              delay: 30
+              retries: 10
+
+        ## Removing the packet drop rule by including the relevant util..
+            - include_tasks: "/common/utils/inject_packet_loss_tc.yml"
+              vars:
+                status: "remove"
+                target_pod: "{{ replica_pod }}"
+                operator_namespace: "{{ operator_ns }}"
+
+            - name: Form the snap name being rebuilt.
+              set_fact:
+                name: "{{ pv.stdout }}@rebuild_snap"
+
+            - name: Check if the snapshot is being rebuilt.
+              shell: kubectl exec -it {{ replica_pod }} -n {{ operator_ns }} --container cstor-pool -- zfs list -t snapshot
+              args:
+                executable: /bin/bash
+              register: list_snap
+              until: "name in list_snap.stdout"
+              delay: 30
+              retries: 20
+ 
+            - debug:
+                msg: "Snapshot is being rebuilt"
+
+            - name: Check if the snapshot rebuild is successful.
+              shell: >
+                kubectl exec -ti {{ replica_pod }} -n {{ operator_ns }} -c cstor-pool 
+                -- zfs stats |json_pp| grep "rebuildStatus" |awk -F ':' '{print $2}' | tr -d '"' | tr -d ','
+              args:
+                executable: /bin/bash
+              register: snap_result
+              until: "'DONE' in snap_result.stdout"
+              delay: 20
+              retries: 100
+
+            - set_fact:
+                flag: "Pass"
+
+          when: "healthy_pods.stdout >= consistency_factor.stdout" 
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/apps/percona/functional/snapshot_rebuild/test.yml
+++ b/apps/percona/functional/snapshot_rebuild/test.yml
@@ -1,4 +1,13 @@
 ---
+## Test involved.
+#Check if the application is running already.
+#Selct one of the replicas.
+#Introduce packet drop in the selected replica.
+#Create snapshot.
+#check if the snapshot is not present in the degraded pod.
+#Bring up the replica.
+#Check if the snapshot is rebuilt.
+
 - hosts: localhost
   connection: local
 
@@ -57,11 +66,6 @@
           args:
             executable: /bin/bash
           register: healthy_pods
-
-          ## Pre-requisite for creation of snapshot - healthy pods should be greater than or equal to consistency factor.  
-          # - name: Exit the playbook if the healthy pods are lesser than the consistency factor.
-          #meta: end_play
-          #when: "healthy_pods.stdout < consistency_factor.stdout"
 
         - name: Create an empty list of replica pods.
           set_fact:

--- a/apps/percona/functional/snapshot_rebuild/test_vars.yml
+++ b/apps/percona/functional/snapshot_rebuild/test_vars.yml
@@ -1,0 +1,13 @@
+---
+test_name: snapshot-rebuild
+
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+
+snap_name: "{{ lookup('env','SNAPSHOT') }}"
+
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+application_label: "{{ lookup('env','APP_LABEL') }}"
+
+operator_ns: openebs
+

--- a/common/utils/inject_packet_loss_tc.yml
+++ b/common/utils/inject_packet_loss_tc.yml
@@ -1,0 +1,33 @@
+---
+
+# This util induces packet drop in the pod provided. The inputs required are:
+#      - target_pod : pod where it has to be induced.
+#      - operator_namespace : openebs namespace.
+
+- block:
+
+    - name: Install tc command on targeted replica pod
+      shell: >
+        kubectl exec -it {{ target_pod }} -n {{ operator_namespace }} --container cstor-pool 
+        -- bash -c "apt-get update && apt-get -y install iproute2"
+      register: tc_apt_output
+
+    - name: Inject packet loss on targeted replica
+      shell: >
+        kubectl exec -it {{ target_pod }} -n {{ operator_namespace }} --container cstor-pool 
+        -- bash -c "tc qdisc add dev eth0 root netem loss 100.00"
+      register: tc_output
+
+  when: status == "induce"
+
+- block:
+
+    - name: Remove packet loss rule from targeted replica pod
+      shell: >
+        kubectl exec -it {{ target_pod }} -n {{ operator_namespace }} --container cstor-pool 
+        -- bash -c "tc qdisc del dev eth0 root netem loss 100.00"
+      register: apt_rc
+
+  when: status == "remove"
+
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This litmusbook is capable of testing snapshot rebuild functionality.
- Included an util which induces packet drop in the provided replica and remove the packet drop role based on the condition.
**Special notes for your reviewer**:
Tasks included:
- Bringing down one of the pool pods using tc( above said util).
- Creating snapshot if the consistency factor is lesser than or equal to healthy replicas.
- Checking if the snapshot is not present in the degraded replica.
- Bringing up the pool pod.
- Using 'zfs stats' command, checking if the snapshot is rebuilt successfully.
