### PR TITLE
(Functionality) Fill the volume capacity upto 97% to check the behaviour of application.

### DIFF
--- a/apps/fio/tests/data-integrity/commands.sh
+++ b/apps/fio/tests/data-integrity/commands.sh
@@ -1,0 +1,39 @@
+cd datadir
+error_check()
+{
+	if [ $? != 0 ]
+	then
+		echo "error caught"
+		exit 1
+	fi
+}
+
+perform_data_write()
+{
+        value=space_left
+	i=0
+	while [ $i -le $value ]
+	do
+		ls -all
+		error_check
+		touch file$i
+		error_check
+		dd if=/dev/urandom of=file$i bs=4k count=5000
+		error_check
+		sync
+		read_data
+		i=$(( i + 1 ))
+		error_check
+	done
+}
+read_data()
+{
+	touch testfile
+	error_check
+	echo "OpenEBS Released newer version"
+	error_check
+	cat testfile
+	error_check
+	rm testfile
+}
+perform_data_write

--- a/apps/fio/tests/data-integrity/fio-read.yml
+++ b/apps/fio/tests/data-integrity/fio-read.yml
@@ -31,15 +31,19 @@ spec:
       restartPolicy: Never
       containers:
       - name: perfrunner
-        image: openebs/tests-fio
+        image: openebs/tests-fio:latest
+        imagePullPolicy: Always
         command: ["/bin/bash"]
-        args: ["-c", "./fio_runner.sh --size 128m; exit 0"]
+        args: ["-c", "./fio_runner.sh --size 256m; df -h;cat commands.sh > cp_commands.sh; chmod 775 cp_commands.sh; ./cp_commands.sh; df -h;exit 0"]
         volumeMounts:
            - mountPath: /datadir
              name: demo-vol1
            - mountPath: templates/file/basic-rw
              subPath: basic-rw
              name: basic-configmap-read
+           - mountPath: /commands.sh
+             subPath: commands.sh
+             name: commandconfig
         tty: true
 
       volumes:
@@ -49,3 +53,6 @@ spec:
       - name: basic-configmap-read
         configMap:
           name: basic-read
+      - name: commandconfig
+        configMap:
+          name: commandfile

--- a/apps/fio/tests/data-integrity/fio-write.yml
+++ b/apps/fio/tests/data-integrity/fio-write.yml
@@ -11,7 +11,7 @@ data:
      directory=/datadir
 
      [basic-fio]
-     rw=write
+     rw=randwrite
      bs=4k
      time_based=1
      runtime=60
@@ -33,9 +33,10 @@ spec:
       restartPolicy: Never
       containers:
       - name: perfrunner
-        image: openebs/tests-fio
+        image: openebs/tests-fio:latest
+        imagePullPolicy: Always
         command: ["/bin/bash"]
-        args: ["-c", "./fio_runner.sh --size 256m; exit 0"]
+        args: ["-c", "./fio_runner.sh --size 256m; sync;exit 0"]
         volumeMounts:
            - mountPath: /datadir
              name: demo-vol1
@@ -51,15 +52,3 @@ spec:
       - name: basic-configmap
         configMap:
           name: basic
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: demo-vol1-claim
-spec:
-  storageClassName: testclass
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: "5G"

--- a/apps/fio/tests/data-integrity/pvc.yml
+++ b/apps/fio/tests/data-integrity/pvc.yml
@@ -1,0 +1,12 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1-claim
+spec:
+  storageClassName: openebs-cstor-sparse
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "5G"

--- a/apps/fio/tests/data-integrity/run_litmus_test.yml
+++ b/apps/fio/tests/data-integrity/run_litmus_test.yml
@@ -31,6 +31,9 @@ spec:
  
           - name: FIO_TESTRUN_PERIOD
             value: "60"
+
+          - name: DATA_CHECK
+            value: "data_accessibility"
  
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./fio/tests/data-integrity/test.yml -i /etc/ansible/hosts -v; exit 0"]
@@ -54,18 +57,18 @@ spec:
             value: /mnt/fio
         command: ["/bin/bash"]
         args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,fio; exit 0"]
-        volumeMounts:
+       volumeMounts:
           - name: kubeconfig
             mountPath: /root/admin.conf
             subPath: admin.conf
-          - name: logs
-            mountPath: /mnt
-        tty: true
-      volumes:
+         - name: logs
+           mountPath: /mnt
+       tty: true
+     volumes:
         - name: kubeconfig
           configMap:
             name: kubeconfig
-        - name: logs
-          hostPath:
-            path: /mnt/fio
-            type: ""
+       - name: logs
+         hostPath:
+           path: /mnt/fio
+           type: ""

--- a/apps/fio/tests/data-integrity/test.yml
+++ b/apps/fio/tests/data-integrity/test.yml
@@ -57,11 +57,78 @@
          delay: 30
          retries: 10
 
+       - name: Deploy PVC to get size of volume requested application namespace
+         shell: kubectl apply -f {{ pvc_yml }} -n {{ app_ns }}
+         args:
+           executable: /bin/bash
+
+       - include_tasks: /common/utils/disable_compression_on_pools.yml
+         when: data_check == 'data_accessibility'
+
        - name: Replace the data sample size with user-defined size
          replace:
            path: "{{ fio_write_yml }}"
            regexp: "256m"
            replace: "{{ lookup('env','FIO_SAMPLE_SIZE') }}"
+         when: data_check == 'data_integrity'
+
+       - block:
+
+           - name: Fetch the Storage from PVC using namespace(need to modify)
+             shell: kubectl get pvc -n {{ app_ns }} -o jsonpath={.items[0].spec.resources.requests.storage}
+             args:
+               executable: /bin/bash
+             register: storage_capacity
+
+           - name: Fetch the alphabet(G,M,m,g) from storage capacity
+             shell: echo "{{ storage_capacity.stdout }}" | grep -o -E '[A-Za-z]+'
+             args:
+               executable: /bin/bash
+             register: symbol
+
+           - name: Fetch the alphabet(G,M,m,g) from storage capacity
+             shell: echo "{{ storage_capacity.stdout }}" | grep -o -E '[0-9]+'
+             args:
+               executable: /bin/bash
+             register: value_str
+
+           - set_fact:
+               value_num: '{{ ( (value_str.stdout | int - 0.2) * 0.93 * 1024) |  int }}'
+             when: "'G' in symbol.stdout"
+
+           - set_fact:
+               value_num: '{{ ((value_str.stdout | int - 0.2) * 0.93 * 1024 * 1024) | int }}'
+             when: "'T' in symbol.stdout"
+
+           - name: Replace the data sample size with 90% of pvc size in {{ fio_write_yml }}
+             replace:
+               path: "{{ fio_write_yml }}"
+               regexp: "256m"
+               replace: "{{ value_num }}m"
+             when: "'G' in symbol.stdout or 'T' in symbol.stdout"
+
+           - name: Replace the data sample size with 90% 0f pvc size in {{ fio_read_yml }}
+             replace:
+               path: "{{ fio_read_yml }}"
+               regexp: "256m"
+               replace: "{{ value_num }}m"
+             when: "'G' in symbol.stdout or 'T' in symbol.stdout"
+
+           - name: Replace the data sample size with 90% of pvc size in {{ fio_write_yml }}
+             replace:
+               path: "{{ fio_write_yml }}"
+               regexp: "256m"
+               replace: "{{ storage_capacity.stdout }}"
+             when: "'M' in symbol.stdout"
+
+           - name: Replace the data sample size with 90% of pvc size in {{ fio_read_yml }}
+             replace:
+               path: "{{ fio_read_yml }}"
+               regexp: "256m"
+               replace: "{{ storage_capacity.stdout }}"
+             when: "'M' in symbol.stdout"
+
+         when: data_check == 'data_accessibility'
 
        - name: Replace the default I/O test duration with user-defined period
          replace:
@@ -76,12 +143,60 @@
          args:
            executable: /bin/bash
 
-       - name: Confirm fio pod status is running
+       - name: Fetch the pod name in {{ app_ns }}
          shell: >
            kubectl get pods -n {{ app_ns }} -l name=fio-write -o custom-columns=:metadata.name --no-headers
          args:
            executable: /bin/bash
          register: fio_pod_name
+
+       - name: Check the status of pod
+         shell: kubectl get po {{ fio_pod_name.stdout }} -n {{ app_ns }} -o jsonpath={.status.phase}
+         args:
+           executable: /bin/bash
+         register: status_fio_pod
+         until: "'Running' in status_fio_pod.stdout"
+         delay: 5
+         retries: 100
+
+       - block:
+
+           - name: Fetch the remaining space from application side
+             shell: kubectl exec {{ fio_pod_name.stdout }} -n {{ app_ns }} df /datadir | awk 'NR==2 {print $4}'
+             args:
+               executable: /bin/bash
+             register: space_left
+
+            ## Convert GB into Mb
+           - set_fact:
+               space_left_mb: '{{ (space_left.stdout| int / 20480) | round | int }}'
+
+           - set_fact:
+               fill_value: '{{ space_left_mb | int - 5 }}'
+             when: space_left_mb > 10
+
+           - name: Replace the space_left in commands.sh file with calculated value
+             replace:
+               path: "commands.sh"
+               regexp: "space_left"
+               replace: "{{ fill_value }}"
+             when: fill_value is defined
+
+           - name: Replace the space_left in commands.sh file with calculated value
+             replace:
+               path: "commands.sh"
+               regexp: "space_left"
+               replace: "{{ space_left_mb }}"
+             when: fill_value is not defined
+
+         when: data_check == 'data_accessibility'
+
+       - name: Replace the space_left in commands.sh file with calculated value
+         replace:
+           path: "commands.sh"
+           regexp: "space_left"
+           replace: "0"
+         when: data_check == 'data_accessibility'
 
        - name: Check if fio write job is completed
          shell: >
@@ -91,7 +206,7 @@
          register: result_fio_pod
          until: "'Completed' in result_fio_pod.stdout"
          delay: 60
-         retries: 10
+         retries: 900
 
        - name: Verify the fio logs to check if run is complete w/o errors
          shell: >
@@ -108,12 +223,30 @@
            path: "{{ fio_read_yml }}"
            regexp: "256m"
            replace: "{{ lookup('env','FIO_SAMPLE_SIZE') }}"
+         when: data_check == 'data_integrity'
 
        - name: Replace the default I/O test duration with user-defined period
          replace:
            path: "{{ fio_read_yml }}"
            regexp: "60"
            replace: "{{ lookup('env','FIO_TESTRUN_PERIOD') }}"
+
+       - name: Checking for configmap
+         shell: kubectl get configmap -n {{ app_ns }}
+         register: configmap
+
+       - name: Create the configmap
+         shell: kubectl create cm commandfile --from-file=commands.sh -n {{ app_ns }}
+         args:
+           executable: /bin/bash
+         when: "'commandfile' not in configmap.stdout"
+
+       - name: Verify Successfull creation of configmap
+         shell: kubectl describe cm commandfile -n {{ app_ns }}
+         register: config
+         until: "'commandfile' in config.stdout"
+         delay: 5
+         retries: 20
 
        - name: Deploy fio read test job
          shell: kubectl apply -f {{ fio_read_yml }} -n {{ app_ns }}
@@ -146,6 +279,13 @@
            executable: /bin/bash
          register: result_di
          failed_when: result_di.stdout != " 0,"
+#         ignore-errors: true
+
+       - name: Check for error while writing
+         shell: >
+           kubectl get logs {{ read_pod.stdout }} -n {{ app_ns }} | grep 'error caught' | wc -l
+         register: final_result
+         failed_when: final_result.stdout > 0
 
        - set_fact:
            flag: "Pass"

--- a/apps/fio/tests/data-integrity/test_vars.yml
+++ b/apps/fio/tests/data-integrity/test_vars.yml
@@ -5,3 +5,6 @@ test_name: fio-data-integrity
 fio_write_yml: fio-write.yml
 fio_read_yml: fio-read.yml
 app_ns: "{{ lookup('env','FIO_NAMESPACE') }}"
+data_check: "{{ lookup('env','DATA_CHECK') }}"
+pvc_yml: pvc.yml
+operator_ns: "openebs"

--- a/common/utils/disable_compression_on_pools.yml
+++ b/common/utils/disable_compression_on_pools.yml
@@ -1,0 +1,86 @@
+---
+- name: Wait for 15s for target pod to deploy
+  wait_for:
+    timeout: 15
+
+- name: Get the pv name from application namespace
+  shell: >
+    kubectl get pvc -n fio -o jsonpath={.items[0].spec.volumeName}
+  register: pv
+
+- name: Get the target name associated to PVC
+  shell: >
+    kubectl get po -n openebs --no-headers | grep {{ pv.stdout }} | awk '{ print $1 }'
+  register: target_pod
+
+- name: Check the status of the target pod
+  shell: kubectl get pod {{ target_pod.stdout }} -n {{ operator_ns }} -o jsonpath={.status.phase}
+  register: result_target_pod
+  until: "'Running' in result_target_pod.stdout"
+  delay: 3
+  retries: 30
+
+- name: Get list of pool deployments from cvr
+  shell: >
+    kubectl get cvr -n {{ operator_ns }}
+    -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
+    -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}'
+    | awk '{print $1}'
+  args:
+    executable: /bin/bash
+  register: pool_deployment_list
+
+- name: Obtaining the replicasets corresponding to pool deployements.
+  shell: >
+    kubectl get rs -l app=cstor-pool -n {{ operator_ns }} --no-headers
+    -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item}}")].metadata.name}'
+  register: rs_list
+  with_items:
+    - "{{ pool_deployment_list.stdout_lines }}"
+
+- name: Obtaining the pool pods
+  shell: >
+    kubectl get pod -l app=cstor-pool -n {{ operator_ns }} --no-headers
+    -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item.stdout}}")].metadata.name}'
+  register: pool_pod_list
+  with_items:
+    - "{{ rs_list.results }}"
+
+- set_fact:
+    #pool_pod_length: "{{ pool_pod_list.results | length }}"
+    pool_pod_named_list: "{{ pool_pod_named_list|default([])}}"
+
+- name: Build a list of replica pods
+  set_fact:
+    pool_pod_named_list : "{{ pool_pod_named_list  }} + [ '{{ item.stdout }}' ]"
+  with_items: "{{ pool_pod_list.results }}"
+
+- name: Get pool name from first pool pod
+  shell: >
+    kubectl exec {{ item }} -n {{ operator_ns }} -c cstor-pool zpool list | awk 'NR==2 {print $1}'
+  args:
+    executable: /bin/bash
+  register: pool_name
+  with_items:
+    - "{{ pool_pod_named_list }}"
+
+- set_fact:
+    pool_names_list: "{{ pool_names_list|default([])}}"
+
+- name: Build a list of replica pods
+  set_fact:
+    pool_names_list : "{{ pool_names_list  }} + [ '{{ item.stdout }}' ]"
+  with_items: "{{ pool_name.results }}"
+
+- debug:
+    msg: "{{ item }} are pool name"
+  with_items: "{{ pool_names_list }}"
+
+- name: Disable compression factor on pool/volumes
+  shell: >
+    kubectl exec {{ item.0 }} -n {{ operator_ns }} -c cstor-pool zfs set compression=off {{ item.1 }}/{{ pv.stdout }}
+  args:
+    executable: /bin/bash
+  with_together:
+    - "{{ pool_pod_named_list }}"
+    - "{{ pool_names_list }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
1) This litmusbook is capable of filling the ~97% of volume by setting DATA_CHECK env to data_accessibility.
2) Include a util which will disable the compression at zfs side.
3) Using fio read job verfies written data and also performs RW operations after filling 95% of volume capacity.

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
**Logs:**
```
 kubectl logs -f litmus-di-fio-pdgv7-lq4mf -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2018-12-18T04:52:32.340796 (delta: 0.03544)         elapsed: 0.03544 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2018-12-18T04:52:32.349498 (delta: 0.008676)         elapsed: 0.044142 ******** 
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
2018-12-18T04:52:35.153652 (delta: 2.804135)         elapsed: 2.848296 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2018-12-18T04:52:35.191053 (delta: 0.037374)         elapsed: 2.885697 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2018-12-18T04:52:35.228155 (delta: 0.037073)         elapsed: 2.922799 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2018-12-18T04:52:35.292585 (delta: 0.0644)         elapsed: 2.987229 ********** 
changed: [127.0.0.1] => {"changed": true, "checksum": "146d56191547cf1ef37fc24f1c32123c685a3ba2", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "1858ec125d0913cc89507969a9190901", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1545108755.32-80234398630570/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2018-12-18T04:52:35.689025 (delta: 0.396407)         elapsed: 3.383669 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.307543", "end": "2018-12-18 04:52:36.193429", "rc": 0, "start": "2018-12-18 04:52:35.885886", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-data-integrity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-data-integrity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2018-12-18T04:52:36.226177 (delta: 0.53712)         elapsed: 3.920821 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.651940", "end": "2018-12-18 04:52:36.983306", "failed_when_result": false, "rc": 0, "start": "2018-12-18 04:52:36.331366", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-data-integrity configured", "stdout_lines": ["litmusresult.litmus.io/fio-data-integrity configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2018-12-18T04:52:37.020970 (delta: 0.794764)         elapsed: 4.715614 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2018-12-18T04:52:37.053407 (delta: 0.032406)         elapsed: 4.748051 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2018-12-18T04:52:37.084723 (delta: 0.031287)         elapsed: 4.779367 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the provider storageclass is applied] **********************
2018-12-18T04:52:37.115900 (delta: 0.031149)         elapsed: 4.810544 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse", "delta": "0:00:00.380313", "end": "2018-12-18 04:52:37.603627", "rc": 0, "start": "2018-12-18 04:52:37.223314", "stderr": "", "stderr_lines": [], "stdout": "NAME                   PROVISIONER                    AGE\nopenebs-cstor-sparse   openebs.io/provisioner-iscsi   31m", "stdout_lines": ["NAME                   PROVISIONER                    AGE", "openebs-cstor-sparse   openebs.io/provisioner-iscsi   31m"]}

TASK [Replace the storageclass placeholder with provider] **********************
2018-12-18T04:52:37.638025 (delta: 0.522095)         elapsed: 5.332669 ******** 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Create test specific namespace.] *****************************************
2018-12-18T04:52:37.867600 (delta: 0.229545)         elapsed: 5.562244 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns fio", "delta": "0:00:00.351611", "end": "2018-12-18 04:52:38.331088", "rc": 0, "start": "2018-12-18 04:52:37.979477", "stderr": "", "stderr_lines": [], "stdout": "namespace/fio created", "stdout_lines": ["namespace/fio created"]}

TASK [Checking the status  of test specific namespace.] ************************
2018-12-18T04:52:38.364999 (delta: 0.497366)         elapsed: 6.059643 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns fio -o jsonpath='{.status.phase}'", "delta": "0:00:00.375000", "end": "2018-12-18 04:52:38.847766", "rc": 0, "start": "2018-12-18 04:52:38.472766", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Deploy PVC to get size of volume requested application namespace] ********
2018-12-18T04:52:38.883980 (delta: 0.51895)         elapsed: 6.578624 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f pvc.yml -n fio", "delta": "0:00:00.456161", "end": "2018-12-18 04:52:39.448277", "rc": 0, "start": "2018-12-18 04:52:38.992116", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/demo-vol1-claim created", "stdout_lines": ["persistentvolumeclaim/demo-vol1-claim created"]}

TASK [include_tasks] ***********************************************************
2018-12-18T04:52:39.483253 (delta: 0.599242)         elapsed: 7.177897 ******** 
included: /common/utils/disable_compression_on_pools.yml for 127.0.0.1

TASK [Get the pv name from application namespace] ******************************
2018-12-18T04:52:39.576567 (delta: 0.09328)         elapsed: 7.271211 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n fio -o jsonpath={.items[0].spec.volumeName}", "delta": "0:00:00.386605", "end": "2018-12-18 04:52:40.068907", "rc": 0, "start": "2018-12-18 04:52:39.682302", "stderr": "", "stderr_lines": [], "stdout": "pvc-bef86ce2-0280-11e9-bcb1-064a6500ddfa", "stdout_lines": ["pvc-bef86ce2-0280-11e9-bcb1-064a6500ddfa"]}

TASK [Get the target name associated to PVC] ***********************************
2018-12-18T04:52:40.103150 (delta: 0.526548)         elapsed: 7.797794 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n openebs --no-headers | grep pvc-bef86ce2-0280-11e9-bcb1-064a6500ddfa | awk '{ print $1 }'", "delta": "0:00:00.357740", "end": "2018-12-18 04:52:40.566355", "rc": 0, "start": "2018-12-18 04:52:40.208615", "stderr": "", "stderr_lines": [], "stdout": "pvc-bef86ce2-0280-11e9-bcb1-064a6500ddfa-target-d9b979bff-mgzpx", "stdout_lines": ["pvc-bef86ce2-0280-11e9-bcb1-064a6500ddfa-target-d9b979bff-mgzpx"]}

TASK [Check the status of the target pod] **************************************
2018-12-18T04:52:40.600704 (delta: 0.497521)         elapsed: 8.295348 ******** 
FAILED - RETRYING: Check the status of the target pod (30 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod pvc-bef86ce2-0280-11e9-bcb1-064a6500ddfa-target-d9b979bff-mgzpx -n openebs -o jsonpath={.status.phase}", "delta": "0:00:00.381928", "end": "2018-12-18 04:52:44.566929", "rc": 0, "start": "2018-12-18 04:52:44.185001", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get list of pool deployments from cvr] ***********************************
2018-12-18T04:52:44.602606 (delta: 4.001868)         elapsed: 12.29725 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-bef86ce2-0280-11e9-bcb1-064a6500ddfa --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}' | awk '{print $1}'", "delta": "0:00:00.381186", "end": "2018-12-18 04:52:45.087885", "rc": 0, "start": "2018-12-18 04:52:44.706699", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-3rcr\ncstor-sparse-pool-8rbg\ncstor-sparse-pool-pul2", "stdout_lines": ["cstor-sparse-pool-3rcr", "cstor-sparse-pool-8rbg", "cstor-sparse-pool-pul2"]}

TASK [Obtaining the replicasets corresponding to pool deployements.] ***********
2018-12-18T04:52:45.121934 (delta: 0.519298)         elapsed: 12.816578 ******* 
changed: [127.0.0.1] => (item=cstor-sparse-pool-3rcr) => {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-3rcr\")].metadata.name}'", "delta": "0:00:00.385675", "end": "2018-12-18 04:52:45.618082", "item": "cstor-sparse-pool-3rcr", "rc": 0, "start": "2018-12-18 04:52:45.232407", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-3rcr-69c8b66cb5", "stdout_lines": ["cstor-sparse-pool-3rcr-69c8b66cb5"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-8rbg) => {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-8rbg\")].metadata.name}'", "delta": "0:00:00.392844", "end": "2018-12-18 04:52:46.106613", "item": "cstor-sparse-pool-8rbg", "rc": 0, "start": "2018-12-18 04:52:45.713769", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-8rbg-75bf5797c7", "stdout_lines": ["cstor-sparse-pool-8rbg-75bf5797c7"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-pul2) => {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-pul2\")].metadata.name}'", "delta": "0:00:00.381346", "end": "2018-12-18 04:52:46.578682", "item": "cstor-sparse-pool-pul2", "rc": 0, "start": "2018-12-18 04:52:46.197336", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-pul2-5cf89ddbc7", "stdout_lines": ["cstor-sparse-pool-pul2-5cf89ddbc7"]}

TASK [Obtaining the pool pods] *************************************************
2018-12-18T04:52:46.613407 (delta: 1.491443)         elapsed: 14.308051 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-3rcr-69c8b66cb5', '_ansible_item_result': True, u'delta': u'0:00:00.385675', 'stdout_lines': [u'cstor-sparse-pool-3rcr-69c8b66cb5'], '_ansible_item_label': u'cstor-sparse-pool-3rcr', u'end': u'2018-12-18 04:52:45.618082', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-3rcr")].metadata.name}\'', 'item': u'cstor-sparse-pool-3rcr', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-3rcr")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-18 04:52:45.232407', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-3rcr-69c8b66cb5\")].metadata.name}'", "delta": "0:00:00.388588", "end": "2018-12-18 04:52:47.113157", "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-3rcr\")].metadata.name}'", "delta": "0:00:00.385675", "end": "2018-12-18 04:52:45.618082", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-3rcr\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-3rcr", "rc": 0, "start": "2018-12-18 04:52:45.232407", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-3rcr-69c8b66cb5", "stdout_lines": ["cstor-sparse-pool-3rcr-69c8b66cb5"]}, "rc": 0, "start": "2018-12-18 04:52:46.724569", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd", "stdout_lines": ["cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-8rbg-75bf5797c7', '_ansible_item_result': True, u'delta': u'0:00:00.392844', 'stdout_lines': [u'cstor-sparse-pool-8rbg-75bf5797c7'], '_ansible_item_label': u'cstor-sparse-pool-8rbg', u'end': u'2018-12-18 04:52:46.106613', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-8rbg")].metadata.name}\'', 'item': u'cstor-sparse-pool-8rbg', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-8rbg")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-18 04:52:45.713769', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-8rbg-75bf5797c7\")].metadata.name}'", "delta": "0:00:00.361063", "end": "2018-12-18 04:52:47.567092", "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-8rbg\")].metadata.name}'", "delta": "0:00:00.392844", "end": "2018-12-18 04:52:46.106613", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-8rbg\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-8rbg", "rc": 0, "start": "2018-12-18 04:52:45.713769", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-8rbg-75bf5797c7", "stdout_lines": ["cstor-sparse-pool-8rbg-75bf5797c7"]}, "rc": 0, "start": "2018-12-18 04:52:47.206029", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-8rbg-75bf5797c7-tfbxk", "stdout_lines": ["cstor-sparse-pool-8rbg-75bf5797c7-tfbxk"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-pul2-5cf89ddbc7', '_ansible_item_result': True, u'delta': u'0:00:00.381346', 'stdout_lines': [u'cstor-sparse-pool-pul2-5cf89ddbc7'], '_ansible_item_label': u'cstor-sparse-pool-pul2', u'end': u'2018-12-18 04:52:46.578682', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-pul2")].metadata.name}\'', 'item': u'cstor-sparse-pool-pul2', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-pul2")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-18 04:52:46.197336', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-pul2-5cf89ddbc7\")].metadata.name}'", "delta": "0:00:00.362532", "end": "2018-12-18 04:52:48.023233", "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-pul2\")].metadata.name}'", "delta": "0:00:00.381346", "end": "2018-12-18 04:52:46.578682", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-pul2\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-pul2", "rc": 0, "start": "2018-12-18 04:52:46.197336", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-pul2-5cf89ddbc7", "stdout_lines": ["cstor-sparse-pool-pul2-5cf89ddbc7"]}, "rc": 0, "start": "2018-12-18 04:52:47.660701", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-pul2-5cf89ddbc7-m758n", "stdout_lines": ["cstor-sparse-pool-pul2-5cf89ddbc7-m758n"]}

TASK [set_fact] ****************************************************************
2018-12-18T04:52:48.062218 (delta: 1.448782)         elapsed: 15.756862 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pool_pod_named_list": []}, "changed": false}

TASK [Build a list of replica pods] ********************************************
2018-12-18T04:52:48.112964 (delta: 0.050715)         elapsed: 15.807608 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd', '_ansible_item_result': True, u'delta': u'0:00:00.388588', 'stdout_lines': [u'cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-3rcr-69c8b66cb5', '_ansible_item_result': True, u'delta': u'0:00:00.385675', 'stdout_lines': [u'cstor-sparse-pool-3rcr-69c8b66cb5'], '_ansible_item_label': u'cstor-sparse-pool-3rcr', u'end': u'2018-12-18 04:52:45.618082', '_ansible_no_log': False, u'start': u'2018-12-18 04:52:45.232407', u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-3rcr")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-3rcr', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-3rcr")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2018-12-18 04:52:47.113157', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-3rcr-69c8b66cb5")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-3rcr-69c8b66cb5', '_ansible_item_result': True, u'delta': u'0:00:00.385675', 'stdout_lines': [u'cstor-sparse-pool-3rcr-69c8b66cb5'], '_ansible_item_label': u'cstor-sparse-pool-3rcr', u'end': u'2018-12-18 04:52:45.618082', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-3rcr")].metadata.name}\'', u'start': u'2018-12-18 04:52:45.232407', 'item': u'cstor-sparse-pool-3rcr', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-3rcr")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-3rcr-69c8b66cb5")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-18 04:52:46.724569', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_pod_named_list": ["cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-3rcr-69c8b66cb5\")].metadata.name}'", "delta": "0:00:00.388588", "end": "2018-12-18 04:52:47.113157", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-3rcr-69c8b66cb5\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-3rcr\")].metadata.name}'", "delta": "0:00:00.385675", "end": "2018-12-18 04:52:45.618082", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-3rcr\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-3rcr", "rc": 0, "start": "2018-12-18 04:52:45.232407", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-3rcr-69c8b66cb5", "stdout_lines": ["cstor-sparse-pool-3rcr-69c8b66cb5"]}, "rc": 0, "start": "2018-12-18 04:52:46.724569", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd", "stdout_lines": ["cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-8rbg-75bf5797c7-tfbxk', '_ansible_item_result': True, u'delta': u'0:00:00.361063', 'stdout_lines': [u'cstor-sparse-pool-8rbg-75bf5797c7-tfbxk'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-8rbg-75bf5797c7', '_ansible_item_result': True, u'delta': u'0:00:00.392844', 'stdout_lines': [u'cstor-sparse-pool-8rbg-75bf5797c7'], '_ansible_item_label': u'cstor-sparse-pool-8rbg', u'end': u'2018-12-18 04:52:46.106613', '_ansible_no_log': False, u'start': u'2018-12-18 04:52:45.713769', u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-8rbg")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-8rbg', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-8rbg")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2018-12-18 04:52:47.567092', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-8rbg-75bf5797c7")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-8rbg-75bf5797c7', '_ansible_item_result': True, u'delta': u'0:00:00.392844', 'stdout_lines': [u'cstor-sparse-pool-8rbg-75bf5797c7'], '_ansible_item_label': u'cstor-sparse-pool-8rbg', u'end': u'2018-12-18 04:52:46.106613', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-8rbg")].metadata.name}\'', u'start': u'2018-12-18 04:52:45.713769', 'item': u'cstor-sparse-pool-8rbg', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-8rbg")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-8rbg-75bf5797c7")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-18 04:52:47.206029', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_pod_named_list": ["cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd", "cstor-sparse-pool-8rbg-75bf5797c7-tfbxk"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-8rbg-75bf5797c7\")].metadata.name}'", "delta": "0:00:00.361063", "end": "2018-12-18 04:52:47.567092", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-8rbg-75bf5797c7\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-8rbg\")].metadata.name}'", "delta": "0:00:00.392844", "end": "2018-12-18 04:52:46.106613", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-8rbg\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-8rbg", "rc": 0, "start": "2018-12-18 04:52:45.713769", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-8rbg-75bf5797c7", "stdout_lines": ["cstor-sparse-pool-8rbg-75bf5797c7"]}, "rc": 0, "start": "2018-12-18 04:52:47.206029", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-8rbg-75bf5797c7-tfbxk", "stdout_lines": ["cstor-sparse-pool-8rbg-75bf5797c7-tfbxk"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-pul2-5cf89ddbc7-m758n', '_ansible_item_result': True, u'delta': u'0:00:00.362532', 'stdout_lines': [u'cstor-sparse-pool-pul2-5cf89ddbc7-m758n'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-pul2-5cf89ddbc7', '_ansible_item_result': True, u'delta': u'0:00:00.381346', 'stdout_lines': [u'cstor-sparse-pool-pul2-5cf89ddbc7'], '_ansible_item_label': u'cstor-sparse-pool-pul2', u'end': u'2018-12-18 04:52:46.578682', '_ansible_no_log': False, u'start': u'2018-12-18 04:52:46.197336', u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-pul2")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-pul2', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-pul2")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2018-12-18 04:52:48.023233', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-pul2-5cf89ddbc7")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-pul2-5cf89ddbc7', '_ansible_item_result': True, u'delta': u'0:00:00.381346', 'stdout_lines': [u'cstor-sparse-pool-pul2-5cf89ddbc7'], '_ansible_item_label': u'cstor-sparse-pool-pul2', u'end': u'2018-12-18 04:52:46.578682', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-pul2")].metadata.name}\'', u'start': u'2018-12-18 04:52:46.197336', 'item': u'cstor-sparse-pool-pul2', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-pul2")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-pul2-5cf89ddbc7")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-18 04:52:47.660701', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_pod_named_list": ["cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd", "cstor-sparse-pool-8rbg-75bf5797c7-tfbxk", "cstor-sparse-pool-pul2-5cf89ddbc7-m758n"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-pul2-5cf89ddbc7\")].metadata.name}'", "delta": "0:00:00.362532", "end": "2018-12-18 04:52:48.023233", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-pul2-5cf89ddbc7\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-pul2\")].metadata.name}'", "delta": "0:00:00.381346", "end": "2018-12-18 04:52:46.578682", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-pul2\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-pul2", "rc": 0, "start": "2018-12-18 04:52:46.197336", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-pul2-5cf89ddbc7", "stdout_lines": ["cstor-sparse-pool-pul2-5cf89ddbc7"]}, "rc": 0, "start": "2018-12-18 04:52:47.660701", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-pul2-5cf89ddbc7-m758n", "stdout_lines": ["cstor-sparse-pool-pul2-5cf89ddbc7-m758n"]}}

TASK [Get pool name from first pool pod] ***************************************
2018-12-18T04:52:48.195446 (delta: 0.082445)         elapsed: 15.89009 ******** 
changed: [127.0.0.1] => (item=cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.471046", "end": "2018-12-18 04:52:48.774299", "item": "cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd", "rc": 0, "start": "2018-12-18 04:52:48.303253", "stderr": "", "stderr_lines": [], "stdout": "cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa", "stdout_lines": ["cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-8rbg-75bf5797c7-tfbxk) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-8rbg-75bf5797c7-tfbxk -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.507810", "end": "2018-12-18 04:52:49.376284", "item": "cstor-sparse-pool-8rbg-75bf5797c7-tfbxk", "rc": 0, "start": "2018-12-18 04:52:48.868474", "stderr": "", "stderr_lines": [], "stdout": "cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa", "stdout_lines": ["cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-pul2-5cf89ddbc7-m758n) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-pul2-5cf89ddbc7-m758n -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.472362", "end": "2018-12-18 04:52:49.940204", "item": "cstor-sparse-pool-pul2-5cf89ddbc7-m758n", "rc": 0, "start": "2018-12-18 04:52:49.467842", "stderr": "", "stderr_lines": [], "stdout": "cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa", "stdout_lines": ["cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa"]}

TASK [set_fact] ****************************************************************
2018-12-18T04:52:49.975499 (delta: 1.780022)         elapsed: 17.670143 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pool_names_list": []}, "changed": false}

TASK [Build a list of replica pods] ********************************************
2018-12-18T04:52:50.026779 (delta: 0.051248)         elapsed: 17.721423 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa', '_ansible_item_result': True, u'delta': u'0:00:00.471046', 'stdout_lines': [u'cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa'], '_ansible_item_label': u'cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd', u'end': u'2018-12-18 04:52:48.774299', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl exec cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", 'item': u'cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u"kubectl exec cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-18 04:52:48.303253', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_names_list": ["cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.471046", "end": "2018-12-18 04:52:48.774299", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl exec cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd", "rc": 0, "start": "2018-12-18 04:52:48.303253", "stderr": "", "stderr_lines": [], "stdout": "cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa", "stdout_lines": ["cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa', '_ansible_item_result': True, u'delta': u'0:00:00.507810', 'stdout_lines': [u'cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa'], '_ansible_item_label': u'cstor-sparse-pool-8rbg-75bf5797c7-tfbxk', u'end': u'2018-12-18 04:52:49.376284', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl exec cstor-sparse-pool-8rbg-75bf5797c7-tfbxk -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", 'item': u'cstor-sparse-pool-8rbg-75bf5797c7-tfbxk', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u"kubectl exec cstor-sparse-pool-8rbg-75bf5797c7-tfbxk -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-18 04:52:48.868474', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_names_list": ["cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa", "cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-8rbg-75bf5797c7-tfbxk -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.507810", "end": "2018-12-18 04:52:49.376284", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl exec cstor-sparse-pool-8rbg-75bf5797c7-tfbxk -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-8rbg-75bf5797c7-tfbxk", "rc": 0, "start": "2018-12-18 04:52:48.868474", "stderr": "", "stderr_lines": [], "stdout": "cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa", "stdout_lines": ["cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa', '_ansible_item_result': True, u'delta': u'0:00:00.472362', 'stdout_lines': [u'cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa'], '_ansible_item_label': u'cstor-sparse-pool-pul2-5cf89ddbc7-m758n', u'end': u'2018-12-18 04:52:49.940204', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl exec cstor-sparse-pool-pul2-5cf89ddbc7-m758n -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", 'item': u'cstor-sparse-pool-pul2-5cf89ddbc7-m758n', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u"kubectl exec cstor-sparse-pool-pul2-5cf89ddbc7-m758n -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-18 04:52:49.467842', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_names_list": ["cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa", "cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa", "cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-pul2-5cf89ddbc7-m758n -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.472362", "end": "2018-12-18 04:52:49.940204", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl exec cstor-sparse-pool-pul2-5cf89ddbc7-m758n -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-pul2-5cf89ddbc7-m758n", "rc": 0, "start": "2018-12-18 04:52:49.467842", "stderr": "", "stderr_lines": [], "stdout": "cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa", "stdout_lines": ["cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa"]}}

TASK [debug] *******************************************************************
2018-12-18T04:52:50.102642 (delta: 0.075825)         elapsed: 17.797286 ******* 
ok: [127.0.0.1] => (item=cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa) => {
    "msg": "cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa are pool name"
}
ok: [127.0.0.1] => (item=cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa) => {
    "msg": "cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa are pool name"
}
ok: [127.0.0.1] => (item=cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa) => {
    "msg": "cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa are pool name"
}

TASK [Disable compression factor on pool/volumes] ******************************
2018-12-18T04:52:50.169194 (delta: 0.066517)         elapsed: 17.863838 ******* 
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd', u'cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa']) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd -n openebs -c cstor-pool zfs set compression=off cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa/pvc-bef86ce2-0280-11e9-bcb1-064a6500ddfa", "delta": "0:00:00.499237", "end": "2018-12-18 04:52:50.781540", "item": ["cstor-sparse-pool-3rcr-69c8b66cb5-gl9hd", "cstor-5ca225a3-027c-11e9-bcb1-064a6500ddfa"], "rc": 0, "start": "2018-12-18 04:52:50.282303", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-8rbg-75bf5797c7-tfbxk', u'cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa']) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-8rbg-75bf5797c7-tfbxk -n openebs -c cstor-pool zfs set compression=off cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa/pvc-bef86ce2-0280-11e9-bcb1-064a6500ddfa", "delta": "0:00:00.509103", "end": "2018-12-18 04:52:51.383405", "item": ["cstor-sparse-pool-8rbg-75bf5797c7-tfbxk", "cstor-5ca1bce1-027c-11e9-bcb1-064a6500ddfa"], "rc": 0, "start": "2018-12-18 04:52:50.874302", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-pul2-5cf89ddbc7-m758n', u'cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa']) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-pul2-5cf89ddbc7-m758n -n openebs -c cstor-pool zfs set compression=off cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa/pvc-bef86ce2-0280-11e9-bcb1-064a6500ddfa", "delta": "0:00:00.469792", "end": "2018-12-18 04:52:51.946937", "item": ["cstor-sparse-pool-pul2-5cf89ddbc7-m758n", "cstor-5ca13c99-027c-11e9-bcb1-064a6500ddfa"], "rc": 0, "start": "2018-12-18 04:52:51.477145", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Replace the data sample size with user-defined size] *********************
2018-12-18T04:52:51.982247 (delta: 1.813019)         elapsed: 19.676891 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Fetch the Storage from PVC using namespace(need to modify)] **************
2018-12-18T04:52:52.019780 (delta: 0.037497)         elapsed: 19.714424 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n fio -o jsonpath={.items[0].spec.resources.requests.storage}", "delta": "0:00:00.379853", "end": "2018-12-18 04:52:52.511215", "rc": 0, "start": "2018-12-18 04:52:52.131362", "stderr": "", "stderr_lines": [], "stdout": "5G", "stdout_lines": ["5G"]}

TASK [Fetch the alphabet(G,M,m,g) from storage capacity] ***********************
2018-12-18T04:52:52.545367 (delta: 0.52555)         elapsed: 20.240011 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "echo \"5G\" | grep -o -E '[A-Za-z]+'", "delta": "0:00:00.311411", "end": "2018-12-18 04:52:52.991928", "rc": 0, "start": "2018-12-18 04:52:52.680517", "stderr": "", "stderr_lines": [], "stdout": "G", "stdout_lines": ["G"]}

TASK [Fetch the alphabet(G,M,m,g) from storage capacity] ***********************
2018-12-18T04:52:53.025899 (delta: 0.4805)         elapsed: 20.720543 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "echo \"5G\" | grep -o -E '[0-9]+'", "delta": "0:00:00.309693", "end": "2018-12-18 04:52:53.446313", "rc": 0, "start": "2018-12-18 04:52:53.136620", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [set_fact] ****************************************************************
2018-12-18T04:52:53.480214 (delta: 0.454284)         elapsed: 21.174858 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"value_num": "4571"}, "changed": false}

TASK [set_fact] ****************************************************************
2018-12-18T04:52:53.539137 (delta: 0.058891)         elapsed: 21.233781 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the data sample size with 90% of pvc size in fio-write.yml] ******
2018-12-18T04:52:53.579489 (delta: 0.040318)         elapsed: 21.274133 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the data sample size with 90% 0f pvc size in fio-read.yml] *******
2018-12-18T04:52:53.725707 (delta: 0.146188)         elapsed: 21.420351 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the default I/O test duration with user-defined period] **********
2018-12-18T04:52:53.897991 (delta: 0.172252)         elapsed: 21.592635 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Deploy fio write test job] ***********************************************
2018-12-18T04:52:54.065823 (delta: 0.167799)         elapsed: 21.760467 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f fio-write.yml -n fio", "delta": "0:00:00.472141", "end": "2018-12-18 04:52:54.644760", "rc": 0, "start": "2018-12-18 04:52:54.172619", "stderr": "", "stderr_lines": [], "stdout": "configmap/basic created\njob.batch/fio created", "stdout_lines": ["configmap/basic created", "job.batch/fio created"]}

TASK [Fetch the pod name in fio] ***********************************************
2018-12-18T04:52:54.686210 (delta: 0.620355)         elapsed: 22.380854 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n fio -l name=fio-write -o custom-columns=:metadata.name --no-headers", "delta": "0:00:00.381969", "end": "2018-12-18 04:52:55.174750", "rc": 0, "start": "2018-12-18 04:52:54.792781", "stderr": "", "stderr_lines": [], "stdout": "fio-rqxg7", "stdout_lines": ["fio-rqxg7"]}

TASK [Check the status of pod] *************************************************
2018-12-18T04:52:55.208855 (delta: 0.522614)         elapsed: 22.903499 ******* 
FAILED - RETRYING: Check the status of pod (100 retries left).
FAILED - RETRYING: Check the status of pod (99 retries left).
FAILED - RETRYING: Check the status of pod (98 retries left).
FAILED - RETRYING: Check the status of pod (97 retries left).
FAILED - RETRYING: Check the status of pod (96 retries left).
FAILED - RETRYING: Check the status of pod (95 retries left).
FAILED - RETRYING: Check the status of pod (94 retries left).
FAILED - RETRYING: Check the status of pod (93 retries left).
FAILED - RETRYING: Check the status of pod (92 retries left).
changed: [127.0.0.1] => {"attempts": 10, "changed": true, "cmd": "kubectl get po fio-rqxg7 -n fio -o jsonpath={.status.phase}", "delta": "0:00:00.362536", "end": "2018-12-18 04:53:44.835919", "rc": 0, "start": "2018-12-18 04:53:44.473383", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Fetch the remaining space from application side] *************************
2018-12-18T04:53:44.874491 (delta: 49.665606)         elapsed: 72.569135 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec fio-rqxg7 -n fio df /datadir | awk 'NR==2 {print $4}'", "delta": "0:00:00.462309", "end": "2018-12-18 04:53:45.447509", "rc": 0, "start": "2018-12-18 04:53:44.985200", "stderr": "", "stderr_lines": [], "stdout": "322180", "stdout_lines": ["322180"]}

TASK [set_fact] ****************************************************************
2018-12-18T04:53:45.482459 (delta: 0.607942)         elapsed: 73.177103 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"space_left_mb": "16"}, "changed": false}

TASK [set_fact] ****************************************************************
2018-12-18T04:53:45.545147 (delta: 0.062657)         elapsed: 73.239791 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"fill_value": "11"}, "changed": false}

TASK [Replace the space_left in commands.sh file with calculated value] ********
2018-12-18T04:53:45.608757 (delta: 0.063575)         elapsed: 73.303401 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the space_left in commands.sh file with calculated value] ********
2018-12-18T04:53:45.754972 (delta: 0.146181)         elapsed: 73.449616 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the space_left in commands.sh file with calculated value] ********
2018-12-18T04:53:45.791787 (delta: 0.036781)         elapsed: 73.486431 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Check if fio write job is completed] *************************************
2018-12-18T04:53:45.933266 (delta: 0.141445)         elapsed: 73.62791 ******** 
FAILED - RETRYING: Check if fio write job is completed (900 retries left).
FAILED - RETRYING: Check if fio write job is completed (899 retries left).

FAILED - RETRYING: Check if fio write job is completed (898 retries left).
FAILED - RETRYING: Check if fio write job is completed (897 retries left).
FAILED - RETRYING: Check if fio write job is completed (896 retries left).
FAILED - RETRYING: Check if fio write job is completed (895 retries left).
FAILED - RETRYING: Check if fio write job is completed (894 retries left).
FAILED - RETRYING: Check if fio write job is completed (893 retries left).
FAILED - RETRYING: Check if fio write job is completed (892 retries left).
FAILED - RETRYING: Check if fio write job is completed (891 retries left).
changed: [127.0.0.1] => {"attempts": 11, "changed": true, "cmd": "kubectl get pods -n fio -o jsonpath='{.items[?(@.metadata.labels.name==\"fio-write\")].status.containerStatuses[*].state.terminated.reason}'", "delta": "0:00:00.383837", "end": "2018-12-18 05:03:51.786778", "rc": 0, "start": "2018-12-18 05:03:51.402941", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Verify the fio logs to check if run is complete w/o errors] **************
2018-12-18T05:03:51.823034 (delta: 605.889733)         elapsed: 679.517678 **** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl logs fio-rqxg7 -n fio | grep -i error | cut -d \":\" -f 2 | sort | uniq", "delta": "0:00:00.406198", "end": "2018-12-18 05:03:52.338549", "failed_when_result": false, "rc": 0, "start": "2018-12-18 05:03:51.932351", "stderr": "", "stderr_lines": [], "stdout": " 0,", "stdout_lines": [" 0,"]}

TASK [Replace the data sample size with user-defined size] *********************
2018-12-18T05:03:52.376065 (delta: 0.553)         elapsed: 680.070709 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace the default I/O test duration with user-defined period] **********
2018-12-18T05:03:52.410864 (delta: 0.034766)         elapsed: 680.105508 ****** 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Checking for configmap] **************************************************
2018-12-18T05:03:52.548892 (delta: 0.137994)         elapsed: 680.243536 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get configmap -n fio", "delta": "0:00:00.379062", "end": "2018-12-18 05:03:53.039353", "rc": 0, "start": "2018-12-18 05:03:52.660291", "stderr": "", "stderr_lines": [], "stdout": "NAME    DATA   AGE\nbasic   1      10m", "stdout_lines": ["NAME    DATA   AGE", "basic   1      10m"]}

TASK [Create the configmap] ****************************************************
2018-12-18T05:03:53.075584 (delta: 0.526652)         elapsed: 680.770228 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create cm commandfile --from-file=commands.sh -n fio", "delta": "0:00:00.388290", "end": "2018-12-18 05:03:53.573613", "rc": 0, "start": "2018-12-18 05:03:53.185323", "stderr": "", "stderr_lines": [], "stdout": "configmap/commandfile created", "stdout_lines": ["configmap/commandfile created"]}

TASK [Verify Successfull creation of configmap] ********************************
2018-12-18T05:03:53.608082 (delta: 0.532466)         elapsed: 681.302726 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl describe cm commandfile -n fio", "delta": "0:00:00.384863", "end": "2018-12-18 05:03:54.104863", "rc": 0, "start": "2018-12-18 05:03:53.720000", "stderr": "", "stderr_lines": [], "stdout": "Name:         commandfile\nNamespace:    fio\nLabels:       <none>\nAnnotations:  <none>\n\nData\n====\ncommands.sh:\n----\ncd datadir\nerror_check()\n{\n  if [ $? != 0 ]\n  then\n    echo \"error caught\"\n    exit 1\n  fi\n}\n\nperform_data_write()\n{\n        value=11\n  i=0\n  while [ $i -le $value ]\n  do\n    ls -all\n    error_check\n    touch file$i\n    error_check\n    dd if=/dev/urandom of=file$i bs=4k count=5000\n    error_check\n    sync\n    read_data\n    i=$(( i + 1 ))\n    error_check\n  done\n}\nread_data()\n{\n  touch testfile\n  error_check\n  echo \"OpenEBS Released newer version\"\n  error_check\n  cat testfile\n  error_check\n  rm testfile\n}\nperform_data_write\n\nEvents:  <none>", "stdout_lines": ["Name:         commandfile", "Namespace:    fio", "Labels:       <none>", "Annotations:  <none>", "", "Data", "====", "commands.sh:", "----", "cd datadir", "error_check()", "{", "  if [ $? != 0 ]", "  then", "    echo \"error caught\"", "    exit 1", "  fi", "}", "", "perform_data_write()", "{", "        value=11", "  i=0", "  while [ $i -le $value ]", "  do", "    ls -all", "    error_check", "    touch file$i", "    error_check", "    dd if=/dev/urandom of=file$i bs=4k count=5000", "    error_check", "    sync", "    read_data", "    i=$(( i + 1 ))", "    error_check", "  done", "}", "read_data()", "{", "  touch testfile", "  error_check", "  echo \"OpenEBS Released newer version\"", "  error_check", "  cat testfile", "  error_check", "  rm testfile", "}", "perform_data_write", "", "Events:  <none>"]}

TASK [Deploy fio read test job] ************************************************
2018-12-18T05:03:54.143953 (delta: 0.535836)         elapsed: 681.838597 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f fio-read.yml -n fio", "delta": "0:00:00.466512", "end": "2018-12-18 05:03:54.719561", "rc": 0, "start": "2018-12-18 05:03:54.253049", "stderr": "", "stderr_lines": [], "stdout": "configmap/basic-read created\njob.batch/fio-read created", "stdout_lines": ["configmap/basic-read created", "job.batch/fio-read created"]}

TASK [Obtaining the fio read job pod name] *************************************
2018-12-18T05:03:54.763176 (delta: 0.619188)         elapsed: 682.45782 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n fio -l name=fio-read -o custom-columns=:metadata.name --no-headers", "delta": "0:00:00.384100", "end": "2018-12-18 05:03:55.255940", "rc": 0, "start": "2018-12-18 05:03:54.871840", "stderr": "", "stderr_lines": [], "stdout": "fio-read-l48t6", "stdout_lines": ["fio-read-l48t6"]}

TASK [Check if fio read job is completed] **************************************
2018-12-18T05:03:55.290232 (delta: 0.527021)         elapsed: 682.984876 ****** 
FAILED - RETRYING: Check if fio read job is completed (10 retries left).
FAILED - RETRYING: Check if fio read job is completed (9 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pods -n fio -o jsonpath='{.items[?(@.metadata.labels.name==\"fio-read\")].status.containerStatuses[*].state.terminated.reason}'", "delta": "0:00:00.382748", "end": "2018-12-18 05:05:56.862005", "rc": 0, "start": "2018-12-18 05:05:56.479257", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Verify the data integrity check] *****************************************
2018-12-18T05:05:56.898613 (delta: 121.608349)         elapsed: 804.593257 **** 
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "kubectl logs fio-read-l48t6 -n fio | grep -i error | cut -d \":\" -f 2 | sort | uniq", "delta": "0:00:00.398956", "end": "2018-12-18 05:05:57.402986", "failed_when_result": true, "rc": 0, "start": "2018-12-18 05:05:57.004030", "stderr": "", "stderr_lines": [], "stdout": " 84,\r\n pid=15, err=84/file", "stdout_lines": [" 84,", " pid=15, err=84/file"]}

TASK [set_fact] ****************************************************************
2018-12-18T05:05:57.441965 (delta: 0.54332)         elapsed: 805.136609 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Fail"}, "changed": false}

TASK [include_tasks] ***********************************************************
2018-12-18T05:05:57.490660 (delta: 0.048658)         elapsed: 805.185304 ****** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2018-12-18T05:05:57.555577 (delta: 0.064884)         elapsed: 805.250221 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2018-12-18T05:05:57.589975 (delta: 0.034364)         elapsed: 805.284619 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2018-12-18T05:05:57.623978 (delta: 0.033967)         elapsed: 805.318622 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2018-12-18T05:05:57.657996 (delta: 0.033985)         elapsed: 805.35264 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "b6a18896984a5fcca00b4f2ce1a2b1a21ccf9ff8", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "d759608761d7e7a9e4117ff629d8cb25", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1545109557.69-243606120661804/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2018-12-18T05:05:58.513161 (delta: 0.855131)         elapsed: 806.207805 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.306468", "end": "2018-12-18 05:05:58.953610", "rc": 0, "start": "2018-12-18 05:05:58.647142", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-data-integrity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Fail ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-data-integrity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Fail "]}

TASK [Apply the litmus result CR] **********************************************
2018-12-18T05:05:59.007900 (delta: 0.494705)         elapsed: 806.702544 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.459549", "end": "2018-12-18 05:05:59.572913", "failed_when_result": false, "rc": 0, "start": "2018-12-18 05:05:59.113364", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-data-integrity configured", "stdout_lines": ["litmusresult.litmus.io/fio-data-integrity configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=53   changed=36   unreachable=0    failed=1   

2018-12-18T05:05:59.593274 (delta: 0.585346)         elapsed: 807.287918 ****** 
=============================================================================== 
```
**Read job logs:**
```
kubectl logs -f fio-read-l48t6 -n fio

Running basic-rw test with size=4571m, runtime=60... Wait for results !!

fio: got pattern 'ec', wanted '00'. Bad bits 5
fio: bad pattern block offset 0
fio: verify type mismatch (3731 media, 14 given)
fio: pid=15, err=84/file:io_u.c:1805, func=io_u_sync_complete, error=Invalid or incomplete multibyte or wide character
{
  "fio version" : "fio-2.2.10",
  "timestamp" : 1545109474,
  "time" : "Tue Dec 18 05:04:34 2018",
  "jobs" : [
    {
      "jobname" : "basic-fio",
      "groupid" : 0,
      "error" : 84,
      "eta" : 0,
      "elapsed" : 20,
      "read" : {
        "io_bytes" : 478556,
        "bw" : 24120,
        "iops" : 6030.19,
        "runtime" : 19840,
        "total_ios" : 119639,
        "short_ios" : 0,
        "drop_ios" : 0,
        "slat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00
        },
        "clat" : {
          "min" : 1,
          "max" : 238927,
          "mean" : 163.72,
          "stddev" : 2170.17,
          "percentile" : {
            "1.000000" : 1,
            "5.000000" : 1,
            "10.000000" : 1,
            "20.000000" : 1,
            "30.000000" : 1,
            "40.000000" : 1,
            "50.000000" : 1,
            "60.000000" : 1,
            "70.000000" : 1,
            "80.000000" : 2,
            "90.000000" : 2,
            "95.000000" : 2,
            "99.000000" : 2288,
            "99.500000" : 11072,
            "99.900000" : 36608,
            "99.950000" : 40192,
            "99.990000" : 52992,
            "0.00" : 0,
            "0.00" : 0,
            "0.00" : 0
          }
        },
        "lat" : {
          "min" : 1,
          "max" : 238928,
          "mean" : 164.13,
          "stddev" : 2170.17
        },
        "bw_min" : 12525,
        "bw_max" : 26814,
        "bw_agg" : 99.15,
        "bw_mean" : 23915.26,
        "bw_dev" : 2827.45
      },
      "write" : {
        "io_bytes" : 0,
        "bw" : 0,
        "iops" : 0.00,
        "runtime" : 0,
        "total_ios" : 0,
        "short_ios" : 0,
        "drop_ios" : 0,
        "slat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00
        },
        "clat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00,
          "percentile" : {
            "1.000000" : 0,
            "5.000000" : 0,
            "10.000000" : 0,
            "20.000000" : 0,
            "30.000000" : 0,
            "40.000000" : 0,
            "50.000000" : 0,
            "60.000000" : 0,
            "70.000000" : 0,
            "80.000000" : 0,
            "90.000000" : 0,
            "95.000000" : 0,
            "99.000000" : 0,
            "99.500000" : 0,
            "99.900000" : 0,
            "99.950000" : 0,
            "99.990000" : 0,
            "0.00" : 0,
            "0.00" : 0,
            "0.00" : 0
          }
        },
        "lat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00
        },
        "bw_min" : 0,
        "bw_max" : 0,
        "bw_agg" : 0.00,
        "bw_mean" : 0.00,
        "bw_dev" : 0.00
      },
      "trim" : {
        "io_bytes" : 0,
        "bw" : 0,
        "iops" : 0.00,
        "runtime" : 0,
        "total_ios" : 0,
        "short_ios" : 0,
        "drop_ios" : 0,
        "slat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00
        },
        "clat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00,
          "percentile" : {
            "1.000000" : 0,
            "5.000000" : 0,
            "10.000000" : 0,
            "20.000000" : 0,
            "30.000000" : 0,
            "40.000000" : 0,
            "50.000000" : 0,
            "60.000000" : 0,
            "70.000000" : 0,
            "80.000000" : 0,
            "90.000000" : 0,
            "95.000000" : 0,
            "99.000000" : 0,
            "99.500000" : 0,
            "99.900000" : 0,
            "99.950000" : 0,
            "99.990000" : 0,
            "0.00" : 0,
            "0.00" : 0,
            "0.00" : 0
          }
        },
        "lat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00
        },
        "bw_min" : 0,
        "bw_max" : 0,
        "bw_agg" : 0.00,
        "bw_mean" : 0.00,
        "bw_dev" : 0.00
      },
      "usr_cpu" : 0.77,
      "sys_cpu" : 1.94,
      "ctx" : 1593,
      "majf" : 0,
      "minf" : 18,
      "iodepth_level" : {
        "1" : 100.00,
        "2" : 0.00,
        "4" : 0.00,
        "8" : 0.00,
        "16" : 0.00,
        "32" : 0.00,
        ">=64" : 0.00
      },
      "latency_us" : {
        "2" : 76.64,
        "4" : 20.78,
        "10" : 0.91,
        "20" : 0.06,
        "50" : 0.06,
        "100" : 0.23,
        "250" : 0.00,
        "500" : 0.01,
        "750" : 0.01,
        "1000" : 0.01
      },
      "latency_ms" : {
        "2" : 0.26,
        "4" : 0.14,
        "10" : 0.25,
        "20" : 0.48,
        "50" : 0.17,
        "100" : 0.01,
        "250" : 0.01,
        "500" : 0.00,
        "750" : 0.00,
        "1000" : 0.00,
        "2000" : 0.00,
        ">=2000" : 0.00
      },
      "latency_depth" : 1,
      "latency_target" : 0,
      "latency_percentile" : 100.00,
      "latency_window" : 0
    }
  ],
  "disk_util" : [
    {
      "name" : "sda",
      "read_ios" : 1839,
      "write_ios" : 0,
      "read_merges" : 0,
      "write_merges" : 0,
      "read_ticks" : 32916,
      "write_ticks" : 0,
      "in_queue" : 32916,
      "util" : 99.30
    }
  ]
}
Filesystem      Size  Used Avail Use% Mounted on
overlay         125G   10G  115G   8% /
tmpfs           7.9G     0  7.9G   0% /dev
tmpfs           7.9G     0  7.9G   0% /sys/fs/cgroup
/dev/sda        4.8G  4.5G  315M  94% /datadir
/dev/xvda1      125G   10G  115G   8% /etc/hosts
shm              64M     0   64M   0% /dev/shm
tmpfs           7.9G   12K  7.9G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs           7.9G     0  7.9G   0% /sys/firmware
total 4680732
drwxr-xr-x 3 root root       4096 Dec 18 04:53 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.64115 s, 12.5 MB/s
OpenEBS Released newer version
total 4700732
drwxr-xr-x 3 root root       4096 Dec 18 05:04 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file0
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.60806 s, 12.7 MB/s
OpenEBS Released newer version
total 4720732
drwxr-xr-x 3 root root       4096 Dec 18 05:04 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file1
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.58094 s, 13.0 MB/s
OpenEBS Released newer version
total 4740732
drwxr-xr-x 3 root root       4096 Dec 18 05:04 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file1
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file2
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.60499 s, 12.8 MB/s
OpenEBS Released newer version
total 4760732
drwxr-xr-x 3 root root       4096 Dec 18 05:04 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file1
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file2
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file3
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.60372 s, 12.8 MB/s
OpenEBS Released newer version
total 4780732
drwxr-xr-x 3 root root       4096 Dec 18 05:04 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file1
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file2
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file3
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file4
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.60709 s, 12.7 MB/s
OpenEBS Released newer version
total 4800732
drwxr-xr-x 3 root root       4096 Dec 18 05:04 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file1
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file2
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file3
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file4
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file5
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.61548 s, 12.7 MB/s
OpenEBS Released newer version
total 4820732
drwxr-xr-x 3 root root       4096 Dec 18 05:04 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file1
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file2
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file3
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file4
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file5
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file6
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.60378 s, 12.8 MB/s
OpenEBS Released newer version
total 4840732
drwxr-xr-x 3 root root       4096 Dec 18 05:05 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file1
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file2
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file3
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file4
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file5
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file6
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file7
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.59329 s, 12.9 MB/s
OpenEBS Released newer version
total 4860732
drwxr-xr-x 3 root root       4096 Dec 18 05:05 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file1
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file2
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file3
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file4
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file5
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file6
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file7
-rw-r--r-- 1 root root   20480000 Dec 18 05:05 file8
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.59793 s, 12.8 MB/s
OpenEBS Released newer version
total 4880732
drwxr-xr-x 3 root root       4096 Dec 18 05:05 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file1
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file2
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file3
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file4
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file5
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file6
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file7
-rw-r--r-- 1 root root   20480000 Dec 18 05:05 file8
-rw-r--r-- 1 root root   20480000 Dec 18 05:05 file9
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.6 s, 12.8 MB/s
OpenEBS Released newer version
total 4900732
drwxr-xr-x 3 root root       4096 Dec 18 05:05 .
drwxr-xr-x 1 root root       4096 Dec 18 05:04 ..
-rw-r--r-- 1 root root 4793040896 Dec 18 05:03 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file0
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file1
-rw-r--r-- 1 root root   20480000 Dec 18 05:05 file10
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file2
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file3
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file4
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file5
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file6
-rw-r--r-- 1 root root   20480000 Dec 18 05:04 file7
-rw-r--r-- 1 root root   20480000 Dec 18 05:05 file8
-rw-r--r-- 1 root root   20480000 Dec 18 05:05 file9
drwx------ 2 root root      16384 Dec 18 04:53 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.58716 s, 12.9 MB/s
OpenEBS Released newer version
Filesystem      Size  Used Avail Use% Mounted on
overlay         125G   11G  114G   9% /
tmpfs           7.9G     0  7.9G   0% /dev
tmpfs           7.9G     0  7.9G   0% /sys/fs/cgroup
/dev/sda        4.8G  4.8G   81M  99% /datadir
/dev/xvda1      125G   11G  114G   9% /etc/hosts
shm              64M     0   64M   0% /dev/shm
tmpfs           7.9G   12K  7.9G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs           7.9G     0  7.9G   0% /sys/firmware
```