### PR TITLE
(update)(yml):Upgrade kubernetes version of packet cluster

### DIFF
--- a/k8s/packet/k8s-installer/vars.yml
+++ b/k8s/packet/k8s-installer/vars.yml
@@ -7,4 +7,4 @@ os: ubuntu_16_04
 network_cidr: 10.1.0.0/16
 master_config: t1.small.x86
 workers_config: t1.small.x86
-default_k8s_version: 1.10.0-00
+default_k8s_version: 1.12.3-00


### PR DESCRIPTION
Signed-off-by: Chandan Kumar <chandan.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

Upgrade default kubernetes version of packet cluster
- From 1.10.0-00 to 1.12.3-00
