### PR TITLE
[openebs/litmus] (test): Include a litmus book to perform application node name replacement (via ansible ec2 shutdown module).

### DIFF
--- a/apps/percona/chaos/app_node_failure_ups_diff_name/run_litmus_test.yml
+++ b/apps/percona/chaos/app_node_failure_ups_diff_name/run_litmus_test.yml
@@ -1,0 +1,108 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: node-replacement-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: node-replacement
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      #nodeSelector:
+      #  kubernetes.io/hostname:
+
+      tolerations:
+      - key: "infra-aid"
+        operator: "Equal"
+        value: "observer"
+        effect: "NoSchedule"
+
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            #value: actionable
+            value: default
+
+          - name: APP_NAMESPACE
+            value: app-percona-ns
+
+          - name: APP_PVC
+            value: percona-mysql-claim
+
+          - name: APP_LABEL
+            value: 'name=percona'
+
+          - name: LIVENESS_APP_LABEL
+            value: "liveness=percona-liveness"
+
+          - name: LIVENESS_APP_NAMESPACE
+            value: "litmus"
+
+          - name: DATA_PERSISTENCY
+            value: "enable"
+
+          - name: PLATFORM
+            value: "AWS"
+
+          ## Value of AWS_ACCESS_KEY_ID need to be replaced with original value
+          - name: AWS_ACCESS_KEY_ID
+            value: "access_key"
+
+          ## Value of AWS_SECRET_ACCESS_KEY need to be replaced with original value
+          - name: AWS_SECRET_ACCESS_KEY
+            value: "secret_key"
+
+          ## Actions can be performed on AWS ec2 instance and values (stopped,running,present,absent,restarted ansible-version >= 2.2)
+          - name: ACTION
+            value: "stopped"
+
+          - name: SUBNET_ID
+            value: "subnet_id"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./percona/chaos/app_node_failure_ups_diff_name/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+          - name: logs
+            mountPath: /var/log/ansible
+        tty: true
+
+      - name: logger
+        image: openebs/logger
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # spec.volumes is not supported via downward API
+          - name: MY_POD_HOSTPATH
+            value: /mnt/chaos/node-replacement
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,percona; exit 0"]
+        volumeMounts:
+          - name: kubeconfig
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt
+        tty: true
+      volumes:
+        - name: kubeconfig
+          configMap:
+            name: kubeconfig
+        - name: logs
+          hostPath:
+            path: /mnt/chaos/node-replacement
+            type: ""
+

--- a/apps/percona/chaos/app_node_failure_ups_diff_name/test.yml
+++ b/apps/percona/chaos/app_node_failure_ups_diff_name/test.yml
@@ -1,0 +1,163 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+
+        ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
+
+        ## RECORD START OF THE TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/create_testname.yml
+
+        - include_tasks: /chaoslib/aws_chaos/prerequisites_aws.yml
+          when: lookup('env','PLATFORM') == 'AWS'
+
+        - name: Check the status of nodes and have count of nodes
+          shell: kubectl get nodes --no-headers | grep -v 'master'
+          args:
+            executable: /bin/bash
+          register: pre_chaos_node_count
+
+        ## RECORD START-OF-NODE-CHAOS TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "node-shutdown-up-diff-name"
+            app: "percona"
+
+        ## DISPLAY APP INFORMATION
+        - name: Display the app information passed via the test job
+          debug:
+            msg:
+              - "The application info is as follows:"
+              - "Namespace    : {{ namespace }}"
+              - "Label        : {{ label }}"
+
+        ## Verify the APPLICATION UNDER TEST PRE CHAOS
+        - include_tasks: /common/utils/status_app_pod.yml
+          vars:
+            application_name: "Percona"
+            app_ns: "{{ namespace }}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: '2'
+            retries: '60'
+
+        ## Fetch app pod name
+        - name: Get application pod name
+          shell: >
+            kubectl get po -n {{ namespace }} -l {{ label }} --no-headers -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
+        ## Generate Database name
+        - name: Generate some random name for database creation
+          shell: >
+              echo $(mktemp) | cut -d '.' -f 2
+          args:
+            executable: /bin/bash
+          register: randstr
+
+        ## Create Load for testing
+        - name: Create test load in the mysql database
+          include_tasks: /common/utils/mysql_data_persistence.yml
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: "tdb{{ randstr.stdout }}"
+          when: data_persistance != ''
+
+        ## Node Failure Chaos
+        - name: Get Application pod Node to perform chaos
+          shell: >
+            kubectl get pod {{ app_pod_name.stdout }} -n {{ namespace }}
+            --no-headers -o custom-columns=:spec.nodeName
+          args:
+            executable: /bin/bash
+          register: app_node
+
+          ## Fetch the AWS instance details(instance_id, region)
+        - include_tasks: /common/utils/aws/fetch_aws_details.yml
+          when: lookup('env', 'PLATFORM') == 'AWS'
+
+        ## Execute the chaos util
+        - include_tasks: /chaoslib/aws_chaos/chaosutil_aws.yml
+          when: lookup('env', 'PLATFORM') == 'AWS'
+
+        - include_tasks: /common/utils/check_no_of_nodes.yml
+          vars:
+            post_chaos_soak_time: '40'
+            injected_node_chaos: "yes"
+            delay: '5'
+            retries: '80'
+
+        ## Application verification after the POST chaos
+        - include_tasks: /common/utils/status_app_pod.yml
+          vars:
+            application_name: "Percona post chaos"
+            app_ns: "{{ namespace }}"
+            app_lkey: "name"
+            app_lvalue: "percona"
+            delay: '2'
+            retries: '150'
+
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: rescheduled_app_pod
+
+        - name: Verify mysql data persistence
+          include_tasks: "/common/utils/mysql_data_persistence.yml"
+          vars:
+            status: 'VERIFY'
+            ns: "{{ namespace }}"
+            pod_name: "{{ rescheduled_app_pod.stdout }}"
+            dbuser: 'root'
+            dbpassword: 'k8sDem0'
+            dbname: "tdb{{ randstr.stdout }}"
+          when: data_persistance != ''
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+            chaostype: "node-shutdown-up-diff-name"
+            app: "percona"
+
+        - include_tasks: /common/utils/check_no_of_nodes.yml
+          vars:
+            injected_node_chaos: "no"
+            delay: '5'
+            retries: '80'
+
+        - include_tasks: /chaoslib/openebs/cstor_pool_health_check.yml
+          vars:
+              post_chaos_soak_time: '0'
+              app_ns: "{{ namespace }}"
+              app_pvc: "{{ pvc }}"
+              error_messages: "{{ pool_debug_msg }}"

--- a/apps/percona/chaos/app_node_failure_ups_diff_name/test_vars.yml
+++ b/apps/percona/chaos/app_node_failure_ups_diff_name/test_vars.yml
@@ -1,0 +1,12 @@
+---
+test_name: node-replacement
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+label: "{{ lookup('env','APP_LABEL') }}"
+liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
+data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
+subnet_id: "{{ lookup('env', 'SUBNET_ID') }}"
+action: "{{ lookup('env','ACTION') }}"
+pvc: "{{lookup('env','APP_PVC') }}"
+operator_ns: openebs
+pool_debug_msg: 'uncorrectable I/O failure|suspended|ERROR ZFS event'

--- a/chaoslib/aws_chaos/chaosutil_aws.yml
+++ b/chaoslib/aws_chaos/chaosutil_aws.yml
@@ -1,0 +1,11 @@
+---
+- name: Performing action on AWS ec2 instances
+  ec2:
+    spot_wait_timeout: 200
+    instance_ids: "{{ instance_id }}"
+    region: "{{ region }}"
+    state: "{{ action }}"
+    wait: True
+    vpc_subnet_id: "{{ subnet_id }}"
+    assign_public_ip: yes
+  ignore_errors: true

--- a/chaoslib/aws_chaos/ebs_volume_operations.yml
+++ b/chaoslib/aws_chaos/ebs_volume_operations.yml
@@ -1,0 +1,36 @@
+---
+- block:
+
+   - name: Attaching the existing volume to the ec2 instance
+     ec2_vol:
+        instance: "{{ instance_id }}"
+        id: "{{ volume_id }}"
+        device_name: "{{ device_name }}"
+        region: "{{ region }}"
+  when: action_on_volume == "attach"
+
+- block:
+
+   - name: Dettach disk from ec2 instance
+     ec2_vol:
+        id: "{{ volume_id }}"
+        region: "{{ region }}"
+        instance: None
+  when: action_on_volume == "detach"
+
+- block:
+
+   - name: Delete the ebs volume
+     ec2_vol:
+        id: "{{ volume_id }}"
+        state: absent
+        region: "{{ region }}"
+  when: action_on_volume == "delete"
+
+- block:
+
+   - name: List EBS disks attached to instance
+     ec2_vol:
+        instance: "{{ instance_id }}"
+        state: list
+  when: action_on_volume == "list"

--- a/chaoslib/aws_chaos/prerequisites_aws.yml
+++ b/chaoslib/aws_chaos/prerequisites_aws.yml
@@ -1,0 +1,11 @@
+---
+- name: Installing pip
+  shell: apt install python-pip
+  args:
+    executable: /bin/bash
+
+- name: Installing boto
+  shell: pip install boto
+  args:
+    executable: /bin/bash
+

--- a/common/utils/application_liveness_check.yml
+++ b/common/utils/application_liveness_check.yml
@@ -1,0 +1,13 @@
+---
+- name: Get the liveness pods
+  shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o=custom-columns=NAME:".metadata.name" --no-headers
+  register: liveness_pods
+
+- name: Checking status of liveness pods
+  shell: kubectl get pods {{ item }} -n {{ liveness_namespace }} -o=custom-columns=NAME:".status.phase" --no-headers
+  register: result
+  with_items: "{{ liveness_pods.stdout_lines }}"
+  until: "'Running' in result.stdout"
+  delay: 10
+  retries: 10
+

--- a/common/utils/aws/fetch_aws_details.yml
+++ b/common/utils/aws/fetch_aws_details.yml
@@ -1,0 +1,18 @@
+---
+  ## Get AWS instance Id of the Application node
+- name: Get the AWS instance Id of APP NOde
+  shell: kubectl get node {{ app_node.stdout }} -o jsonpath={.spec.providerID} | cut -d '/' -f 5
+  args:
+    executable: /bin/bash
+  register: instance_id
+
+- name: Get region from app node
+  shell: >
+    kubectl get nodes {{ app_node.stdout }}
+    -o jsonpath='{.metadata.labels.failure-domain\.beta\.kubernetes\.io\/region}'
+  register: region
+
+  ## Values are used in another utils
+- set_fact:
+    instance_id: "{{ instance_id.stdout }}"
+    region: "{{ region.stdout }}"

--- a/common/utils/check_no_of_nodes.yml
+++ b/common/utils/check_no_of_nodes.yml
@@ -1,0 +1,31 @@
+---
+- block:
+
+   - name: Waiting for application pod reschedule (evict)
+     wait_for:
+       timeout: "{{ post_chaos_soak_time }}"
+
+   - name: Checking the status of chaos injected node
+     shell: kubectl get nodes --no-headers | grep -vi 'master'
+     args:
+       executable: /bin/bash
+     register: node_names
+     until: "'{{ app_node.stdout }}' not in node_names.stdout"
+     retries: "{{ retries }}"
+     delay: "{{ delay }}"
+
+  when: injected_node_chaos == "yes"
+
+
+- block:
+
+   - name: Checking the no.of nodes
+     shell: kubectl get nodes --no-headers | grep -vi 'master' | grep -i 'Ready'
+     args:
+       executable: /bin/bash
+     register: node_count
+     until: node_count.stdout_lines|length >= pre_chaos_node_count.stdout_lines|length
+     retries: "{{ retries }}"
+     delay: "{{ delay }}"
+
+  when: injected_node_chaos == "no"


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Include a litmus book to perform application node replacement. (by shutting down the application node)
- This test requires AWS kops cluster and by shutting down the node kops will create another node(with a different name).
- Pre-chaos and post chaos will verify the application pod status by verifying the liveness pod status.
**Test logs:**:
```
ansible-playbook 2.7.4
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./percona/chaos/app_node_failure_ups_diff_name/test.yml
 [WARNING]: Found variable using reserved name: action


PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:2
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:13
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:17
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /common/utils/create_testname.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /common/utils/create_testname.yml:7
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:19
included: /chaoslib/aws_chaos/prerequisites_aws.yml for 127.0.0.1

TASK [Installing pip] **********************************************************
task path: /chaoslib/aws_chaos/prerequisites_aws.yml:2
changed: [127.0.0.1] => {"changed": true, "cmd": "apt install python-pip", "delta": "0:00:01.405323", "end": "2018-12-05 08:24:27.321882", "rc": 0, "start": "2018-12-05 08:24:25.916559", "stderr": "\nWARNING: apt does not have a stable CLI interface. Use with caution in scripts.", "stderr_lines": ["", "WARNING: apt does not have a stable CLI interface. Use with caution in scripts."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\npython-pip is already the newest version (9.0.1-2.3~ubuntu1).\n0 upgraded, 0 newly installed, 0 to remove and 16 not upgraded.", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "python-pip is already the newest version (9.0.1-2.3~ubuntu1).", "0 upgraded, 0 newly installed, 0 to remove and 16 not upgraded."]}

TASK [Installing boto] *********************************************************
task path: /chaoslib/aws_chaos/prerequisites_aws.yml:7
changed: [127.0.0.1] => {"changed": true, "cmd": "pip install boto", "delta": "0:00:01.844309", "end": "2018-12-05 08:24:29.300764", "rc": 0, "start": "2018-12-05 08:24:27.456455", "stderr": "", "stderr_lines": [], "stdout": "Collecting boto\n  Downloading https://files.pythonhosted.org/packages/23/10/c0b78c27298029e4454a472a1919bde20cb182dab1662cec7f2ca1dcc523/boto-2.49.0-py2.py3-none-any.whl (1.4MB)\nInstalling collected packages: boto\nSuccessfully installed boto-2.49.0", "stdout_lines": ["Collecting boto", "  Downloading https://files.pythonhosted.org/packages/23/10/c0b78c27298029e4454a472a1919bde20cb182dab1662cec7f2ca1dcc523/boto-2.49.0-py2.py3-none-any.whl (1.4MB)", "Installing collected packages: boto", "Successfully installed boto-2.49.0"]}

TASK [Check the status of nodes and have count of nodes] ***********************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:22
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes --no-headers | grep -v 'master'", "delta": "0:00:00.490638", "end": "2018-12-05 08:24:29.925141", "rc": 0, "start": "2018-12-05 08:24:29.434503", "stderr": "", "stderr_lines": [], "stdout": "ip-10-0-1-196.us-west-1.compute.internal   Ready   node     3h    v1.11.0\nip-10-0-1-197.us-west-1.compute.internal   Ready   node     30m   v1.11.0\nip-10-0-1-223.us-west-1.compute.internal   Ready   node     18m   v1.11.0", "stdout_lines": ["ip-10-0-1-196.us-west-1.compute.internal   Ready   node     3h    v1.11.0", "ip-10-0-1-197.us-west-1.compute.internal   Ready   node     30m   v1.11.0", "ip-10-0-1-223.us-west-1.compute.internal   Ready   node     18m   v1.11.0"]}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:29
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
changed: [127.0.0.1] => {"changed": true, "checksum": "e909735046d5c6ee8373199726aa1bce8b2c254c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f3cc97d53b74529366406c555ecc059b", "mode": "0644", "owner": "root", "size": 465, "src": "/root/.ansible/tmp/ansible-tmp-1543998270.05-107062844560661/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.287629", "end": "2018-12-05 08:24:30.838701", "rc": 0, "start": "2018-12-05 08:24:30.551072", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-shutdown-up-with-diff-name \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app: percona \n    chaostype: node-shutdown-up-diff-name \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-shutdown-up-with-diff-name ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app: percona ", "    chaostype: node-shutdown-up-diff-name ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.448031", "end": "2018-12-05 08:24:31.424967", "failed_when_result": false, "rc": 0, "start": "2018-12-05 08:24:30.976936", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/node-shutdown-up-with-diff-name configured", "stdout_lines": ["litmusresult.litmus.io/node-shutdown-up-with-diff-name configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:36
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : app-percona-ns", 
        "Label        : name=percona"
    ]
}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:44
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Checking Percona pod is in running state] ********************************
task path: /common/utils/status_app_pod.yml:2
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.356346", "end": "2018-12-05 08:24:32.139700", "rc": 0, "start": "2018-12-05 08:24:31.783354", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:54
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.356654", "end": "2018-12-05 08:24:32.642383", "rc": 0, "start": "2018-12-05 08:24:32.285729", "stderr": "", "stderr_lines": [], "stdout": "percona-6966c6db86-8gxk4", "stdout_lines": ["percona-6966c6db86-8gxk4"]}

TASK [Generate some random name for database creation] *************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:62
changed: [127.0.0.1] => {"changed": true, "cmd": "echo $(mktemp) | cut -d '.' -f 2", "delta": "0:00:00.279384", "end": "2018-12-05 08:24:33.057051", "rc": 0, "start": "2018-12-05 08:24:32.777667", "stderr": "", "stderr_lines": [], "stdout": "VKT5yG2OtF", "stdout_lines": ["VKT5yG2OtF"]}

TASK [Create test load in the mysql database] **********************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:70
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get Application pod Node to perform chaos] *******************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:82
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod percona-6966c6db86-8gxk4 -n app-percona-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.352246", "end": "2018-12-05 08:24:33.588562", "rc": 0, "start": "2018-12-05 08:24:33.236316", "stderr": "", "stderr_lines": [], "stdout": "ip-10-0-1-197.us-west-1.compute.internal", "stdout_lines": ["ip-10-0-1-197.us-west-1.compute.internal"]}

TASK [Get the AWS instance Id of APP NOde] *************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:91
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get node ip-10-0-1-197.us-west-1.compute.internal -o jsonpath={.spec.providerID} | cut -d '/' -f 5", "delta": "0:00:00.355376", "end": "2018-12-05 08:24:34.079103", "rc": 0, "start": "2018-12-05 08:24:33.723727", "stderr": "", "stderr_lines": [], "stdout": "i-09644e5558538b7d8", "stdout_lines": ["i-09644e5558538b7d8"]}

TASK [Get region from app node] ************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:97
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes ip-10-0-1-197.us-west-1.compute.internal -o jsonpath='{.metadata.labels.failure-domain\\.beta\\.kubernetes\\.io\\/region}'", "delta": "0:00:00.356482", "end": "2018-12-05 08:24:34.571390", "rc": 0, "start": "2018-12-05 08:24:34.214908", "stderr": "", "stderr_lines": [], "stdout": "us-west-1", "stdout_lines": ["us-west-1"]}

TASK [set_fact] ****************************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:103
ok: [127.0.0.1] => {"ansible_facts": {"instance_id": "i-09644e5558538b7d8", "region": "us-west-1"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:108
included: /chaoslib/aws_chaos/chaosutil_aws.yml for 127.0.0.1

TASK [Stop the AWS ec2 instances] **********************************************
task path: /chaoslib/aws_chaos/chaosutil_aws.yml:2
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "wait for instances running timeout on Wed Dec  5 08:29:38 2018"}
...ignoring

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:111
included: /common/utils/check_no_of_nodes.yml for 127.0.0.1

TASK [Waiting for application pod reschedule (evict)] **************************
task path: /common/utils/check_no_of_nodes.yml:4
ok: [127.0.0.1] => {"changed": false, "elapsed": 50, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Checking the status of chaos injected node] ******************************
task path: /common/utils/check_no_of_nodes.yml:8
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get nodes --no-headers | grep -vi 'master'", "delta": "0:00:00.361597", "end": "2018-12-05 08:30:29.059198", "rc": 0, "start": "2018-12-05 08:30:28.697601", "stderr": "", "stderr_lines": [], "stdout": "ip-10-0-1-196.us-west-1.compute.internal   Ready   node     3h    v1.11.0\nip-10-0-1-223.us-west-1.compute.internal   Ready   node     24m   v1.11.0\nip-10-0-1-93.us-west-1.compute.internal    Ready   node     2m    v1.11.0", "stdout_lines": ["ip-10-0-1-196.us-west-1.compute.internal   Ready   node     3h    v1.11.0", "ip-10-0-1-223.us-west-1.compute.internal   Ready   node     24m   v1.11.0", "ip-10-0-1-93.us-west-1.compute.internal    Ready   node     2m    v1.11.0"]}

TASK [Checking the no.of nodes] ************************************************
task path: /common/utils/check_no_of_nodes.yml:22
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:116
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Checking Percona post chaos pod is in running state] *********************
task path: /common/utils/status_app_pod.yml:2
FAILED - RETRYING: Checking Percona post chaos pod is in running state (30 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (29 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (28 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (27 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (26 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (25 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (24 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (23 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (22 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (21 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (20 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (19 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (18 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (17 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (16 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (15 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (14 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (13 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (12 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (11 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (10 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (9 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (8 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (7 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (6 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (5 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (4 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (3 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (2 retries left).
FAILED - RETRYING: Checking Percona post chaos pod is in running state (1 retries left).
fatal: [127.0.0.1]: FAILED! => {"attempts": 30, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.361336", "end": "2018-12-05 08:35:43.453856", "rc": 0, "start": "2018-12-05 08:35:43.092520", "stderr": "", "stderr_lines": [], "stdout": "Pending", "stdout_lines": ["Pending"]}

TASK [set_fact] ****************************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:152
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Fail"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:156
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
changed: [127.0.0.1] => {"changed": true, "checksum": "172ad245da32aeaf259c6b1090839707494baa19", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "bb91bd76c32793425a40a7447b4a7257", "mode": "0644", "owner": "root", "size": 463, "src": "/root/.ansible/tmp/ansible-tmp-1543998943.73-228328549819093/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.279322", "end": "2018-12-05 08:35:44.872047", "rc": 0, "start": "2018-12-05 08:35:44.592725", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-shutdown-up-with-diff-name \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app: percona \n    chaostype: node-shutdown-up-diff-name \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Fail ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-shutdown-up-with-diff-name ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app: percona ", "    chaostype: node-shutdown-up-diff-name ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Fail "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.419271", "end": "2018-12-05 08:35:45.431301", "failed_when_result": false, "rc": 0, "start": "2018-12-05 08:35:45.012030", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/node-shutdown-up-with-diff-name configured", "stdout_lines": ["litmusresult.litmus.io/node-shutdown-up-with-diff-name configured"]}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:162
included: /common/utils/check_no_of_nodes.yml for 127.0.0.1

TASK [Waiting for application pod reschedule (evict)] **************************
task path: /common/utils/check_no_of_nodes.yml:4
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the status of chaos injected node] ******************************
task path: /common/utils/check_no_of_nodes.yml:8
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the no.of nodes] ************************************************
task path: /common/utils/check_no_of_nodes.yml:22
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get nodes --no-headers | grep -vi 'master' | grep -i 'Ready'", "delta": "0:00:00.352739", "end": "2018-12-05 08:35:46.053236", "rc": 0, "start": "2018-12-05 08:35:45.700497", "stderr": "", "stderr_lines": [], "stdout": "ip-10-0-1-196.us-west-1.compute.internal   Ready   node     3h    v1.11.0\nip-10-0-1-223.us-west-1.compute.internal   Ready   node     29m   v1.11.0\nip-10-0-1-93.us-west-1.compute.internal    Ready   node     7m    v1.11.0", "stdout_lines": ["ip-10-0-1-196.us-west-1.compute.internal   Ready   node     3h    v1.11.0", "ip-10-0-1-223.us-west-1.compute.internal   Ready   node     29m   v1.11.0", "ip-10-0-1-93.us-west-1.compute.internal    Ready   node     7m    v1.11.0"]}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/app_node_failure_ups_diff_name/test.yml:166
included: /common/utils/check_cstor_pool_pod.yml for 127.0.0.1

TASK [Get the cstor pool pods which remains in a pending state] ****************
task path: /common/utils/check_cstor_pool_pod.yml:2
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "kubectl get po -n openebs -l app=cstor-pool -o jsonpath='{.items[?(@.status.phase==\"Pending\")].metadata.name}' | cut -d '-' -f -4", "delta": "0:00:00.359822", "end": "2018-12-05 08:35:46.616208", "failed_when_result": true, "rc": 0, "start": "2018-12-05 08:35:46.256386", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-h5s8", "stdout_lines": ["cstor-sparse-pool-h5s8"]}
	to retry, use: --limit @/percona/chaos/app_node_failure_ups_diff_name/test.retry

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=33   changed=17   unreachable=0    failed=2   
```

