### PR TITLE
Modified:containerStatus with restarts over pod status check in utils file

### DIFF
--- a/apps/percona/chaos/app_node_failure_ups_diff_name/test.yml
+++ b/apps/percona/chaos/app_node_failure_ups_diff_name/test.yml
@@ -50,6 +50,15 @@
             delay: '2'
             retries: '60'
 
+
+        ## Fetch app pod name
+        - name: Get application pod name
+          shell: >
+            kubectl get po -n {{ namespace }} -l {{ label }} --no-headers -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name    
+
         ## Generate Database name
         - name: Generate some random name for database creation
           shell: >
@@ -107,6 +116,14 @@
         ## POST-CHAOS APPLICATION LIVENESS CHECK
         - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: rescheduled_app_pod
 
         - name: Verify mysql data persistence
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/app_node_failure_ups_diff_name/test.yml
+++ b/apps/percona/chaos/app_node_failure_ups_diff_name/test.yml
@@ -50,14 +50,6 @@
             delay: '2'
             retries: '60'
 
-        ## Fetch app pod name
-        - name: Get application pod name
-          shell: >
-            kubectl get po -n {{ namespace }} -l {{ label }} --no-headers -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: app_pod_name
-
         ## Generate Database name
         - name: Generate some random name for database creation
           shell: >
@@ -107,22 +99,14 @@
           vars:
             application_name: "Percona post chaos"
             app_ns: "{{ namespace }}"
-            app_lkey: "name"
-            app_lvalue: "percona"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
             delay: '2'
             retries: '150'
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
         - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
-
-        - name: Get application pod name
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: rescheduled_app_pod
 
         - name: Verify mysql data persistence
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/app_node_failure_ups_diff_name/test.yml
+++ b/apps/percona/chaos/app_node_failure_ups_diff_name/test.yml
@@ -43,7 +43,6 @@
         ## Verify the APPLICATION UNDER TEST PRE CHAOS
         - include_tasks: /common/utils/status_app_pod.yml
           vars:
-            application_name: "Percona"
             app_ns: "{{ namespace }}"
             app_lkey: "{{ label.split('=')[0] }}"
             app_lvalue: "{{ label.split('=')[1] }}"
@@ -106,7 +105,6 @@
         ## Application verification after the POST chaos
         - include_tasks: /common/utils/status_app_pod.yml
           vars:
-            application_name: "Percona post chaos"
             app_ns: "{{ namespace }}"
             app_lkey: "{{ label.split('=')[0] }}"
             app_lvalue: "{{ label.split('=')[1] }}"

--- a/apps/percona/chaos/cstor_verify_rebuild/test.yml
+++ b/apps/percona/chaos/cstor_verify_rebuild/test.yml
@@ -8,16 +8,7 @@
   tasks:
     - block:
 
-        ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE   
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-
+        - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
 
         - include: test_prerequisites.yml
@@ -31,17 +22,7 @@
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
 
-        - block:
-
-            - name: Record test instance/run ID
-              set_fact:
-                run_id: "{{ lookup('env','RUN_ID') }}"
-
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
-
-          when: lookup('env','RUN_ID')
+        - include_tasks: /common/utils/create_testname.yml
 
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
@@ -85,15 +66,7 @@
             delay: 5
             retries: 60
 
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-
+        - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
 
         - set_fact:

--- a/apps/percona/chaos/cstor_verify_rebuild/test.yml
+++ b/apps/percona/chaos/cstor_verify_rebuild/test.yml
@@ -60,17 +60,14 @@
               - "StorageClass : {{ sc }}"
 
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
-
         - name: Verify that the AUT (Application Under Test) is running
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60   
 
         ## STORAGE TEST
         - include: "{{ chaos_util_path }}"
@@ -80,15 +77,13 @@
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
 
         - block:
 

--- a/apps/percona/chaos/drain_node/test.yml
+++ b/apps/percona/chaos/drain_node/test.yml
@@ -55,23 +55,13 @@
               - "Label        : {{ label }}"
 
         - name: Verify that the AUT (Application Under Test) is running
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
-
-        - name: Get application pod name
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: app_pod_name
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"       
+            delay: 5
+            retries: 60
 
         - name: Generate unique string for use in dbname
           shell: echo $(mktemp) | cut -d '.' -f 2
@@ -99,15 +89,13 @@
             app: "{{ app_pod_name.stdout }}"
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
         - block:

--- a/apps/percona/chaos/drain_node/test.yml
+++ b/apps/percona/chaos/drain_node/test.yml
@@ -40,6 +40,14 @@
             delay: 5
             retries: 60
 
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
         - name: Generate unique string for use in dbname
           shell: echo $(mktemp) | cut -d '.' -f 2
           args:
@@ -78,6 +86,14 @@
 
         - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
+        
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: rescheduled_app_pod  
 
         - name: Verify mysql data persistence
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/drain_node/test.yml
+++ b/apps/percona/chaos/drain_node/test.yml
@@ -9,35 +9,12 @@
     - block:
 
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
-        - block:
-
-            - name: Get the liveness pods
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o=custom-columns=NAME:".metadata.name" --no-headers
-              register: liveness_pods_before_drain
-
-            - name: Checking status of liveness pods
-              shell: kubectl get pods {{ item }} -n {{ liveness_namespace }} -o=custom-columns=NAME:".status.phase" --no-headers
-              register: result
-              with_items: "{{ liveness_pods_before_drain.stdout_lines }}"
-              until: "'Running' in result.stdout"
-              delay: 10
-              retries: 10
-             
-          when: liveness_label != ''  
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
-
-        - block:
- 
-            - name: Record test instance/run ID 
-              set_fact: 
-                run_id: "{{ lookup('env','RUN_ID') }}"
-           
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
-
-          when: lookup('env','RUN_ID')
+        
+        - include_tasks: /common/utils/create_testname.yml
 
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
@@ -98,29 +75,9 @@
             retries: 60
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
-        - block:
 
-            - name: Get the liveness pods
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o=custom-columns=NAME:".metadata.name" --no-headers
-              register: liveness_pods_after_drain
-
-            - name: Checking status of liveness pods
-              shell: kubectl get pods {{ item }} -n {{ liveness_namespace }} -o=custom-columns=NAME:".status.phase" --no-headers
-              register: result
-              with_items: "{{ liveness_pods_after_drain.stdout_lines }}"
-              until: "'Running' in result.stdout"
-              delay: 10
-              retries: 10
-             
-          when: liveness_label != ''  
-
-        - name: Get application pod name
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: rescheduled_app_pod
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
         - name: Verify mysql data persistence
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/node_freeze/test.yml
+++ b/apps/percona/chaos/node_freeze/test.yml
@@ -11,6 +11,9 @@
         - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
 
+         ## RECORD START OF THE TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/create_testname.yml
+
         - include_tasks: /chaoslib/aws_chaos/prerequisites_aws.yml
           when: lookup('env','PLATFORM') == 'AWS'
 
@@ -29,23 +32,13 @@
               - "Label        : {{ app_label }}"
 
         - name: Verify that the AUT (Application Under Test) is running
-          shell: >
-            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
-
-        - name: Get application pod name
-          shell: >
-            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: app_pod_name
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60   
 
         - name: Generate unique string for use in dbname
           shell: echo $(mktemp) | cut -d '.' -f 2
@@ -78,26 +71,16 @@
             executable: /bin/bash
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60  
 
         - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
-
-        - name: Get application pod name
-          shell: >
-            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: rescheduled_app_pod
 
         - name: Verify mysql data persistence
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/node_freeze/test.yml
+++ b/apps/percona/chaos/node_freeze/test.yml
@@ -30,21 +30,21 @@
           debug: 
             msg: 
               - "The application info is as follows:"
-              - "Namespace    : {{ app_ns }}"
+              - "Namespace    : {{ namespace }}"
               - "Label        : {{ app_label }}"
 
         - name: Verify that the AUT (Application Under Test) is running
           include_tasks: "/common/utils/status_app_pod.yml"
           vars:
             app_ns: "{{namespace}}"
-            app_lkey: "{{ label.split('=')[0] }}"
-            app_lvalue: "{{ label.split('=')[1] }}"
+            app_lkey: "{{ app_label.split('=')[0] }}"
+            app_lvalue: "{{ app_label.split('=')[1] }}"
             delay: 5
             retries: 60
 
         - name: Get application pod name
           shell: >
-            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
+            kubectl get pods -n {{ namespace }} -l {{ app_label }} --no-headers
             -o=custom-columns=NAME:".metadata.name"
           args:
             executable: /bin/bash
@@ -61,7 +61,7 @@
           include_tasks: "/common/utils/mysql_data_persistence.yml"
           vars:
             status: 'LOAD'
-            ns: "{{ app_ns }}"
+            ns: "{{ namespace }}"
             pod_name: "{{ app_pod_name.stdout }}"
             dbuser: 'root'
             dbpassword: 'k8sDem0'
@@ -73,7 +73,7 @@
         - include_tasks: /chaoslib/chaoskube/node_freeze_chaos.yml
           vars:
             nodeaction: "memory-freeze"      
-            namespace: "{{ app_ns }}"
+            app_ns: "{{ namespace }}"
 
         - name: wait for app pod to reschedule
           shell: >
@@ -105,7 +105,7 @@
           include_tasks: "/common/utils/mysql_data_persistence.yml"
           vars:
             status: 'VERIFY'
-            ns: "{{ app_ns }}"
+            ns: "{{ namespace }}"
             pod_name: "{{ rescheduled_app_pod.stdout }}"
             dbuser: 'root'
             dbpassword: 'k8sDem0'

--- a/apps/percona/chaos/node_freeze/test.yml
+++ b/apps/percona/chaos/node_freeze/test.yml
@@ -40,7 +40,16 @@
             app_lkey: "{{ label.split('=')[0] }}"
             app_lvalue: "{{ label.split('=')[1] }}"
             delay: 5
-            retries: 60   
+            retries: 60
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+     
 
         - name: Generate unique string for use in dbname
           shell: echo $(mktemp) | cut -d '.' -f 2
@@ -84,6 +93,14 @@
         - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
 
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: rescheduled_app_pod
+  
         - name: Verify mysql data persistence
           include_tasks: "/common/utils/mysql_data_persistence.yml"
           vars:

--- a/apps/percona/chaos/node_freeze/test.yml
+++ b/apps/percona/chaos/node_freeze/test.yml
@@ -21,6 +21,8 @@
         - include_tasks: "/common/utils/update_litmus_result_resource.yml"
           vars:
             status: 'SOT'
+            chaostype: "{{test_name}}"
+            app: "percona"
        
         # DISPLAY APP INFORMATION 
  

--- a/apps/percona/chaos/node_freeze/test_vars.yml
+++ b/apps/percona/chaos/node_freeze/test_vars.yml
@@ -1,6 +1,6 @@
 test_name: node-mem-freeze
 
-app_ns: "{{ lookup('env','APP_NS') }}"
+namespace: "{{ lookup('env','APP_NS') }}"
 
 app_label: "{{ lookup('env','APP_LABEL') }}"
 

--- a/apps/percona/chaos/openebs_app_svc_chaos/test.yml
+++ b/apps/percona/chaos/openebs_app_svc_chaos/test.yml
@@ -8,17 +8,8 @@
   tasks:
     - block:
 
-        ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE       
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-             
-          when: liveness_label != '' 
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
         - include: test_prerequisites.yml
   
@@ -30,18 +21,7 @@
             chaos_util_path: "/chaoslib/{{ chaosutil }}"
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
-
-        - block:
-
-            - name: Record test instance/run ID
-              set_fact:
-                run_id: "{{ lookup('env','RUN_ID') }}"
-
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
-
-          when: lookup('env','RUN_ID')
+        - include_tasks: /common/utils/create_testname.yml
 
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
@@ -106,17 +86,9 @@
             delay: 5
             retries: 60
 
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-
+        - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
-          
+   
         - set_fact:
             flag: "Pass"
 

--- a/apps/percona/chaos/openebs_app_svc_chaos/test.yml
+++ b/apps/percona/chaos/openebs_app_svc_chaos/test.yml
@@ -61,16 +61,14 @@
 
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
 
-        - name: Verify that the AUT (Application Under Test) is running 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"       
+            delay: 5
+            retries: 60 
 
         ## STORAGE FAULT INJECTION 
 
@@ -97,17 +95,16 @@
           delay: 30
           retries: 10
 
-       
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          failed_when: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"       
+            delay: 5
+            retries: 60
 
         - block:
 

--- a/apps/percona/chaos/openebs_pool_failure/test.yml
+++ b/apps/percona/chaos/openebs_pool_failure/test.yml
@@ -83,17 +83,14 @@
               - "PVC          : {{ pvc }}"  
 
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
-
-        - name: Verify that the AUT (Application Under Test) is running 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
 
         ## STORAGE FAULT INJECTION 
 
@@ -107,15 +104,14 @@
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
+
 
         - name: Verify mysql data persistence  
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/openebs_pool_failure/test.yml
+++ b/apps/percona/chaos/openebs_pool_failure/test.yml
@@ -9,23 +9,8 @@
     - block:
 
         ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE       
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-          when: liveness_label != ''  
-
-        - name: Get application pod name 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: app_pod_name 
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
         - name: Generate unique string for use in dbname
           shell: echo $(mktemp) | cut -d '.' -f 2
@@ -56,21 +41,12 @@
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
 
-        - block:
- 
-            - name: Record test instance/run ID 
-              set_fact: 
-                run_id: "{{ lookup('env','RUN_ID') }}"
-           
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
+        - include_tasks: /common/utils/create_testname.yml
 
-            - include_tasks: /common/utils/update_litmus_result_resource.yml
-              vars:
-                status: 'SOT'
-                chaostype: "{{ chaosutil.split('.')[0] }}"
-          when: lookup('env','RUN_ID')
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+           chaostype: "{{ chaosutil.split('.')[0] }}"
 
         ## DISPLAY APP INFORMATION 
  
@@ -135,15 +111,8 @@
             dbname: "tdb{{ uniqstr.stdout }}"
           when: data_persistance != '' 
 
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-             
+          # Check application liveness post chaos
+        - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''  
 
         - set_fact:

--- a/apps/percona/chaos/openebs_pool_failure/test.yml
+++ b/apps/percona/chaos/openebs_pool_failure/test.yml
@@ -12,6 +12,14 @@
         - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
 
+        - name: Get application pod name 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name 
+
         - name: Generate unique string for use in dbname
           shell: echo $(mktemp) | cut -d '.' -f 2
           args:
@@ -46,7 +54,7 @@
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
             status: 'SOT'
-           chaostype: "{{ chaosutil.split('.')[0] }}"
+            chaostype: "{{ chaosutil.split('.')[0] }}"
 
         ## DISPLAY APP INFORMATION 
  

--- a/apps/percona/chaos/openebs_pool_network/test.yml
+++ b/apps/percona/chaos/openebs_pool_network/test.yml
@@ -36,7 +36,6 @@
         - name: Verify that the AUT (Application Under Test) is running 
           include_tasks: /common/utils/status_app_pod.yml
           vars:
-            application_name: "Percona"
             app_ns: "{{ namespace }}"
             app_lkey: "{{ label.split('=')[0] }}"
             app_lvalue: "{{ label.split('=')[1] }}"
@@ -59,7 +58,6 @@
         - name: Verify AUT liveness post fault-injection
           include_tasks: /common/utils/status_app_pod.yml
           vars:
-            application_name: "Percona"
             app_ns: "{{ namespace }}"
             app_lkey: "{{ label.split('=')[0] }}"
             app_lvalue: "{{ label.split('=')[1] }}"

--- a/apps/percona/chaos/openebs_pool_network/test.yml
+++ b/apps/percona/chaos/openebs_pool_network/test.yml
@@ -8,31 +8,12 @@
   tasks:
     - block:
 
-        ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE       
-        - block:
+          ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-             
-          when: liveness_label != ''  
-
-        ## RECORD START-OF-TEST IN LITMUS RESULT CR
-
-        - block: 
-          
-            - name: Record test instance/run ID
-              set_fact:
-                run_id: "{{ lookup('env','RUN_ID') }}"
-
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
-
-          when: lookup('env','RUN_ID')     
+        ## RECORD START OF THE TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/create_testname.yml 
 
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
@@ -53,16 +34,15 @@
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify that the AUT (Application Under Test) is running 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
-
+          include_tasks: /common/utils/status_app_pod.yml
+          vars:
+            application_name: "Percona"
+            app_ns: "{{ namespace }}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: '2'
+            retries: '60'
+  
         ## STORAGE FAULT INJECTION 
 
         - include: "/chaoslib/openebs/cstor_pool_network.yml"
@@ -77,26 +57,20 @@
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
-        
-        - block:
+          include_tasks: /common/utils/status_app_pod.yml
+          vars:
+            application_name: "Percona"
+            app_ns: "{{ namespace }}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: '2'
+            retries: '60'
+          
+         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-
+        - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
+
 
         - set_fact:
             flag: "Pass"

--- a/apps/percona/chaos/openebs_replica_network_delay/test.yml
+++ b/apps/percona/chaos/openebs_replica_network_delay/test.yml
@@ -50,17 +50,15 @@
               - "StorageClass : {{ sc }}"
 
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
-
-        - name: Verify that the AUT (Application Under Test) is running 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"       
+            delay: 5
+            retries: 60
 
         - name: Get application pod name 
           shell: >
@@ -91,17 +89,14 @@
           chaos_duration: "{{ c_duration }}"
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
-
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"       
+            delay: 5
+            retries: 60
 
         - name: Verify mysql data persistence  
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/openebs_replica_network_delay/test.yml
+++ b/apps/percona/chaos/openebs_replica_network_delay/test.yml
@@ -8,6 +8,9 @@
   tasks:
     - block:
 
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''    
+
         ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE       
  
         - include: test_prerequisites.yml
@@ -21,17 +24,7 @@
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
 
-        - block:
-
-            - name: Record test instance/run ID
-              set_fact:
-                run_id: "{{ lookup('env','RUN_ID') }}"
-
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
-
-          when: lookup('env','RUN_ID')
+        - include_tasks: /common/utils/create_testname.yml
 
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
@@ -59,14 +52,6 @@
             app_lvalue: "{{ label.split('=')[1] }}"       
             delay: 5
             retries: 60
-
-        - name: Get application pod name 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: app_pod_name  
 
         - name: Create some test data in the mysql database
           include_tasks: "/common/utils/mysql_data_persistence.yml"
@@ -97,6 +82,9 @@
             app_lvalue: "{{ label.split('=')[1] }}"       
             delay: 5
             retries: 60
+
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
         - name: Verify mysql data persistence  
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/openebs_replica_network_delay/test.yml
+++ b/apps/percona/chaos/openebs_replica_network_delay/test.yml
@@ -53,6 +53,14 @@
             delay: 5
             retries: 60
 
+        - name: Get application pod name 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name      
+
         - name: Create some test data in the mysql database
           include_tasks: "/common/utils/mysql_data_persistence.yml"
           vars:

--- a/apps/percona/chaos/openebs_target_failure/test.yml
+++ b/apps/percona/chaos/openebs_target_failure/test.yml
@@ -63,15 +63,13 @@
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify that the AUT (Application Under Test) is running 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"       
+            delay: 5
+            retries: 60
 
         - name: Get application pod name 
           shell: >
@@ -107,16 +105,14 @@
             timeout: "{{ chaos_duration }}"
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
-        
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"       
+            delay: 5
+            retries: 60        
+
         - block:
 
             - name: Checking status of liveness pod

--- a/apps/percona/chaos/openebs_target_failure/test.yml
+++ b/apps/percona/chaos/openebs_target_failure/test.yml
@@ -52,6 +52,14 @@
             delay: 5
             retries: 60
 
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name    
+
         - name: Create some test data in the mysql database
           include_tasks: "/common/utils/mysql_data_persistence.yml"
           vars:
@@ -91,12 +99,20 @@
         - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
 
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: rescheduled_app_pod  
+
         - name: Verify mysql data persistence  
           include_tasks: "/common/utils/mysql_data_persistence.yml"
           vars:
             status: 'VERIFY'
             ns: "{{ namespace }}"
-            pod_name: "{{ app_pod_name.stdout }}"
+            pod_name: "{{ rescheduled_app_pod.stdout }}"
             dbuser: 'root'
             dbpassword: 'k8sDem0'
             dbname: 'tdb' 

--- a/apps/percona/chaos/openebs_target_failure/test.yml
+++ b/apps/percona/chaos/openebs_target_failure/test.yml
@@ -8,17 +8,9 @@
   tasks:
     - block:
 
-        ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE       
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-             
-          when: liveness_label != ''  
+         ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
         - include: test_prerequisites.yml
   
@@ -30,18 +22,7 @@
             chaos_util_path: "/chaoslib/{{ chaosutil }}"
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
-
-        - block: 
-          
-            - name: Record test instance/run ID
-              set_fact:
-                run_id: "{{ lookup('env','RUN_ID') }}"
-
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
-
-          when: lookup('env','RUN_ID')     
+        - include_tasks: /common/utils/create_testname.yml
 
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
@@ -70,14 +51,6 @@
             app_lvalue: "{{ label.split('=')[1] }}"       
             delay: 5
             retries: 60
-
-        - name: Get application pod name 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: app_pod_name  
 
         - name: Create some test data in the mysql database
           include_tasks: "/common/utils/mysql_data_persistence.yml"
@@ -113,15 +86,9 @@
             delay: 5
             retries: 60        
 
-        - block:
 
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-
+        ## POST-CHAOS APPLICATION LIVENESS CHECK
+        - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
 
         - name: Verify mysql data persistence  

--- a/apps/percona/chaos/openebs_target_network_delay/test.yml
+++ b/apps/percona/chaos/openebs_target_network_delay/test.yml
@@ -7,18 +7,13 @@
 
   tasks:
     - block:
+            
+          ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
-        ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE       
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-             
-          when: liveness_label != '' 
+          # Create test name append with run_id 
+        - include_tasks: /common/utils/create_testname.yml  
 
         - include: test_prerequisites.yml
   
@@ -30,18 +25,6 @@
             chaos_util_path: "/chaoslib/{{ chaosutil }}"
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
-
-        - block:
-
-            - name: Record test instance/run ID
-              set_fact:
-                run_id: "{{ lookup('env','RUN_ID') }}"
-
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
-
-          when: lookup('env','RUN_ID')
 
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
@@ -61,24 +44,14 @@
 
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
 
-        - name: Verify that the AUT (Application Under Test) is running 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
-
-        - name: Get application pod name 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: app_pod_name
+        - name: Verify that the AUT (Application Under Test) is running
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60  
 
         - name: Create some test data in the mysql database
           include_tasks: "/common/utils/mysql_data_persistence.yml"
@@ -103,27 +76,17 @@
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
-
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60 
+            
+        - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
-
+    
         - name: Verify mysql data persistence  
           include_tasks: "/common/utils/mysql_data_persistence.yml"
           vars:

--- a/apps/percona/chaos/openebs_target_network_delay/test.yml
+++ b/apps/percona/chaos/openebs_target_network_delay/test.yml
@@ -51,7 +51,15 @@
             app_lkey: "{{ label.split('=')[0] }}"
             app_lvalue: "{{ label.split('=')[1] }}"
             delay: 5
-            retries: 60  
+            retries: 60 
+
+        - name: Get application pod name 
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name    
 
         - name: Create some test data in the mysql database
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/openebs_target_network_loss/test.yml
+++ b/apps/percona/chaos/openebs_target_network_loss/test.yml
@@ -52,6 +52,14 @@
             delay: 5
             retries: 60
 
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
         - name: Create some test data in the mysql database
           include_tasks: "/common/utils/mysql_data_persistence.yml"
           vars:

--- a/apps/percona/chaos/openebs_target_network_loss/test.yml
+++ b/apps/percona/chaos/openebs_target_network_loss/test.yml
@@ -8,17 +8,10 @@
   tasks:
     - block:
 
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''    
+
         ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-
-          when: liveness_label != ''
 
         - include: test_prerequisites.yml
 
@@ -30,18 +23,8 @@
             chaos_util_path: "/chaoslib/{{ chaosutil }}"
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
-
-        - block:
-
-            - name: Record test instance/run ID
-              set_fact:
-                run_id: "{{ lookup('env','RUN_ID') }}"
-
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
-
-          when: lookup('env','RUN_ID')
+        
+        - include_tasks: /common/utils/create_testname.yml
 
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
@@ -133,15 +116,7 @@
             executable: /bin/bash
           register: new_pod_name
 
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-
+        - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
 
         - name: Verify mysql data persistence

--- a/apps/percona/chaos/openebs_target_network_loss/test.yml
+++ b/apps/percona/chaos/openebs_target_network_loss/test.yml
@@ -60,25 +60,14 @@
               - "StorageClass : {{ sc }}"
 
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
-
         - name: Verify that the AUT (Application Under Test) is running
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
-
-        - name: Get application pod name
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: app_pod_name
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"       
+            delay: 5
+            retries: 60
 
         - name: Create some test data in the mysql database
           include_tasks: "/common/utils/mysql_data_persistence.yml"
@@ -102,15 +91,13 @@
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} 
-            -o jsonpath='{.items[*].status.containerStatuses[].state.waiting.reason}'
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'CrashLoopBackOff' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"       
+            delay: 5
+            retries: 60
 
         - name: Delete the application pod
           shell: kubectl delete pod {{ app_pod_name.stdout }} -n {{ namespace }}

--- a/apps/percona/chaos/openebs_volume_replica_failure/test.yml
+++ b/apps/percona/chaos/openebs_volume_replica_failure/test.yml
@@ -62,15 +62,13 @@
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify that the AUT (Application Under Test) is running 
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"       
+            delay: 5
+            retries: 60
 
         - name: Get application pod name 
           shell: >
@@ -101,15 +99,13 @@
         ## POST-CHAOS APPLICATION LIVENESS CHECK
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}" 
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"       
+            delay: 5
+            retries: 60
 
         - block:
 

--- a/apps/percona/chaos/openebs_volume_replica_failure/test.yml
+++ b/apps/percona/chaos/openebs_volume_replica_failure/test.yml
@@ -91,12 +91,20 @@
         - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
 
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: rescheduled_app_pod  
+
         - name: Verify mysql data persistence  
           include_tasks: "/common/utils/mysql_data_persistence.yml"
           vars:
             status: 'VERIFY'
             ns: "{{ namespace }}"
-            pod_name: "{{ app_pod_name.stdout }}"
+            pod_name: "{{ rescheduled_app_pod.stdout }}"
             dbuser: 'root'
             dbpassword: 'k8sDem0'
             dbname: 'tdb'  

--- a/apps/percona/chaos/openebs_volume_replica_failure/test.yml
+++ b/apps/percona/chaos/openebs_volume_replica_failure/test.yml
@@ -8,17 +8,9 @@
   tasks:
     - block:
 
-        ## DERIVE THE APP STORAGE CLASS AND CHAOS UTIL TO USE       
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-             
-          when: liveness_label != ''  
+         ## PRE-CHAOS APPLICATION LIVENESS CHECK
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
         - include: test_prerequisites.yml
   
@@ -30,18 +22,7 @@
             chaos_util_path: "/chaoslib/{{ chaosutil }}"
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
-
-        - block:
- 
-            - name: Record test instance/run ID 
-              set_fact: 
-                run_id: "{{ lookup('env','RUN_ID') }}"
-           
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
-
-          when: lookup('env','RUN_ID')
+        - include_tasks: /common/utils/create_testname.yml
 
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
@@ -107,16 +88,8 @@
             delay: 5
             retries: 60
 
-        - block:
-
-            - name: Checking status of liveness pod
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o jsonpath='{.items[0].status.phase}'
-              register: liveness_pod
-              until: "'Running' in liveness_pod.stdout"
-              delay: 10
-              retries: 10
-             
-          when: liveness_label != ''  
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
         - name: Verify mysql data persistence  
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/taint_node/test.yml
+++ b/apps/percona/chaos/taint_node/test.yml
@@ -91,7 +91,7 @@
             -o=custom-columns=NAME:".metadata.name"
           args:
             executable: /bin/bash
-          register: rescheduled_app_pod  
+          register: rescheduled_app_pod 
 
         - name: Verify mysql data persistence
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/taint_node/test.yml
+++ b/apps/percona/chaos/taint_node/test.yml
@@ -55,15 +55,13 @@
               - "Label        : {{ label }}"
 
         - name: Verify that the AUT (Application Under Test) is running
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
 
         - name: Get application pod name
           shell: >
@@ -99,15 +97,13 @@
             app: "{{ app_pod_name.stdout }}"
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: 5
+            retries: 60
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
         - block:

--- a/apps/percona/chaos/taint_node/test.yml
+++ b/apps/percona/chaos/taint_node/test.yml
@@ -39,6 +39,14 @@
             delay: 5
             retries: 60
 
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+    
         - name: Generate unique string for use in dbname
           shell: echo $(mktemp) | cut -d '.' -f 2
           args:
@@ -76,6 +84,14 @@
         ## POST-CHAOS APPLICATION LIVENESS CHECK
         - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
+
+        - name: Get application pod name
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
+            -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: rescheduled_app_pod  
 
         - name: Verify mysql data persistence
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/apps/percona/chaos/taint_node/test.yml
+++ b/apps/percona/chaos/taint_node/test.yml
@@ -9,35 +9,11 @@
     - block:
 
         ## PRE-CHAOS APPLICATION LIVENESS CHECK
-        - block:
-
-            - name: Get the liveness pods
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o=custom-columns=NAME:".metadata.name" --no-headers
-              register: liveness_pods_before_drain
-
-            - name: Checking status of liveness pods
-              shell: kubectl get pods {{ item }} -n {{ liveness_namespace }} -o=custom-columns=NAME:".status.phase" --no-headers
-              register: result
-              with_items: "{{ liveness_pods_before_drain.stdout_lines }}"
-              until: "'Running' in result.stdout"
-              delay: 10
-              retries: 10
-             
-          when: liveness_label != ''  
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
         ## RECORD START-OF-TEST IN LITMUS RESULT CR
-
-        - block:
- 
-            - name: Record test instance/run ID 
-              set_fact: 
-                run_id: "{{ lookup('env','RUN_ID') }}"
-           
-            - name: Construct testname appended with runID
-              set_fact:
-                test_name: "{{ test_name }}-{{ run_id }}"
-
-          when: lookup('env','RUN_ID')
+        - include_tasks: /common/utils/create_testname.yml
 
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
@@ -62,14 +38,6 @@
             app_lvalue: "{{ label.split('=')[1] }}"
             delay: 5
             retries: 60
-
-        - name: Get application pod name
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: app_pod_name
 
         - name: Generate unique string for use in dbname
           shell: echo $(mktemp) | cut -d '.' -f 2
@@ -106,29 +74,8 @@
             retries: 60
 
         ## POST-CHAOS APPLICATION LIVENESS CHECK
-        - block:
-
-            - name: Get the liveness pods
-              shell: kubectl get pod -n {{ liveness_namespace }} -l {{ liveness_label }} -o=custom-columns=NAME:".metadata.name" --no-headers
-              register: liveness_pods_after_drain
-
-            - name: Checking status of liveness pods
-              shell: kubectl get pods {{ item }} -n {{ liveness_namespace }} -o=custom-columns=NAME:".status.phase" --no-headers
-              register: result
-              with_items: "{{ liveness_pods_after_drain.stdout_lines }}"
-              until: "'Running' in result.stdout"
-              delay: 10
-              retries: 10
-             
-          when: liveness_label != ''  
-
-        - name: Get application pod name
-          shell: >
-            kubectl get pods -n {{ namespace }} -l {{ label }} --no-headers
-            -o=custom-columns=NAME:".metadata.name"
-          args:
-            executable: /bin/bash
-          register: rescheduled_app_pod
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
         - name: Verify mysql data persistence
           include_tasks: "/common/utils/mysql_data_persistence.yml"

--- a/chaoslib/kubectl/cordon_drain_node.yaml
+++ b/chaoslib/kubectl/cordon_drain_node.yaml
@@ -15,7 +15,7 @@
     - name: Drain the application node
       shell: >
         kubectl drain {{ app_node }}
-        --ignore-daemonsets --force
+        --ignore-daemonsets --delete-local-data  --force
       args:
         executable: /bin/bash
       register: result

--- a/common/utils/status_app_pod.yml
+++ b/common/utils/status_app_pod.yml
@@ -1,7 +1,27 @@
 ---
+- name: Get application pod name
+  shell: >
+      kubectl get pods -n {{ app_ns }} -l {{ app_lkey }}="{{app_lvalue}}" --no-headers
+      -o=custom-columns=NAME:".metadata.name"
+  args:
+    executable: /bin/bash
+  register: app_pod_name
+
+- name: Get the container status of application.
+  shell: >
+     kubectl get pod {{ app_pod_name.stdout }} -n {{ app_ns }}
+     -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' | grep -w "running"
+  args:
+    executable: /bin/bash
+  register: containerStatus
+  until: "'running' in containerStatus.stdout"
+  delay: 2
+  retries: 150
+
 - name: Checking {{ application_name }} pod is in running state
   shell: kubectl get pods -n {{ app_ns }} -o jsonpath='{.items[?(@.metadata.labels.{{app_lkey}}=="{{app_lvalue}}")].status.phase}'
   register: result
   until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
   delay: '{{ delay }}'
   retries: '{{ retries }}'
+

--- a/common/utils/status_app_pod.yml
+++ b/common/utils/status_app_pod.yml
@@ -1,16 +1,8 @@
 ---
-- name: Get application pod name
-  shell: >
-      kubectl get pods -n {{ app_ns }} -l {{ app_lkey }}="{{app_lvalue}}" --no-headers
-      -o=custom-columns=NAME:".metadata.name"
-  args:
-    executable: /bin/bash
-  register: app_pod_name
-
 - name: Get the container status of application.
   shell: >
-     kubectl get pod {{ app_pod_name.stdout }} -n {{ app_ns }}
-     -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' | grep -w "running"
+     kubectl get pod -n {{ app_ns }} -l {{app_lkey}}="{{app_lvalue}}"
+     -o custom-columns=:..containerStatuses[].state --no-headers | grep -w "running"
   args:
     executable: /bin/bash
   register: containerStatus


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:


1) Application under test name fetch tasks at the beginning of test to check container-status.
2) Check rescheduled pod container statuses after the test.

**Special notes for your reviewer**: util file is tested on drain-node and taint_node for now.
@dargasudarshan @ksatchit @nsathyaseelan 

**test-logs**

```[0;34mansible-playbook 2.7.5[0m
[0;34m  config file = None[0m
[0;34m  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules'][0m
[0;34m  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible[0m
[0;34m  executable location = /usr/local/bin/ansible-playbook[0m
[0;34m  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0][0m
[0;34mNo config file found; using defaults[0m
[0;34m/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected[0m
[0;34m/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected[0m

PLAYBOOK: test.yml *************************************************************
[0;34m1 plays in ./percona/chaos/taint_node/test.yml[0m

PLAY [localhost] ***************************************************************
2018-12-14T11:02:19.461926 (delta: 0.064141)         elapsed: 0.064141 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:2[0m
2018-12-14T11:02:19.475374 (delta: 0.01341)         elapsed: 0.077589 ********* 
[0;32mok: [127.0.0.1][0m
[0;34mMETA: ran handlers[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:12[0m
2018-12-14T11:02:23.917130 (delta: 4.441581)         elapsed: 4.519345 ******** 
[0;36mincluded: /common/utils/application_liveness_check.yml for 127.0.0.1[0m

TASK [Get the liveness pods] ***************************************************
[1;30mtask path: /common/utils/application_liveness_check.yml:2[0m
2018-12-14T11:02:24.018407 (delta: 0.101199)         elapsed: 4.620622 ******** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n litmus -l liveness=percona-liveness -o=custom-columns=NAME:\".metadata.name\" --no-headers", "delta": "0:00:00.681700", "end": "2018-12-14 11:02:24.992327", "rc": 0, "start": "2018-12-14 11:02:24.310627", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}[0m

TASK [Checking status of liveness pods] ****************************************
[1;30mtask path: /common/utils/application_liveness_check.yml:6[0m
2018-12-14T11:02:25.031379 (delta: 1.012798)         elapsed: 5.633594 ******** 

TASK [include_tasks] ***********************************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:16[0m
2018-12-14T11:02:25.067840 (delta: 0.036406)         elapsed: 5.670055 ******** 
[0;36mincluded: /common/utils/create_testname.yml for 127.0.0.1[0m

TASK [Record test instance/run ID] *********************************************
[1;30mtask path: /common/utils/create_testname.yml:3[0m
2018-12-14T11:02:25.125487 (delta: 0.057596)         elapsed: 5.727702 ******** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Construct testname appended with runID] **********************************
[1;30mtask path: /common/utils/create_testname.yml:7[0m
2018-12-14T11:02:25.167338 (delta: 0.041802)         elapsed: 5.769553 ******** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:18[0m
2018-12-14T11:02:25.231961 (delta: 0.064516)         elapsed: 5.834176 ******** 
[0;36mincluded: /common/utils/update_litmus_result_resource.yml for 127.0.0.1[0m

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:3[0m
2018-12-14T11:02:25.333515 (delta: 0.101433)         elapsed: 5.93573 ********* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "checksum": "d05aed26cf2bdd381ab7ba1a50da3a89d5919a60", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "554c36677ccd1600ce9808728f926bf5", "mode": "0644", "owner": "root", "size": 436, "src": "/root/.ansible/tmp/ansible-tmp-1544785345.39-114168841520686/source", "state": "file", "uid": 0}[0m

TASK [Analyze the cr yaml] *****************************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:14[0m
2018-12-14T11:02:25.883395 (delta: 0.549781)         elapsed: 6.48561 ********* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.382829", "end": "2018-12-14 11:02:26.402199", "rc": 0, "start": "2018-12-14 11:02:26.019370", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-failure-taint \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app: percona \n    chaostype: taint-node \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-failure-taint ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app: percona ", "    chaostype: taint-node ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}[0m

TASK [Apply the litmus result CR] **********************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:17[0m
2018-12-14T11:02:26.439523 (delta: 0.556079)         elapsed: 7.041738 ******** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.191282", "end": "2018-12-14 11:02:27.812648", "failed_when_result": false, "rc": 0, "start": "2018-12-14 11:02:26.621366", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/node-failure-taint configured", "stdout_lines": ["litmusresult.litmus.io/node-failure-taint configured"]}[0m

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:27[0m
2018-12-14T11:02:27.855173 (delta: 1.415595)         elapsed: 8.457388 ******** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Analyze the cr yaml] *****************************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:38[0m
2018-12-14T11:02:27.893496 (delta: 0.038258)         elapsed: 8.495711 ******** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Apply the litmus result CR] **********************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:41[0m
2018-12-14T11:02:27.943048 (delta: 0.049461)         elapsed: 8.545263 ******** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Display the app information passed via the test job] *********************
[1;30mtask path: /percona/chaos/taint_node/test.yml:26[0m
2018-12-14T11:02:27.999456 (delta: 0.056283)         elapsed: 8.601671 ******** 
[0;32mok: [127.0.0.1] => {[0m
[0;32m    "msg": [[0m
[0;32m        "The application info is as follows:", [0m
[0;32m        "Namespace    : app-percona-ns", [0m
[0;32m        "Label        : name=percona"[0m
[0;32m    ][0m
[0;32m}[0m

TASK [Verify that the AUT (Application Under Test) is running] *****************
[1;30mtask path: /percona/chaos/taint_node/test.yml:33[0m
2018-12-14T11:02:28.091930 (delta: 0.092365)         elapsed: 8.694145 ******** 
[0;36mincluded: /common/utils/status_app_pod.yml for 127.0.0.1[0m

TASK [Get the container status of application.] ********************************
[1;30mtask path: /common/utils/status_app_pod.yml:2[0m
2018-12-14T11:02:28.174234 (delta: 0.082142)         elapsed: 8.776449 ******** 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.602165", "end": "2018-12-14 11:02:28.942784", "rc": 0, "start": "2018-12-14 11:02:28.340619", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2018-12-14T10:41:01Z]]", "stdout_lines": ["map[running:map[startedAt:2018-12-14T10:41:01Z]]"]}[0m

TASK [Checking {{ application_name }} pod is in running state] *****************
[1;30mtask path: /common/utils/status_app_pod.yml:13[0m
2018-12-14T11:02:28.986697 (delta: 0.812384)         elapsed: 9.588912 ******** 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.575036", "end": "2018-12-14 11:02:29.706674", "rc": 0, "start": "2018-12-14 11:02:29.131638", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}[0m

TASK [Get application pod name] ************************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:42[0m
2018-12-14T11:02:29.756198 (delta: 0.769409)         elapsed: 10.358413 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.475483", "end": "2018-12-14 11:02:30.383206", "rc": 0, "start": "2018-12-14 11:02:29.907723", "stderr": "", "stderr_lines": [], "stdout": "percona-69788c4c96-chrks", "stdout_lines": ["percona-69788c4c96-chrks"]}[0m

TASK [Generate unique string for use in dbname] ********************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:50[0m
2018-12-14T11:02:30.427082 (delta: 0.670799)         elapsed: 11.029297 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "echo $(mktemp) | cut -d '.' -f 2", "delta": "0:00:00.451230", "end": "2018-12-14 11:02:31.014004", "rc": 0, "start": "2018-12-14 11:02:30.562774", "stderr": "", "stderr_lines": [], "stdout": "G20yN1pSUr", "stdout_lines": ["G20yN1pSUr"]}[0m

TASK [Create some test data in the mysql database] *****************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:56[0m
2018-12-14T11:02:31.052708 (delta: 0.625519)         elapsed: 11.654923 ******* 
[0;36mincluded: /common/utils/mysql_data_persistence.yml for 127.0.0.1[0m

TASK [Create some test data in the mysql database] *****************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:4[0m
2018-12-14T11:02:31.136361 (delta: 0.083604)         elapsed: 11.738576 ******* 
[0;33mchanged: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdbG20yN1pSUr;') => {"changed": true, "cmd": "kubectl exec percona-69788c4c96-chrks -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database tdbG20yN1pSUr;'", "delta": "0:00:00.610859", "end": "2018-12-14 11:02:31.910953", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdbG20yN1pSUr;'", "rc": 0, "start": "2018-12-14 11:02:31.300094", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}[0m
[0;33mchanged: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdbG20yN1pSUr) => {"changed": true, "cmd": "kubectl exec percona-69788c4c96-chrks -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdbG20yN1pSUr", "delta": "0:00:00.831011", "end": "2018-12-14 11:02:32.900118", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdbG20yN1pSUr", "rc": 0, "start": "2018-12-14 11:02:32.069107", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}[0m
[0;33mchanged: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdbG20yN1pSUr) => {"changed": true, "cmd": "kubectl exec percona-69788c4c96-chrks -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdbG20yN1pSUr", "delta": "0:00:00.725820", "end": "2018-12-14 11:02:33.763540", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdbG20yN1pSUr", "rc": 0, "start": "2018-12-14 11:02:33.037720", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}[0m

TASK [Checking for the Corrupted tables] ***************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:21[0m
2018-12-14T11:02:33.815455 (delta: 2.679009)         elapsed: 14.41767 ******** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Verify mysql data persistence] *******************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:30[0m
2018-12-14T11:02:33.853750 (delta: 0.038246)         elapsed: 14.455965 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Delete/drop MySQL database] **********************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:43[0m
2018-12-14T11:02:33.891988 (delta: 0.038192)         elapsed: 14.494203 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Verify successful db delete] *********************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:51[0m
2018-12-14T11:02:33.929459 (delta: 0.037393)         elapsed: 14.531674 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:69[0m
2018-12-14T11:02:33.966597 (delta: 0.037092)         elapsed: 14.568812 ******* 
[0;36mincluded: /chaoslib/kubectl/pod_evict_by_taint.yaml for 127.0.0.1[0m

TASK [Identify the application node] *******************************************
[1;30mtask path: /chaoslib/kubectl/pod_evict_by_taint.yaml:3[0m
2018-12-14T11:02:34.034619 (delta: 0.067921)         elapsed: 14.636834 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod percona-69788c4c96-chrks -n app-percona-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.520580", "end": "2018-12-14 11:02:34.707152", "rc": 0, "start": "2018-12-14 11:02:34.186572", "stderr": "", "stderr_lines": [], "stdout": "gke-e2e-cluster-dev-default-pool-ccc0254f-t9vk", "stdout_lines": ["gke-e2e-cluster-dev-default-pool-ccc0254f-t9vk"]}[0m

TASK [Record the application node name] ****************************************
[1;30mtask path: /chaoslib/kubectl/pod_evict_by_taint.yaml:11[0m
2018-12-14T11:02:34.771500 (delta: 0.736832)         elapsed: 15.373715 ******* 
[0;32mok: [127.0.0.1] => {"ansible_facts": {"app_node": "gke-e2e-cluster-dev-default-pool-ccc0254f-t9vk"}, "changed": false}[0m

TASK [Force eviction of pods by tainting the app node] *************************
[1;30mtask path: /chaoslib/kubectl/pod_evict_by_taint.yaml:15[0m
2018-12-14T11:02:34.866153 (delta: 0.094603)         elapsed: 15.468368 ******* 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl taint node gke-e2e-cluster-dev-default-pool-ccc0254f-t9vk node.kubernetes.io/out-of-disk=:NoExecute", "delta": "0:00:00.490795", "end": "2018-12-14 11:02:35.524047", "rc": 0, "start": "2018-12-14 11:02:35.033252", "stderr": "", "stderr_lines": [], "stdout": "node/gke-e2e-cluster-dev-default-pool-ccc0254f-t9vk tainted", "stdout_lines": ["node/gke-e2e-cluster-dev-default-pool-ccc0254f-t9vk tainted"]}[0m

TASK [Wait for application pod reschedule (evict)] *****************************
[1;30mtask path: /chaoslib/kubectl/pod_evict_by_taint.yaml:26[0m
2018-12-14T11:02:35.568573 (delta: 0.702333)         elapsed: 16.170788 ******* 
[0;32mok: [127.0.0.1] => {"changed": false, "elapsed": 30, "path": null, "port": null, "search_regex": null, "state": "started"}[0m

TASK [Untaint the application node] ********************************************
[1;30mtask path: /chaoslib/kubectl/pod_evict_by_taint.yaml:35[0m
2018-12-14T11:03:05.979121 (delta: 30.410498)         elapsed: 46.581336 ****** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Verify AUT liveness post fault-injection] ********************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:75[0m
2018-12-14T11:03:06.016821 (delta: 0.037541)         elapsed: 46.619036 ******* 
[0;36mincluded: /common/utils/status_app_pod.yml for 127.0.0.1[0m

TASK [Get the container status of application.] ********************************
[1;30mtask path: /common/utils/status_app_pod.yml:2[0m
2018-12-14T11:03:06.076252 (delta: 0.059387)         elapsed: 46.678467 ******* 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.583422", "end": "2018-12-14 11:03:06.802977", "rc": 0, "start": "2018-12-14 11:03:06.219555", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2018-12-14T10:41:01Z]]", "stdout_lines": ["map[running:map[startedAt:2018-12-14T10:41:01Z]]"]}[0m

TASK [Checking {{ application_name }} pod is in running state] *****************
[1;30mtask path: /common/utils/status_app_pod.yml:13[0m
2018-12-14T11:03:06.853551 (delta: 0.777255)         elapsed: 47.455766 ******* 
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (60 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (59 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (58 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (57 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (56 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (55 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (54 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (53 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (52 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (51 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (50 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (49 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (48 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (47 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (46 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (45 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (44 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (43 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (42 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (41 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (40 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (39 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (38 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (37 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (36 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (35 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (34 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (33 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (32 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (31 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (30 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (29 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (28 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (27 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (26 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (25 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (24 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (23 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (22 retries left).[0m
[1;30mFAILED - RETRYING: Checking {{ application_name }} pod is in running state (21 retries left).[0m
[0;33mchanged: [127.0.0.1] => {"attempts": 41, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.585287", "end": "2018-12-14 11:06:54.395557", "rc": 0, "start": "2018-12-14 11:06:53.810270", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:85[0m
2018-12-14T11:06:54.451403 (delta: 227.597775)         elapsed: 275.053618 **** 
[0;36mincluded: /common/utils/application_liveness_check.yml for 127.0.0.1[0m

TASK [Get the liveness pods] ***************************************************
[1;30mtask path: /common/utils/application_liveness_check.yml:2[0m
2018-12-14T11:06:54.529119 (delta: 0.07766)         elapsed: 275.131334 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n litmus -l liveness=percona-liveness -o=custom-columns=NAME:\".metadata.name\" --no-headers", "delta": "0:00:00.485078", "end": "2018-12-14 11:06:55.161545", "rc": 0, "start": "2018-12-14 11:06:54.676467", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}[0m

TASK [Checking status of liveness pods] ****************************************
[1;30mtask path: /common/utils/application_liveness_check.yml:6[0m
2018-12-14T11:06:55.217078 (delta: 0.687913)         elapsed: 275.819293 ****** 

TASK [Get application pod name] ************************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:88[0m
2018-12-14T11:06:55.255130 (delta: 0.037998)         elapsed: 275.857345 ****** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.498434", "end": "2018-12-14 11:06:55.968452", "rc": 0, "start": "2018-12-14 11:06:55.470018", "stderr": "", "stderr_lines": [], "stdout": "percona-69788c4c96-9vl95", "stdout_lines": ["percona-69788c4c96-9vl95"]}[0m

TASK [wait for some duration.] *************************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:96[0m
2018-12-14T11:06:56.008022 (delta: 0.752843)         elapsed: 276.610237 ****** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "sleep 5", "delta": "0:00:06.412417", "end": "2018-12-14 11:07:02.560116", "rc": 0, "start": "2018-12-14 11:06:56.147699", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}[0m

TASK [Verify mysql data persistence] *******************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:102[0m
2018-12-14T11:07:02.597850 (delta: 6.589781)         elapsed: 283.200065 ****** 
[0;36mincluded: /common/utils/mysql_data_persistence.yml for 127.0.0.1[0m

TASK [Create some test data in the mysql database] *****************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:4[0m
2018-12-14T11:07:02.678493 (delta: 0.080592)         elapsed: 283.280708 ****** 
[0;36mskipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdbG20yN1pSUr;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdbG20yN1pSUr;'", "skip_reason": "Conditional result was False"}[0m
[0;36mskipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdbG20yN1pSUr)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdbG20yN1pSUr", "skip_reason": "Conditional result was False"}[0m
[0;36mskipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdbG20yN1pSUr)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdbG20yN1pSUr", "skip_reason": "Conditional result was False"}[0m

TASK [Checking for the Corrupted tables] ***************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:21[0m
2018-12-14T11:07:02.768503 (delta: 0.089965)         elapsed: 283.370718 ****** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-69788c4c96-9vl95 -n app-percona-ns -- mysqlcheck -c tdbG20yN1pSUr -uroot -pk8sDem0", "delta": "0:00:00.943302", "end": "2018-12-14 11:07:03.960572", "failed_when_result": false, "rc": 0, "start": "2018-12-14 11:07:03.017270", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "tdbG20yN1pSUr.ttbl                                 OK", "stdout_lines": ["tdbG20yN1pSUr.ttbl                                 OK"]}[0m

TASK [Verify mysql data persistence] *******************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:30[0m
2018-12-14T11:07:04.002804 (delta: 1.234204)         elapsed: 284.605019 ****** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-69788c4c96-9vl95 -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' tdbG20yN1pSUr;", "delta": "0:00:00.700434", "end": "2018-12-14 11:07:04.894945", "failed_when_result": false, "rc": 0, "start": "2018-12-14 11:07:04.194511", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}[0m

TASK [Delete/drop MySQL database] **********************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:43[0m
2018-12-14T11:07:04.948760 (delta: 0.945889)         elapsed: 285.550975 ****** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Verify successful db delete] *********************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:51[0m
2018-12-14T11:07:05.002075 (delta: 0.053245)         elapsed: 285.60429 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [set_fact] ****************************************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:113[0m
2018-12-14T11:07:05.090249 (delta: 0.08793)         elapsed: 285.692464 ******* 
[0;32mok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}[0m

TASK [Untaint the application node] ********************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:123[0m
2018-12-14T11:07:05.171135 (delta: 0.08083)         elapsed: 285.77335 ******** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl taint node gke-e2e-cluster-dev-default-pool-ccc0254f-t9vk node.kubernetes.io/out-of-disk:NoExecute-", "delta": "0:00:00.545884", "end": "2018-12-14 11:07:05.875191", "failed_when_result": false, "rc": 0, "start": "2018-12-14 11:07:05.329307", "stderr": "", "stderr_lines": [], "stdout": "node/gke-e2e-cluster-dev-default-pool-ccc0254f-t9vk untainted", "stdout_lines": ["node/gke-e2e-cluster-dev-default-pool-ccc0254f-t9vk untainted"]}[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /percona/chaos/taint_node/test.yml:132[0m
2018-12-14T11:07:05.924126 (delta: 0.752884)         elapsed: 286.526341 ****** 
[0;36mincluded: /common/utils/update_litmus_result_resource.yml for 127.0.0.1[0m

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:3[0m
2018-12-14T11:07:05.989962 (delta: 0.065771)         elapsed: 286.592177 ****** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Analyze the cr yaml] *****************************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:14[0m
2018-12-14T11:07:06.032571 (delta: 0.042556)         elapsed: 286.634786 ****** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Apply the litmus result CR] **********************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:17[0m
2018-12-14T11:07:06.071346 (delta: 0.038643)         elapsed: 286.673561 ****** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:27[0m
2018-12-14T11:07:06.109756 (delta: 0.038339)         elapsed: 286.711971 ****** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "checksum": "ec3dfc04cf84ddcab48a2db53906d8c3f425defe", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "bc829afa6a29a7eee43c060a5543ba93", "mode": "0644", "owner": "root", "size": 434, "src": "/root/.ansible/tmp/ansible-tmp-1544785626.15-209042106597864/source", "state": "file", "uid": 0}[0m

TASK [Analyze the cr yaml] *****************************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:38[0m
2018-12-14T11:07:07.241603 (delta: 1.131791)         elapsed: 287.843818 ****** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.370509", "end": "2018-12-14 11:07:07.756054", "rc": 0, "start": "2018-12-14 11:07:07.385545", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-failure-taint \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app: percona \n    chaostype: taint-node \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-failure-taint ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app: percona ", "    chaostype: taint-node ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}[0m

TASK [Apply the litmus result CR] **********************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:41[0m
2018-12-14T11:07:07.794829 (delta: 0.553169)         elapsed: 288.397044 ****** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.751596", "end": "2018-12-14 11:07:08.685567", "failed_when_result": false, "rc": 0, "start": "2018-12-14 11:07:07.933971", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/node-failure-taint configured", "stdout_lines": ["litmusresult.litmus.io/node-failure-taint configured"]}[0m
[0;34mMETA: ran handlers[0m
[0;34mMETA: ran handlers[0m

PLAY RECAP *********************************************************************
[0;33m127.0.0.1[0m                  : [0;32mok=37  [0m [0;33mchanged=22  [0m unreachable=0    failed=0   

2018-12-14T11:07:08.715023 (delta: 0.920146)         elapsed: 289.317238 ****** 
=============================================================================== ```