### PR TITLE
fix(pool_chaos): change in defaults for pool-failure chaos

### DIFF
--- a/apps/percona/chaos/openebs_pool_failure/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_pool_failure/run_litmus_test.yml
@@ -25,6 +25,7 @@ spec:
       containers:
       - name: ansibletest
         image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
         env:
           - name: ANSIBLE_STDOUT_CALLBACK
             #value: log_plays
@@ -50,7 +51,7 @@ spec:
             value: "enable"  
 
           - name: CHAOS_TYPE
-            value: "pool-delete"
+            value: "pool-kill"
 
           - name: CHAOS_ITERATIONS
             value: "2" 


### PR DESCRIPTION
This PR sets default CHAOS_TYPE as pool-kill and imagePullPolicy as Always for pool-failure chaos.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>