### PR TITLE
fix(istgtcontrol): istgtcontrol output change from 'status' to 'Mode'

### DIFF
--- a/apps/percona/functional/snapshot_rebuild/snap_rebuild_multiple_rep/test.yml
+++ b/apps/percona/functional/snapshot_rebuild/snap_rebuild_multiple_rep/test.yml
@@ -59,7 +59,7 @@
         - name: Check if the targeted replica is disconnected.
           shell: >
             kubectl exec -it {{ cstor_target.stdout }} -n {{ operator_ns }} --container  cstor-istgt 
-            -- istgtcontrol -q replica |json_pp | jq '.volumeStatus[0].replicaStatus[].status' | grep Healthy | wc -l
+            -- istgtcontrol -q replica |json_pp | jq '.volumeStatus[0].replicaStatus[].Mode' | grep Healthy | wc -l
           register: connected_replica
           until: "(connected_replica.stdout|int) == ((healthy_pods.stdout|int) - 2)"
           delay: 15

--- a/apps/percona/functional/snapshot_rebuild/snap_rebuild_single_rep/test.yml
+++ b/apps/percona/functional/snapshot_rebuild/snap_rebuild_single_rep/test.yml
@@ -53,7 +53,7 @@
         - name: Check if the targeted replica is disconnected.
           shell: >
             kubectl exec -it {{ cstor_target.stdout }} -n {{ operator_ns }} --container  cstor-istgt 
-            -- istgtcontrol -q replica |json_pp | jq '.volumeStatus[0].replicaStatus[].status' | grep Healthy | wc -l
+            -- istgtcontrol -q replica |json_pp | jq '.volumeStatus[0].replicaStatus[].Mode' | grep Healthy | wc -l
           register: connected_replica
           until: "(connected_replica.stdout|int) == ((healthy_pods.stdout|int) - 1)"
           delay: 15

--- a/chaoslib/openebs/cstor_replica_network_delay.yaml
+++ b/chaoslib/openebs/cstor_replica_network_delay.yaml
@@ -115,8 +115,15 @@
   delay: 30
   retries: 10
 
-- name: Wait until all replica becomes healthy
+- name: Wait until volume becomes healthy
   shell: kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol -q replica |json_pp |grep "\"status" |awk -F ':' '{print $2}' | tr -d ','
+  register: volume_status
+  until: volume_status.stdout.find("Degraded") == -1
+  retries: 50
+  delay: 10
+
+- name: Wait until all replica becomes healthy
+  shell: kubectl exec -it {{ istgt_replica.stdout }} -n {{ operator_ns }} --container  cstor-istgt -- istgtcontrol -q replica |json_pp |grep "\"Mode" |awk -F ':' '{print $2}' | tr -d ','
   register: replica_status
   until: replica_status.stdout.find("Degraded") == -1
   retries: 50

--- a/funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequesites.yml
+++ b/funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequesites.yml
@@ -82,7 +82,7 @@
         - name: Making sure number of healthy pods is equal to replication factor
           shell: >
             kubectl exec -it {{ cstor_target.stdout }} -n {{ ns }} --container  cstor-istgt
-            -- istgtcontrol -q replica |json_pp | jq '.volumeStatus[0].replicaStatus[].status' | grep Healthy | wc -l
+            -- istgtcontrol -q replica |json_pp | jq '.volumeStatus[0].replicaStatus[].Mode' | grep Healthy | wc -l
           args:
             executable: /bin/bash
           register: healthy_pods


### PR DESCRIPTION
There is change in istgtcontrol output format. Below is new one:
```istgtcontrol -q replica | json_pp 
{
   "volumeStatus" : [
      {
         "status" : "Healthy",
         "name" : "vol1",
         "replicaStatus" : [
            {
               "inflightWrite" : "0",
               "Mode" : "Healthy",
               "checkpointedIOSeq" : "1000",
               "inflightSync" : "0",
               "upTime" : 4422,
               "Address" : "127.0.0.1",
               "inflightRead" : "0",
               "replicaId" : "6161"
            },
            {
               "checkpointedIOSeq" : "1000",
               "inflightSync" : "0",
               "upTime" : 4418,
               "inflightWrite" : "0",
               "Mode" : "Healthy",
               "replicaId" : "6162",
               "inflightRead" : "0",
               "Address" : "127.0.0.1"
            }
         ]
      }
   ]
}
```
Replica status is changed from 'status' to 'Mode'.

This PR is in accordance with istgtcontrol output change.
Signed-off-by: Vishnu Itta <vitta@mayadata.io>