### PR TITLE
Included CPU freeze and daemonset pod cleanup task in node_freeze chaos.

### DIFF
--- a/apps/percona/chaos/node_freeze/run_litmus_test.yml
+++ b/apps/percona/chaos/node_freeze/run_litmus_test.yml
@@ -37,10 +37,10 @@ spec:
             value: 'name=percona'
 
           - name: LIVENESS_APP_LABEL
-            value: ""
+            value: "liveness=percona-liveness"
 
           - name: LIVENESS_APP_NAMESPACE
-            value: ""
+            value: "litmus"
 
           - name: PLATFORM
             value: "AWS"

--- a/apps/percona/chaos/node_freeze/test.yml
+++ b/apps/percona/chaos/node_freeze/test.yml
@@ -144,8 +144,13 @@
               register: node_status
               until: "'Ready' in node_status.stdout"
               delay: 5
-              retries: 60 
-             
+              retries: 60
+
+            - include_tasks: /chaoslib/chaoskube/node_freeze_chaos.yml
+              vars:
+                namespace: "{{app_ns}}"
+                nodeaction: "node_chaos_delete"
+                 
           when: lookup('env', 'PLATFORM') == 'AWS'     
 
         # RECORD END-OF-TEST IN LITMUS RESULT CR

--- a/apps/percona/chaos/node_freeze/test.yml
+++ b/apps/percona/chaos/node_freeze/test.yml
@@ -68,8 +68,10 @@
 
         - include_tasks: /chaoslib/chaoskube/node_freeze_chaos.yml
           vars:
-            nodeaction: "memory-freeze"      
-            namespace: "{{ app_ns }}"
+            action: "node-chaos"
+            nodeaction: "cpu-freeze"    
+            platform: "{{ test_bed }}"
+            app_ns: "{{ namespace }}"      
 
         - name: wait for app pod to reschedule
           shell: >
@@ -148,8 +150,8 @@
 
             - include_tasks: /chaoslib/chaoskube/node_freeze_chaos.yml
               vars:
-                namespace: "{{app_ns}}"
-                nodeaction: "node_chaos_delete"
+                action: "node_chaos_delete"
+                app_ns: "{{ namespace }}"      
                  
           when: lookup('env', 'PLATFORM') == 'AWS'     
 

--- a/apps/percona/chaos/node_freeze/test.yml
+++ b/apps/percona/chaos/node_freeze/test.yml
@@ -69,6 +69,8 @@
         - include_tasks: /chaoslib/chaoskube/node_freeze_chaos.yml
           vars:
             action: "node-chaos"
+            application_label: "{{app_label}}"
+            docker_image: "{{ freeze_image }}"
             nodeaction: "cpu-freeze"    
             platform: "{{ test_bed }}"
             app_ns: "{{ namespace }}"      
@@ -151,7 +153,7 @@
             - include_tasks: /chaoslib/chaoskube/node_freeze_chaos.yml
               vars:
                 action: "node_chaos_delete"
-                app_ns: "{{ namespace }}"      
+                app_ns: "{{ namespace }}"     
                  
           when: lookup('env', 'PLATFORM') == 'AWS'     
 

--- a/apps/percona/chaos/node_freeze/test.yml
+++ b/apps/percona/chaos/node_freeze/test.yml
@@ -18,26 +18,24 @@
         - include_tasks: "/common/utils/update_litmus_result_resource.yml"
           vars:
             status: 'SOT'
-       
-        # DISPLAY APP INFORMATION 
- 
+
+        # DISPLAY APP INFORMATION
+
         - name: Display the app information passed via the test job
-          debug: 
-            msg: 
+          debug:
+            msg:
               - "The application info is as follows:"
               - "Namespace    : {{ app_ns }}"
               - "Label        : {{ app_label }}"
 
         - name: Verify that the AUT (Application Under Test) is running
-          shell: >
-            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ app_label.split('=')[0] }}"
+            app_lvalue: "{{ app_label.split('=')[1] }}"
+            delay: 5
+            retries: 60
 
         - name: Get application pod name
           shell: >
@@ -64,16 +62,21 @@
             dbname: "tdb{{ uniqstr.stdout }}"
           when: data_persistance != ''
 
-        ## STORAGE FAULT INJECTION 
+        ## STORAGE FAULT INJECTION
 
         - include_tasks: /chaoslib/chaoskube/node_freeze_chaos.yml
           vars:
             action: "node-chaos"
             application_label: "{{app_label}}"
             docker_image: "{{ freeze_image }}"
-            nodeaction: "cpu-freeze"    
+            nodeaction: "cpu-freeze"
             platform: "{{ test_bed }}"
-            app_ns: "{{ namespace }}"      
+            app_ns: "{{ namespace }}"
+
+        - name: Display application details from above utils.
+          debug:
+            msg:
+              - "APPLICATION_NODE_NAME    : {{ app_node }}"
 
         - name: wait for app pod to reschedule
           shell: >
@@ -82,15 +85,13 @@
             executable: /bin/bash
 
         - name: Verify AUT liveness post fault-injection
-          shell: >
-            kubectl get pods -n {{ app_ns }} -l {{ app_label }} --no-headers
-            -o custom-columns=:status.phase
-          args:
-            executable: /bin/bash
-          register: app_status
-          until: "((app_status.stdout_lines|unique)|length) == 1 and 'Running' in app_status.stdout"
-          delay: 10
-          retries: 12
+          include_tasks: "/common/utils/status_app_pod.yml"
+          vars:
+            app_ns: "{{namespace}}"
+            app_lkey: "{{ app_label.split('=')[0] }}"
+            app_lvalue: "{{ app_label.split('=')[1] }}"
+            delay: 5
+            retries: 60
 
         - include_tasks: /common/utils/application_liveness_check.yml
           when: liveness_label != ''
@@ -117,8 +118,8 @@
         - set_fact:
             flag: "Pass"
 
-      rescue: 
-        - set_fact: 
+      rescue:
+        - set_fact:
             flag: "Fail"
 
       always:
@@ -127,6 +128,8 @@
 
             ## Fetch the AWS instance details(instance_id, region)
             - include_tasks: /common/utils/aws/fetch_aws_details.yml
+              vars:
+                instance_name: "{{ app_node }}"
 
             # Execute the chaos util
             - include_tasks: /chaoslib/aws_chaos/chaosutil_aws.yml
@@ -153,9 +156,9 @@
             - include_tasks: /chaoslib/chaoskube/node_freeze_chaos.yml
               vars:
                 action: "node_chaos_delete"
-                app_ns: "{{ namespace }}"     
-                 
-          when: lookup('env', 'PLATFORM') == 'AWS'     
+                app_ns: "{{ namespace }}"
+
+          when: lookup('env', 'PLATFORM') == 'AWS'
 
         # RECORD END-OF-TEST IN LITMUS RESULT CR
         - include_tasks: "/common/utils/update_litmus_result_resource.yml"

--- a/apps/percona/chaos/node_freeze/test_vars.yml
+++ b/apps/percona/chaos/node_freeze/test_vars.yml
@@ -1,6 +1,6 @@
 test_name: node-mem-freeze
 
-app_ns: "{{ lookup('env','APP_NS') }}"
+namespace: "{{ lookup('env','APP_NS') }}"
 
 app_label: "{{ lookup('env','APP_LABEL') }}"
 
@@ -17,3 +17,5 @@ daemonset: node_freeze.yml
 subnet_id: "{{ lookup('env','SUBNET_ID') }}"
 
 data_persistance: "{{ lookup('env','DATA_PERSISTENCY') }}"
+
+test_bed: "{{ lookup('env','PLATFORM') }}" 

--- a/chaoslib/chaoskube/node_freeze_chaos.yml
+++ b/chaoslib/chaoskube/node_freeze_chaos.yml
@@ -58,23 +58,56 @@
         args:
           executable: /bin/bash
         ignore_errors: true 
-        register: result
-
-      - name: wait for node memory freeze
-        shell: >
-          sleep {{ f_duration }} 
-        args:
-          executable: /bin/bash
-
-      - name: Check the node status after memory consumption.
-        shell: kubectl get node {{ app_node }} --no-headers | awk '{print $2}'
-        args:
-          executable: /bin/bash
-        register: node_status
-        until: "'NotReady' in node_status.stdout"
-        delay: 5
-        retries: 60
    
      when: nodeaction == "memory-freeze"
 
+   - block:
+           
+      - name: Run CPU freeze docker container.
+        shell: >
+          kubectl exec {{ chaos_pod.stdout }} -n {{ namespace }} 
+          docker run {{ freeze_image }} & 
+        args:
+          executable: /bin/bash      
+        ignore_errors: true
+     
+     when: nodeaction == "cpu-freeze"   
+   
+   - name: wait for node memory freeze
+     shell: >
+        sleep {{ f_duration }}
+     args:
+       executable: /bin/bash
 
+   - name: Check the node status after node chaos.
+     shell: kubectl get node {{ app_node }} --no-headers | awk '{print $2}'
+     args:
+       executable: /bin/bash
+     register: node_statusi
+     until: "'NotReady' in node_status.stdout"
+     delay: 5
+     retries: 60        
+
+- block:
+     
+   - name: Delete node chaos infra
+     shell: >
+       kubectl delete ds -l app=node-freeze
+       -n {{ namespace }}
+     args:
+       executable: /bin/bash
+     register: result
+ 
+   - name: Confirm that the node chaos ds is stopped on all nodes
+     shell: >
+       kubectl get pod -l app=node-feeze
+       --no-headers -o custom-columns=:status.phase
+       -n {{ namespace }} | sort | uniq
+     args: 
+       executable: /bin/bash
+     register: result
+     until: "'Running' not in result.stdout"
+     delay: 20
+     retries: 15          
+
+  when: nodeaction == "node_choas_delete"

--- a/chaoslib/chaoskube/node_freeze_chaos.yml
+++ b/chaoslib/chaoskube/node_freeze_chaos.yml
@@ -24,7 +24,7 @@
 
        - name: Obtaining the application pod name using its label.
          shell: >
-           kubectl get pods -n {{ app_ns }} -l {{ app_label }} | grep
+           kubectl get pods -n {{ app_ns }} -l {{ application_label }} | grep
            -w Running | awk '{print $1}' | head -1
          args:
            executable: /bin/bash
@@ -57,7 +57,7 @@
            - name: Run docker container to trigger memory freeze on app node
              shell: >
                 kubectl exec  {{ chaos_pod.stdout }} -n {{ app_ns }}
-                docker run {{ freeze_image }} python memleak.py &
+                docker run {{ docker_image }} python memleak.py &
              args:
                executable: /bin/bash
              ignore_errors: true
@@ -78,7 +78,7 @@
            - name: Run CPU freeze docker container.
              shell: >
                kubectl exec {{ chaos_pod.stdout }} -n {{ app_ns }}
-               docker run {{ freeze_image }} &
+               docker run {{ docker_image }} &
              args:
                executable: /bin/bash
              ignore_errors: true

--- a/chaoslib/chaoskube/node_freeze_chaos.yml
+++ b/chaoslib/chaoskube/node_freeze_chaos.yml
@@ -1,113 +1,114 @@
 ---
 - block:
 
-   - name: Setup node freeze infra
-     shell: >
-       kubectl create -f {{ daemonset }} -n {{ namespace }}
-     args:
-       executable: /bin/bash
-     register: result
-    
-   - name: Confirm that node freeze chaos ds is running on all nodes
-     shell: >
-       kubectl get pod -l app=node-freeze
-       --no-headers -o custom-columns=:status.phase
-       -n {{ namespace }} | sort | uniq
-     args: 
-       executable: /bin/bash
-     register: result
-     until: "result.stdout == 'Running'"
-     delay: 20
-     retries: 15
-
-   - name: Obtaining the application pod name using its label.
-     shell: >
-       kubectl get pods -n {{ namespace }} -l {{ app_label }} | grep
-       -w Running | awk '{print $1}' | head -1 
-     args:
-       executable: /bin/bash
-     register: app_pod
-
-   - name: Identify the application node
-     shell: >
-        kubectl get pod {{ app_pod.stdout }} -n {{ namespace }}
-        --no-headers -o custom-columns=:spec.nodeName
-     args: 
-        executable: /bin/bash
-     register: result 
-               
-   - name: Record the application node name 
-     set_fact:
-       app_node: "{{ result.stdout }}"
-
-   - name: Record the node freeze chaos pod on given app node 
-     shell: >
-       kubectl get pod -l app=node-freeze -o wide 
-       -n {{ namespace }} | grep {{ app_node }} 
-       | awk '{print $1}'
-     args:
-       executable: /bin/bash
-     register: chaos_pod
-
    - block:
-            
-      - name: Run docker container to trigger memory freeze on app node
-        shell: >
-          kubectl exec  {{ chaos_pod.stdout }} -n {{ namespace }}
-          docker run {{ freeze_image }} python memleak.py &
-        args:
-          executable: /bin/bash
-        ignore_errors: true 
-   
-     when: nodeaction == "memory-freeze"
 
-   - block:
-           
-      - name: Run CPU freeze docker container.
-        shell: >
-          kubectl exec {{ chaos_pod.stdout }} -n {{ namespace }} 
-          docker run {{ freeze_image }} & 
-        args:
-          executable: /bin/bash      
-        ignore_errors: true
-     
-     when: nodeaction == "cpu-freeze"   
-   
-   - name: wait for node memory freeze
-     shell: >
-        sleep {{ f_duration }}
-     args:
-       executable: /bin/bash
+       - name: Setup node freeze infra
+         shell: >
+           kubectl create -f {{ daemonset }} -n {{ app_ns }}
+         args:
+           executable: /bin/bash
+         register: result
 
-   - name: Check the node status after node chaos.
-     shell: kubectl get node {{ app_node }} --no-headers | awk '{print $2}'
-     args:
-       executable: /bin/bash
-     register: node_statusi
-     until: "'NotReady' in node_status.stdout"
-     delay: 5
-     retries: 60        
+       - name: Confirm that node freeze chaos ds is running on all nodes
+         shell: >
+           kubectl get pod -l app=node-freeze
+           --no-headers -o custom-columns=:status.phase
+           -n {{ app_ns }} | sort | uniq
+         args:
+           executable: /bin/bash
+         register: result
+         until: "result.stdout == 'Running'"
+         delay: 20
+         retries: 15
+
+       - name: Obtaining the application pod name using its label.
+         shell: >
+           kubectl get pods -n {{ app_ns }} -l {{ app_label }} | grep
+           -w Running | awk '{print $1}' | head -1
+         args:
+           executable: /bin/bash
+         register: app_pod
+
+       - name: Identify the application node
+         shell: >
+           kubectl get pod {{ app_pod.stdout }} -n {{ app_ns }}
+           --no-headers -o custom-columns=:spec.nodeName
+         args:
+            executable: /bin/bash
+         register: result
+
+       - name: Record the application node name
+         set_fact:
+           app_node: "{{ result.stdout }}"
+
+       - name: Record the node freeze chaos pod on given app node
+         shell: >
+           kubectl get pod -l app=node-freeze -o wide
+           -n {{ app_ns }} | grep {{ app_node }}
+           | awk '{print $1}'
+         args:
+           executable: /bin/bash
+         register: chaos_pod
+
+
+       - block:
+
+           - name: Run docker container to trigger memory freeze on app node
+             shell: >
+                kubectl exec  {{ chaos_pod.stdout }} -n {{ app_ns }}
+                docker run {{ freeze_image }} python memleak.py &
+             args:
+               executable: /bin/bash
+             ignore_errors: true
+
+           - name: Check the node status after memory consumption.
+             shell: kubectl get node {{ app_node }} --no-headers | awk '{print $2}'
+             args:
+               executable: /bin/bash
+             register: node_status
+             until: "'NotReady' in node_status.stdout"
+             delay: 5
+             retries: 120
+
+         when: nodeaction == "memory-freeze"
+
+       - block:
+
+           - name: Run CPU freeze docker container.
+             shell: >
+               kubectl exec {{ chaos_pod.stdout }} -n {{ app_ns }}
+               docker run {{ freeze_image }} &
+             args:
+               executable: /bin/bash
+             ignore_errors: true
+
+         when: nodeaction == "cpu-freeze"
+
+     when: platform == "AWS"
+
+  when: action == "node-chaos"
 
 - block:
-     
+
    - name: Delete node chaos infra
      shell: >
        kubectl delete ds -l app=node-freeze
-       -n {{ namespace }}
+       -n {{ app_ns }}
      args:
        executable: /bin/bash
      register: result
- 
+
    - name: Confirm that the node chaos ds is stopped on all nodes
      shell: >
-       kubectl get pod -l app=node-feeze
-       --no-headers -o custom-columns=:status.phase
-       -n {{ namespace }} | sort | uniq
-     args: 
+        kubectl get pod -l app=node-feeze
+        --no-headers -o custom-columns=:status.phase
+        -n {{ app_ns }} | sort | uniq
+     args:
        executable: /bin/bash
      register: result
      until: "'Running' not in result.stdout"
      delay: 20
-     retries: 15          
+     retries: 15
 
-  when: nodeaction == "node_choas_delete"
+  when: action == "node_chaos_delete" 


### PR DESCRIPTION
Signed-off-by: vibhor995 <vibhor.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
1) Included CPU freeze tasks and Daemonset pod cleanup task into node_freeze chaos.


**Special notes for your reviewer**:
@ksatchit @dargasudarshan @nsathyaseelan 


```ansible-playbook 2.7.5
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./percona/chaos/node_freeze/test.yml

PLAY [localhost] ***************************************************************
2018-12-19T14:09:03.440409 (delta: 0.036099)         elapsed: 0.036099 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /percona/chaos/node_freeze/test.yml:2
2018-12-19T14:09:03.448389 (delta: 0.007953)         elapsed: 0.044079 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/node_freeze/test.yml:11
2018-12-19T14:09:06.445350 (delta: 2.996945)         elapsed: 3.04104 ********* 
included: /common/utils/application_liveness_check.yml for 127.0.0.1

TASK [Get the liveness pods] ***************************************************
task path: /common/utils/application_liveness_check.yml:2
2018-12-19T14:09:06.510909 (delta: 0.065534)         elapsed: 3.106599 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n litmus -l liveness=percona-liveness -o=custom-columns=NAME:\".metadata.name\" --no-headers", "delta": "0:00:00.521368", "end": "2018-12-19 14:09:07.221761", "rc": 0, "start": "2018-12-19 14:09:06.700393", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Checking status of liveness pods] ****************************************
task path: /common/utils/application_liveness_check.yml:6
2018-12-19T14:09:07.256683 (delta: 0.745747)         elapsed: 3.852373 ******** 

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/node_freeze/test.yml:14
2018-12-19T14:09:07.290835 (delta: 0.034122)         elapsed: 3.886525 ******** 
included: /chaoslib/aws_chaos/prerequisites_aws.yml for 127.0.0.1

TASK [Installing pip] **********************************************************
task path: /chaoslib/aws_chaos/prerequisites_aws.yml:2
2018-12-19T14:09:07.351666 (delta: 0.060802)         elapsed: 3.947356 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "apt install python-pip", "delta": "0:00:01.462584", "end": "2018-12-19 14:09:08.913007", "rc": 0, "start": "2018-12-19 14:09:07.450423", "stderr": "\nWARNING: apt does not have a stable CLI interface. Use with caution in scripts.", "stderr_lines": ["", "WARNING: apt does not have a stable CLI interface. Use with caution in scripts."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\npython-pip is already the newest version (9.0.1-2.3~ubuntu1).\n0 upgraded, 0 newly installed, 0 to remove and 3 not upgraded.", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "python-pip is already the newest version (9.0.1-2.3~ubuntu1).", "0 upgraded, 0 newly installed, 0 to remove and 3 not upgraded."]}

TASK [Installing boto] *********************************************************
task path: /chaoslib/aws_chaos/prerequisites_aws.yml:7
2018-12-19T14:09:08.946377 (delta: 1.594684)         elapsed: 5.542067 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "pip install boto", "delta": "0:00:01.810347", "end": "2018-12-19 14:09:10.855599", "rc": 0, "start": "2018-12-19 14:09:09.045252", "stderr": "", "stderr_lines": [], "stdout": "Collecting boto\n  Downloading https://files.pythonhosted.org/packages/23/10/c0b78c27298029e4454a472a1919bde20cb182dab1662cec7f2ca1dcc523/boto-2.49.0-py2.py3-none-any.whl (1.4MB)\nInstalling collected packages: boto\nSuccessfully installed boto-2.49.0", "stdout_lines": ["Collecting boto", "  Downloading https://files.pythonhosted.org/packages/23/10/c0b78c27298029e4454a472a1919bde20cb182dab1662cec7f2ca1dcc523/boto-2.49.0-py2.py3-none-any.whl (1.4MB)", "Installing collected packages: boto", "Successfully installed boto-2.49.0"]}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/node_freeze/test.yml:18
2018-12-19T14:09:10.889050 (delta: 1.942644)         elapsed: 7.48474 ********* 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2018-12-19T14:09:10.952095 (delta: 0.063018)         elapsed: 7.547785 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "ec8713f3d4243414caf23f7d0ad783f65c40dbb8", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "80c7fcbb3870ffe6607ceeba3aa69c15", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1545228550.98-93211845819475/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2018-12-19T14:09:11.364221 (delta: 0.412098)         elapsed: 7.959911 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.305529", "end": "2018-12-19 14:09:11.772593", "rc": 0, "start": "2018-12-19 14:09:11.467064", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-mem-freeze \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-mem-freeze ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2018-12-19T14:09:11.806195 (delta: 0.441945)         elapsed: 8.401885 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.485836", "end": "2018-12-19 14:09:12.395295", "failed_when_result": false, "rc": 0, "start": "2018-12-19 14:09:11.909459", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/node-mem-freeze configured", "stdout_lines": ["litmusresult.litmus.io/node-mem-freeze configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2018-12-19T14:09:12.433254 (delta: 0.627029)         elapsed: 9.028944 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2018-12-19T14:09:12.466317 (delta: 0.033033)         elapsed: 9.062007 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2018-12-19T14:09:12.499410 (delta: 0.033063)         elapsed: 9.0951 ********** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /percona/chaos/node_freeze/test.yml:24
2018-12-19T14:09:12.531672 (delta: 0.032233)         elapsed: 9.127362 ******** 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : app-percona-ns", 
        "Label        : name=percona"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /percona/chaos/node_freeze/test.yml:31
2018-12-19T14:09:12.585807 (delta: 0.054106)         elapsed: 9.181497 ******** 
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /common/utils/status_app_pod.yml:2
2018-12-19T14:09:12.643099 (delta: 0.057263)         elapsed: 9.238789 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.375892", "end": "2018-12-19 14:09:13.132843", "rc": 0, "start": "2018-12-19 14:09:12.756951", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2018-12-19T13:18:30Z]]", "stdout_lines": ["map[running:map[startedAt:2018-12-19T13:18:30Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /common/utils/status_app_pod.yml:13
2018-12-19T14:09:13.171342 (delta: 0.528212)         elapsed: 9.767032 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.392256", "end": "2018-12-19 14:09:13.673656", "rc": 0, "start": "2018-12-19 14:09:13.281400", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /percona/chaos/node_freeze/test.yml:40
2018-12-19T14:09:13.712729 (delta: 0.541358)         elapsed: 10.308419 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.376980", "end": "2018-12-19 14:09:14.197986", "rc": 0, "start": "2018-12-19 14:09:13.821006", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-ndttl", "stdout_lines": ["percona-cb697f8b4-ndttl"]}

TASK [Generate unique string for use in dbname] ********************************
task path: /percona/chaos/node_freeze/test.yml:48
2018-12-19T14:09:14.233133 (delta: 0.520374)         elapsed: 10.828823 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "echo $(mktemp) | cut -d '.' -f 2", "delta": "0:00:00.322491", "end": "2018-12-19 14:09:14.656999", "rc": 0, "start": "2018-12-19 14:09:14.334508", "stderr": "", "stderr_lines": [], "stdout": "DvXHzXpvK6", "stdout_lines": ["DvXHzXpvK6"]}

TASK [Create some test data in the mysql database] *****************************
task path: /percona/chaos/node_freeze/test.yml:54
2018-12-19T14:09:14.692305 (delta: 0.459142)         elapsed: 11.287995 ******* 
included: /common/utils/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /common/utils/mysql_data_persistence.yml:4
2018-12-19T14:09:14.769774 (delta: 0.077432)         elapsed: 11.365464 ******* 
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdbDvXHzXpvK6;') => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-ndttl -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database tdbDvXHzXpvK6;'", "delta": "0:00:00.451240", "end": "2018-12-19 14:09:15.340559", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdbDvXHzXpvK6;'", "rc": 0, "start": "2018-12-19 14:09:14.889319", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdbDvXHzXpvK6) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-ndttl -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdbDvXHzXpvK6", "delta": "0:00:00.566109", "end": "2018-12-19 14:09:16.007870", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdbDvXHzXpvK6", "rc": 0, "start": "2018-12-19 14:09:15.441761", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdbDvXHzXpvK6) => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-ndttl -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdbDvXHzXpvK6", "delta": "0:00:00.533568", "end": "2018-12-19 14:09:16.640928", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdbDvXHzXpvK6", "rc": 0, "start": "2018-12-19 14:09:16.107360", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Checking for the Corrupted tables] ***************************************
task path: /common/utils/mysql_data_persistence.yml:21
2018-12-19T14:09:16.679696 (delta: 1.90989)         elapsed: 13.275386 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /common/utils/mysql_data_persistence.yml:30
2018-12-19T14:09:16.712974 (delta: 0.033249)         elapsed: 13.308664 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /common/utils/mysql_data_persistence.yml:43
2018-12-19T14:09:16.746363 (delta: 0.03336)         elapsed: 13.342053 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /common/utils/mysql_data_persistence.yml:51
2018-12-19T14:09:16.778431 (delta: 0.032039)         elapsed: 13.374121 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/node_freeze/test.yml:67
2018-12-19T14:09:16.810389 (delta: 0.03193)         elapsed: 13.406079 ******** 
included: /chaoslib/chaoskube/node_freeze_chaos.yml for 127.0.0.1

TASK [Setup node freeze infra] *************************************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:6
2018-12-19T14:09:16.890661 (delta: 0.080246)         elapsed: 13.486351 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f node_freeze.yml -n app-percona-ns", "delta": "0:00:00.458518", "end": "2018-12-19 14:09:17.463155", "rc": 0, "start": "2018-12-19 14:09:17.004637", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/node-freeze-q76pk created", "stdout_lines": ["daemonset.extensions/node-freeze-q76pk created"]}

TASK [Confirm that node freeze chaos ds is running on all nodes] ***************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:13
2018-12-19T14:09:17.507392 (delta: 0.616702)         elapsed: 14.103082 ******* 
FAILED - RETRYING: Confirm that node freeze chaos ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=node-freeze --no-headers -o custom-columns=:status.phase -n app-percona-ns | sort | uniq", "delta": "0:00:00.395559", "end": "2018-12-19 14:09:38.522311", "rc": 0, "start": "2018-12-19 14:09:38.126752", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtaining the application pod name using its label.] *********************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:25
2018-12-19T14:09:38.560342 (delta: 21.052917)         elapsed: 35.156032 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona | grep -w Running | awk '{print $1}' | head -1", "delta": "0:00:00.392418", "end": "2018-12-19 14:09:39.065421", "rc": 0, "start": "2018-12-19 14:09:38.673003", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-ndttl", "stdout_lines": ["percona-cb697f8b4-ndttl"]}

TASK [Identify the application node] *******************************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:33
2018-12-19T14:09:39.101027 (delta: 0.540657)         elapsed: 35.696717 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod percona-cb697f8b4-ndttl -n app-percona-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.387812", "end": "2018-12-19 14:09:39.601832", "rc": 0, "start": "2018-12-19 14:09:39.214020", "stderr": "", "stderr_lines": [], "stdout": "ip-10-0-1-149.eu-west-2.compute.internal", "stdout_lines": ["ip-10-0-1-149.eu-west-2.compute.internal"]}

TASK [Record the application node name] ****************************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:41
2018-12-19T14:09:39.637403 (delta: 0.536349)         elapsed: 36.233093 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_node": "ip-10-0-1-149.eu-west-2.compute.internal"}, "changed": false}

TASK [Record the node freeze chaos pod on given app node] **********************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:45
2018-12-19T14:09:39.695762 (delta: 0.05833)         elapsed: 36.291452 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l app=node-freeze -o wide -n app-percona-ns | grep ip-10-0-1-149.eu-west-2.compute.internal | awk '{print $1}'", "delta": "0:00:00.392839", "end": "2018-12-19 14:09:40.199488", "rc": 0, "start": "2018-12-19 14:09:39.806649", "stderr": "", "stderr_lines": [], "stdout": "node-freeze-q76pk-jdv2s", "stdout_lines": ["node-freeze-q76pk-jdv2s"]}

TASK [Run docker container to trigger memory freeze on app node] ***************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:57
2018-12-19T14:09:40.234581 (delta: 0.538791)         elapsed: 36.830271 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the node status after memory consumption.] *************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:65
2018-12-19T14:09:40.275824 (delta: 0.041213)         elapsed: 36.871514 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Run CPU freeze docker container.] ****************************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:78
2018-12-19T14:09:40.316955 (delta: 0.041103)         elapsed: 36.912645 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec node-freeze-q76pk-jdv2s -n app-percona-ns docker run mittachaitu/forkbomb:latest &", "delta": "0:00:01.317794", "end": "2018-12-19 14:09:41.751012", "rc": 0, "start": "2018-12-19 14:09:40.433218", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Delete node chaos infra] *************************************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:94
2018-12-19T14:09:41.785576 (delta: 1.468589)         elapsed: 38.381266 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that the node chaos ds is stopped on all nodes] ******************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:102
2018-12-19T14:09:41.818815 (delta: 0.033194)         elapsed: 38.414505 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [wait for app pod to reschedule] ******************************************
task path: /percona/chaos/node_freeze/test.yml:74
2018-12-19T14:09:41.851866 (delta: 0.033022)         elapsed: 38.447556 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 400", "delta": "0:06:40.317544", "end": "2018-12-19 14:16:22.272698", "rc": 0, "start": "2018-12-19 14:09:41.955154", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /percona/chaos/node_freeze/test.yml:80
2018-12-19T14:16:22.306677 (delta: 400.454784)         elapsed: 438.902367 **** 
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /common/utils/status_app_pod.yml:2
2018-12-19T14:16:22.366428 (delta: 0.059721)         elapsed: 438.962118 ****** 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
FAILED - RETRYING: Get the container status of application. (144 retries left).
FAILED - RETRYING: Get the container status of application. (143 retries left).
FAILED - RETRYING: Get the container status of application. (142 retries left).
FAILED - RETRYING: Get the container status of application. (141 retries left).
FAILED - RETRYING: Get the container status of application. (140 retries left).
FAILED - RETRYING: Get the container status of application. (139 retries left).
FAILED - RETRYING: Get the container status of application. (138 retries left).
FAILED - RETRYING: Get the container status of application. (137 retries left).
FAILED - RETRYING: Get the container status of application. (136 retries left).
FAILED - RETRYING: Get the container status of application. (135 retries left).
FAILED - RETRYING: Get the container status of application. (134 retries left).
FAILED - RETRYING: Get the container status of application. (133 retries left).
FAILED - RETRYING: Get the container status of application. (132 retries left).
FAILED - RETRYING: Get the container status of application. (131 retries left).
FAILED - RETRYING: Get the container status of application. (130 retries left).
FAILED - RETRYING: Get the container status of application. (129 retries left).
FAILED - RETRYING: Get the container status of application. (128 retries left).
FAILED - RETRYING: Get the container status of application. (127 retries left).
FAILED - RETRYING: Get the container status of application. (126 retries left).
FAILED - RETRYING: Get the container status of application. (125 retries left).
FAILED - RETRYING: Get the container status of application. (124 retries left).
FAILED - RETRYING: Get the container status of application. (123 retries left).
FAILED - RETRYING: Get the container status of application. (122 retries left).
FAILED - RETRYING: Get the container status of application. (121 retries left).
FAILED - RETRYING: Get the container status of application. (120 retries left).
FAILED - RETRYING: Get the container status of application. (119 retries left).
FAILED - RETRYING: Get the container status of application. (118 retries left).
FAILED - RETRYING: Get the container status of application. (117 retries left).
FAILED - RETRYING: Get the container status of application. (116 retries left).
FAILED - RETRYING: Get the container status of application. (115 retries left).
FAILED - RETRYING: Get the container status of application. (114 retries left).
FAILED - RETRYING: Get the container status of application. (113 retries left).
FAILED - RETRYING: Get the container status of application. (112 retries left).
FAILED - RETRYING: Get the container status of application. (111 retries left).
FAILED - RETRYING: Get the container status of application. (110 retries left).
FAILED - RETRYING: Get the container status of application. (109 retries left).
FAILED - RETRYING: Get the container status of application. (108 retries left).
FAILED - RETRYING: Get the container status of application. (107 retries left).
FAILED - RETRYING: Get the container status of application. (106 retries left).
FAILED - RETRYING: Get the container status of application. (105 retries left).
FAILED - RETRYING: Get the container status of application. (104 retries left).
FAILED - RETRYING: Get the container status of application. (103 retries left).
FAILED - RETRYING: Get the container status of application. (102 retries left).
FAILED - RETRYING: Get the container status of application. (101 retries left).
FAILED - RETRYING: Get the container status of application. (100 retries left).
FAILED - RETRYING: Get the container status of application. (99 retries left).
FAILED - RETRYING: Get the container status of application. (98 retries left).
FAILED - RETRYING: Get the container status of application. (97 retries left).
FAILED - RETRYING: Get the container status of application. (96 retries left).
FAILED - RETRYING: Get the container status of application. (95 retries left).
FAILED - RETRYING: Get the container status of application. (94 retries left).
FAILED - RETRYING: Get the container status of application. (93 retries left).
FAILED - RETRYING: Get the container status of application. (92 retries left).
FAILED - RETRYING: Get the container status of application. (91 retries left).
FAILED - RETRYING: Get the container status of application. (90 retries left).
FAILED - RETRYING: Get the container status of application. (89 retries left).
FAILED - RETRYING: Get the container status of application. (88 retries left).
FAILED - RETRYING: Get the container status of application. (87 retries left).
FAILED - RETRYING: Get the container status of application. (86 retries left).
FAILED - RETRYING: Get the container status of application. (85 retries left).
FAILED - RETRYING: Get the container status of application. (84 retries left).
FAILED - RETRYING: Get the container status of application. (83 retries left).
FAILED - RETRYING: Get the container status of application. (82 retries left).
FAILED - RETRYING: Get the container status of application. (81 retries left).
FAILED - RETRYING: Get the container status of application. (80 retries left).
FAILED - RETRYING: Get the container status of application. (79 retries left).
FAILED - RETRYING: Get the container status of application. (78 retries left).
FAILED - RETRYING: Get the container status of application. (77 retries left).
FAILED - RETRYING: Get the container status of application. (76 retries left).
FAILED - RETRYING: Get the container status of application. (75 retries left).
FAILED - RETRYING: Get the container status of application. (74 retries left).
FAILED - RETRYING: Get the container status of application. (73 retries left).
FAILED - RETRYING: Get the container status of application. (72 retries left).
FAILED - RETRYING: Get the container status of application. (71 retries left).
FAILED - RETRYING: Get the container status of application. (70 retries left).
FAILED - RETRYING: Get the container status of application. (69 retries left).
FAILED - RETRYING: Get the container status of application. (68 retries left).
FAILED - RETRYING: Get the container status of application. (67 retries left).
FAILED - RETRYING: Get the container status of application. (66 retries left).
FAILED - RETRYING: Get the container status of application. (65 retries left).
FAILED - RETRYING: Get the container status of application. (64 retries left).
FAILED - RETRYING: Get the container status of application. (63 retries left).
FAILED - RETRYING: Get the container status of application. (62 retries left).
FAILED - RETRYING: Get the container status of application. (61 retries left).
FAILED - RETRYING: Get the container status of application. (60 retries left).
FAILED - RETRYING: Get the container status of application. (59 retries left).
FAILED - RETRYING: Get the container status of application. (58 retries left).
FAILED - RETRYING: Get the container status of application. (57 retries left).
FAILED - RETRYING: Get the container status of application. (56 retries left).
FAILED - RETRYING: Get the container status of application. (55 retries left).
FAILED - RETRYING: Get the container status of application. (54 retries left).
FAILED - RETRYING: Get the container status of application. (53 retries left).
FAILED - RETRYING: Get the container status of application. (52 retries left).
FAILED - RETRYING: Get the container status of application. (51 retries left).
FAILED - RETRYING: Get the container status of application. (50 retries left).
FAILED - RETRYING: Get the container status of application. (49 retries left).
FAILED - RETRYING: Get the container status of application. (48 retries left).
FAILED - RETRYING: Get the container status of application. (47 retries left).
FAILED - RETRYING: Get the container status of application. (46 retries left).
FAILED - RETRYING: Get the container status of application. (45 retries left).
FAILED - RETRYING: Get the container status of application. (44 retries left).
FAILED - RETRYING: Get the container status of application. (43 retries left).
FAILED - RETRYING: Get the container status of application. (42 retries left).
FAILED - RETRYING: Get the container status of application. (41 retries left).
FAILED - RETRYING: Get the container status of application. (40 retries left).
FAILED - RETRYING: Get the container status of application. (39 retries left).
FAILED - RETRYING: Get the container status of application. (38 retries left).
FAILED - RETRYING: Get the container status of application. (37 retries left).
FAILED - RETRYING: Get the container status of application. (36 retries left).
FAILED - RETRYING: Get the container status of application. (35 retries left).
FAILED - RETRYING: Get the container status of application. (34 retries left).
FAILED - RETRYING: Get the container status of application. (33 retries left).
FAILED - RETRYING: Get the container status of application. (32 retries left).
FAILED - RETRYING: Get the container status of application. (31 retries left).
FAILED - RETRYING: Get the container status of application. (30 retries left).
FAILED - RETRYING: Get the container status of application. (29 retries left).
FAILED - RETRYING: Get the container status of application. (28 retries left).
FAILED - RETRYING: Get the container status of application. (27 retries left).
FAILED - RETRYING: Get the container status of application. (26 retries left).
FAILED - RETRYING: Get the container status of application. (25 retries left).
FAILED - RETRYING: Get the container status of application. (24 retries left).
FAILED - RETRYING: Get the container status of application. (23 retries left).
FAILED - RETRYING: Get the container status of application. (22 retries left).
FAILED - RETRYING: Get the container status of application. (21 retries left).
FAILED - RETRYING: Get the container status of application. (20 retries left).
FAILED - RETRYING: Get the container status of application. (19 retries left).
FAILED - RETRYING: Get the container status of application. (18 retries left).
FAILED - RETRYING: Get the container status of application. (17 retries left).
FAILED - RETRYING: Get the container status of application. (16 retries left).
FAILED - RETRYING: Get the container status of application. (15 retries left).
FAILED - RETRYING: Get the container status of application. (14 retries left).
FAILED - RETRYING: Get the container status of application. (13 retries left).
FAILED - RETRYING: Get the container status of application. (12 retries left).
FAILED - RETRYING: Get the container status of application. (11 retries left).
FAILED - RETRYING: Get the container status of application. (10 retries left).
FAILED - RETRYING: Get the container status of application. (9 retries left).
FAILED - RETRYING: Get the container status of application. (8 retries left).
FAILED - RETRYING: Get the container status of application. (7 retries left).
FAILED - RETRYING: Get the container status of application. (6 retries left).
FAILED - RETRYING: Get the container status of application. (5 retries left).
FAILED - RETRYING: Get the container status of application. (4 retries left).
FAILED - RETRYING: Get the container status of application. (3 retries left).
FAILED - RETRYING: Get the container status of application. (2 retries left).
FAILED - RETRYING: Get the container status of application. (1 retries left).
fatal: [127.0.0.1]: FAILED! => {"attempts": 150, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.390495", "end": "2018-12-19 14:22:34.589368", "msg": "non-zero return code", "rc": 1, "start": "2018-12-19 14:22:34.198873", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
task path: /percona/chaos/node_freeze/test.yml:115
2018-12-19T14:22:34.626942 (delta: 372.260485)         elapsed: 811.222632 **** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Fail"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/node_freeze/test.yml:123
2018-12-19T14:22:34.674152 (delta: 0.047183)         elapsed: 811.269842 ****** 
included: /common/utils/aws/fetch_aws_details.yml for 127.0.0.1

TASK [Get the AWS instance Id of Instance] *************************************
task path: /common/utils/aws/fetch_aws_details.yml:3
2018-12-19T14:22:34.726778 (delta: 0.052597)         elapsed: 811.322468 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get node ip-10-0-1-149.eu-west-2.compute.internal -o jsonpath={.spec.providerID} | cut -d '/' -f 5", "delta": "0:00:00.388039", "end": "2018-12-19 14:22:35.218746", "rc": 0, "start": "2018-12-19 14:22:34.830707", "stderr": "", "stderr_lines": [], "stdout": "i-034eaf1d28a382008", "stdout_lines": ["i-034eaf1d28a382008"]}

TASK [Get region from app node] ************************************************
task path: /common/utils/aws/fetch_aws_details.yml:9
2018-12-19T14:22:35.254253 (delta: 0.527447)         elapsed: 811.849943 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get nodes ip-10-0-1-149.eu-west-2.compute.internal -o jsonpath='{.metadata.labels.failure-domain\\.beta\\.kubernetes\\.io\\/region}'", "delta": "0:00:00.392383", "end": "2018-12-19 14:22:35.750156", "rc": 0, "start": "2018-12-19 14:22:35.357773", "stderr": "", "stderr_lines": [], "stdout": "eu-west-2", "stdout_lines": ["eu-west-2"]}

TASK [set_fact] ****************************************************************
task path: /common/utils/aws/fetch_aws_details.yml:16
2018-12-19T14:22:35.785739 (delta: 0.531458)         elapsed: 812.381429 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"instance_id": "i-034eaf1d28a382008", "region": "eu-west-2"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/node_freeze/test.yml:128
2018-12-19T14:22:35.836355 (delta: 0.050587)         elapsed: 812.432045 ****** 
included: /chaoslib/aws_chaos/chaosutil_aws.yml for 127.0.0.1

TASK [Performing action on AWS ec2 instances] **********************************
task path: /chaoslib/aws_chaos/chaosutil_aws.yml:2
2018-12-19T14:22:35.888350 (delta: 0.051967)         elapsed: 812.48404 ******* 
changed: [127.0.0.1] => {"changed": true, "instance_ids": ["i-034eaf1d28a382008"], "instances": [{"ami_launch_index": "2", "architecture": "x86_64", "block_device_mapping": {"/dev/sda1": {"delete_on_termination": true, "status": "attached", "volume_id": "vol-0b1460c8e06f06a8f"}}, "dns_name": "ec2-35-178-250-161.eu-west-2.compute.amazonaws.com", "ebs_optimized": false, "groups": {"sg-0eedac2f5d14cb1ba": "nodes.k8s-vibhor-test.k8s.local"}, "hypervisor": "xen", "id": "i-034eaf1d28a382008", "image_id": "ami-6b3fd60c", "instance_type": "t2.xlarge", "kernel": null, "key_name": "kubernetes.k8s-vibhor-test.k8s.local-a5:d9:f7:5a:9d:80:8d:f8:60:df:73:cd:18:1d:61:c8", "launch_time": "2018-12-19T06:25:16.000Z", "placement": "eu-west-2a", "private_dns_name": "ip-10-0-1-149.eu-west-2.compute.internal", "private_ip": "10.0.1.149", "public_dns_name": "ec2-35-178-250-161.eu-west-2.compute.amazonaws.com", "public_ip": "35.178.250.161", "ramdisk": null, "region": "eu-west-2", "root_device_name": "/dev/sda1", "root_device_type": "ebs", "state": "running", "state_code": 16, "tags": {"KubernetesCluster": "k8s-vibhor-test.k8s.local", "Name": "nodes.k8s-vibhor-test.k8s.local", "aws:autoscaling:groupName": "nodes.k8s-vibhor-test.k8s.local", "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup": "nodes", "k8s.io/role/node": "1"}, "tenancy": "default", "virtualization_type": "hvm"}], "tagged_instances": []}

TASK [wait after node restarted.] **********************************************
task path: /percona/chaos/node_freeze/test.yml:132
2018-12-19T14:22:46.694636 (delta: 10.806256)         elapsed: 823.290326 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "sleep 300", "delta": "0:05:00.301384", "end": "2018-12-19 14:27:47.098383", "rc": 0, "start": "2018-12-19 14:22:46.796999", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Check the node status after node restarted.] *****************************
task path: /percona/chaos/node_freeze/test.yml:138
2018-12-19T14:27:47.133180 (delta: 300.438512)         elapsed: 1123.72887 **** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get node ip-10-0-1-149.eu-west-2.compute.internal --no-headers | awk '{print $2}'", "delta": "0:00:00.392262", "end": "2018-12-19 14:27:47.627697", "rc": 0, "start": "2018-12-19 14:27:47.235435", "stderr": "", "stderr_lines": [], "stdout": "Ready", "stdout_lines": ["Ready"]}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/node_freeze/test.yml:147
2018-12-19T14:27:47.665727 (delta: 0.532518)         elapsed: 1124.261417 ***** 
included: /chaoslib/chaoskube/node_freeze_chaos.yml for 127.0.0.1

TASK [Setup node freeze infra] *************************************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:6
2018-12-19T14:27:47.728376 (delta: 0.06262)         elapsed: 1124.324066 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm that node freeze chaos ds is running on all nodes] ***************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:13
2018-12-19T14:27:47.762642 (delta: 0.034239)         elapsed: 1124.358332 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtaining the application pod name using its label.] *********************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:25
2018-12-19T14:27:47.795846 (delta: 0.033179)         elapsed: 1124.391536 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the application node] *******************************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:33
2018-12-19T14:27:47.829013 (delta: 0.03314)         elapsed: 1124.424703 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the application node name] ****************************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:41
2018-12-19T14:27:47.861947 (delta: 0.032908)         elapsed: 1124.457637 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the node freeze chaos pod on given app node] **********************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:45
2018-12-19T14:27:47.893805 (delta: 0.031832)         elapsed: 1124.489495 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Run docker container to trigger memory freeze on app node] ***************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:57
2018-12-19T14:27:47.926800 (delta: 0.03297)         elapsed: 1124.52249 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the node status after memory consumption.] *************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:65
2018-12-19T14:27:47.958636 (delta: 0.03181)         elapsed: 1124.554326 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Run CPU freeze docker container.] ****************************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:78
2018-12-19T14:27:47.991692 (delta: 0.033031)         elapsed: 1124.587382 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete node chaos infra] *************************************************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:94
2018-12-19T14:27:48.023620 (delta: 0.031903)         elapsed: 1124.61931 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete ds -l app=node-freeze -n app-percona-ns", "delta": "0:00:00.394747", "end": "2018-12-19 14:27:48.528906", "rc": 0, "start": "2018-12-19 14:27:48.134159", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"node-freeze-q76pk\" deleted", "stdout_lines": ["daemonset.extensions \"node-freeze-q76pk\" deleted"]}

TASK [Confirm that the node chaos ds is stopped on all nodes] ******************
task path: /chaoslib/chaoskube/node_freeze_chaos.yml:102
2018-12-19T14:27:48.569864 (delta: 0.546218)         elapsed: 1125.165554 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -l app=node-feeze --no-headers -o custom-columns=:status.phase -n app-percona-ns | sort | uniq", "delta": "0:00:00.376150", "end": "2018-12-19 14:27:49.056515", "rc": 0, "start": "2018-12-19 14:27:48.680365", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/node_freeze/test.yml:153
2018-12-19T14:27:49.094638 (delta: 0.524743)         elapsed: 1125.690328 ***** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2018-12-19T14:27:49.160674 (delta: 0.066007)         elapsed: 1125.756364 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2018-12-19T14:27:49.192620 (delta: 0.031917)         elapsed: 1125.78831 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2018-12-19T14:27:49.228095 (delta: 0.035447)         elapsed: 1125.823785 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2018-12-19T14:27:49.261311 (delta: 0.033189)         elapsed: 1125.857001 ***** 
changed: [127.0.0.1] => {"changed": true, "checksum": "0924af2b339d11612e8037e8802c082a0867c97c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0b035b4e0585dd362318d5d14821dc6d", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1545229669.29-222478648899690/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2018-12-19T14:27:50.106077 (delta: 0.84474)         elapsed: 1126.701767 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.303596", "end": "2018-12-19 14:27:50.513181", "rc": 0, "start": "2018-12-19 14:27:50.209585", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: node-mem-freeze \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Fail ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: node-mem-freeze ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Fail "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2018-12-19T14:27:50.547018 (delta: 0.440913)         elapsed: 1127.142708 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.447641", "end": "2018-12-19 14:27:51.127926", "failed_when_result": false, "rc": 0, "start": "2018-12-19 14:27:50.680285", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/node-mem-freeze configured", "stdout_lines": ["litmusresult.litmus.io/node-mem-freeze configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=44   changed=28   unreachable=0    failed=1   

2018-12-19T14:27:51.149431 (delta: 0.602385)         elapsed: 1127.745121 ***** 
=============================================================================== 
