### PR TITLE
(feat)(yaml): add target pod affinity check to deployer & target pod failure chaos

### DIFF
--- a/apps/percona/chaos/openebs_target_failure/test.yml
+++ b/apps/percona/chaos/openebs_target_failure/test.yml
@@ -102,6 +102,10 @@
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
+        - name: Wait (soak) for I/O on pools 
+          wait_for:
+            timeout: "{{ chaos_duration }}"
+
         - name: Verify AUT liveness post fault-injection
           shell: >
             kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers

--- a/apps/percona/chaos/openebs_target_failure/test.yml
+++ b/apps/percona/chaos/openebs_target_failure/test.yml
@@ -135,6 +135,13 @@
             dbname: 'tdb' 
           when: data_persistance != ''       
 
+        ## Check application-target pod affinity
+        - include_tasks: /common/utils/openebs/target_affinity_check.yml
+          vars:
+            app_ns: "{{ namespace }}"
+            #operator_ns: works by var scope
+            app_label: "{{ label }}"
+            app_pvc: "{{ pvc }}"
 
         - set_fact:
             flag: "Pass"

--- a/apps/percona/chaos/openebs_target_failure/test_vars.yml
+++ b/apps/percona/chaos/openebs_target_failure/test_vars.yml
@@ -16,4 +16,4 @@ liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
 data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
 chaos_type: "{{ lookup('env','CHAOS_TYPE') }}"
 target_container: "{{ lookup('env','TARGET_CONTAINER') }}"
-
+chaos_duration: 360 

--- a/apps/percona/chaos/openebs_target_failure/test_vars.yml
+++ b/apps/percona/chaos/openebs_target_failure/test_vars.yml
@@ -1,6 +1,14 @@
 test_name: openebs-target-failure
-namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+## TODO: Remove target namespace ENV in future (should be derived) 
+## Retaining now for backward compatibility w/ target chaoslib
 target_namespace: "{{ lookup('env','TARGET_NAMESPACE') }}"
+
+operator_ns: 'openebs'
+
+## TODO: The var names for app labels, pvc, namespace etc., change across tests
+## Need to make this consistent
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
 label: "{{ lookup('env','APP_LABEL') }}"
 pvc: "{{ lookup('env','APP_PVC') }}"
 liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"

--- a/apps/percona/deployers/percona.yml
+++ b/apps/percona/deployers/percona.yml
@@ -4,7 +4,8 @@ kind: Deployment
 metadata:
   name: percona
   labels:
-    name: percona
+    lkey: lvalue
+    openebs.io/target-affinity: percona
 spec:
   replicas: 1
   selector: 
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels: 
         lkey: lvalue
+        openebs.io/target-affinity: percona
     spec:
       containers:
         - resources:
@@ -51,6 +53,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: testclaim
+  labels: 
+    openebs.io/target-affinity: percona  
 spec:
   storageClassName: testclass
   accessModes:
@@ -70,5 +74,5 @@ spec:
     - port: 3306
       targetPort: 3306
   selector:
-      name: percona
+      lkey: lvalue
 

--- a/apps/percona/deployers/test.yml
+++ b/apps/percona/deployers/test.yml
@@ -8,7 +8,7 @@
   tasks:
     - block:
 
-      ## Generating the testname for deployment
+        ## Generating the testname for deployment
         - include_tasks: /common/utils/create_testname.yml
 
          ## RECORD START-OF-TEST IN LITMUS RESULT CR
@@ -18,11 +18,11 @@
    
         - block:
 
-             ##Actual test
-         ## Creating namespaces and making the application for deployment
+            ## Actual test
+            ## Creating namespaces and making the application for deployment
             - include_tasks: /common/utils/pre_create_app_deploy.yml
         
-        ## Deploying the application, upper bound wait time: 900s 
+            ## Deploying the application, upper bound wait time: 900s 
             - include_tasks: /common/utils/deploy_single_app.yml
               vars:
                 check_app_pod: 'yes'
@@ -34,7 +34,10 @@
     
             ## Checking the db is ready for connection
             - include_tasks: /common/utils/check_db_connection.yml
-    
+   
+            ## Check application-target pod affinity
+            - include_tasks: /common/utils/openebs/target_affinity_check.yml
+
             - set_fact:
                 flag: "Pass"  
 

--- a/apps/percona/deployers/test_vars.yml
+++ b/apps/percona/deployers/test_vars.yml
@@ -2,6 +2,7 @@
 
 application_deployment: percona.yml
 app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+operator_ns: 'openebs'
 app_label: "{{ lookup('env','APP_LABEL') }}"
 test_name: percona-deployment
 application_name: "percona"

--- a/common/utils/openebs/target_affinity_check.yml
+++ b/common/utils/openebs/target_affinity_check.yml
@@ -1,0 +1,51 @@
+- name: Obtain node where app pod resides
+  shell: >
+    kubectl get pods -l {{ app_label }} -n {{ app_ns }}
+    --no-headers -o custom-columns=:spec.nodeName
+  args:
+    executable: /bin/bash
+  register: app_node
+
+- name: Derive PV from application PVC
+  shell: >
+    kubectl get pvc {{ app_pvc }}
+    -o custom-columns=:spec.volumeName -n {{ app_ns }}
+    --no-headers
+  args:
+    executable: /bin/bash
+  register: pv
+
+- name: Derive storage engine from PV
+  shell: >
+    kubectl get pv {{ pv.stdout }} --no-headers
+    -o jsonpath="{.metadata.annotations.openebs\\.io/cas-type}"
+  args:
+    executable: /bin/bash
+  register: stg_engine
+
+- set_fact: 
+    target_ns: "{{ app_ns }}"
+  when: stg_engine.stdout == 'jiva'
+
+
+## TODO: Account for the case where cstor target can reside in app_ns
+## For future: Leave a bool var called {{ target_in_app_ns }} as undefined
+
+- set_fact:
+    target_ns: "{{ operator_ns }}"
+  when: stg_engine.stdout == 'cstor' and target_in_app_ns is undefined
+
+- name: Obtain the node where PV target pod resides
+  shell: >
+    kubectl get pod -n {{ target_ns }} 
+    -l openebs.io/persistent-volume={{ pv.stdout }}
+    --no-headers -o custom-columns=:spec.nodeName 
+  args:
+    executable: /bin/bash
+  register: target_node
+
+- name: Verify whether the app & target pod co-exist on same node
+  debug: 
+    msg: "App and Target affinity is maintained"
+  failed_when: target_node.stdout != app_node.stdout
+  


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Verify target pod is always scheduled on app node
- Include checks in deployer and target pod failure tests
- Add I/O soak time post chaos before checking app status 
  (we are seeing some belated failures in chaos tests which are missed by the chaos e2e tests) 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- TODO: Add this util in infra (node) chaos tests 