### PR TITLE
(WIP)(Functionality) Fill the volume capacity upto 97% to check the behaviour of application and pool pods

### DIFF
--- a/apps/fio/tests/pool_capacity/commands.sh
+++ b/apps/fio/tests/pool_capacity/commands.sh
@@ -1,0 +1,39 @@
+cd datadir
+error_check()
+{
+	if [ $? != 0 ]
+	then
+		echo "error caught"
+		exit 1
+	fi
+}
+
+perform_data_write()
+{
+        value=space_left
+	i=0
+	while [ $i -le $value ]
+	do
+		ls -all
+		error_check
+		touch file$i
+		error_check
+		dd if=/dev/urandom of=file$i bs=4k count=5000
+		error_check
+		sync
+		read_data
+		i=$(( i + 1 ))
+		error_check
+	done
+}
+read_data()
+{
+	touch testfile
+	error_check
+	echo "OpenEBS Released newer version"
+	error_check
+	cat testfile
+	error_check
+	rm testfile
+}
+perform_data_write

--- a/apps/fio/tests/pool_capacity/fio-read.yml
+++ b/apps/fio/tests/pool_capacity/fio-read.yml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: basic-read
+data:
+
+ basic-rw : |-
+
+     [global]
+     directory=/datadir
+
+     [basic-fio]
+     rw=read
+     bs=4k
+     verify=crc32c
+     verify=pattern
+     verify_pattern=%o
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fio-read
+spec:
+  template:
+    metadata:
+      name: fio-read
+      labels:
+        name: fio-read
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: perfrunner
+        image: openebs/tests-fio:latest
+        imagePullPolicy: Always
+        command: ["/bin/bash"]
+        args: ["-c", "./fio_runner.sh --size 256m; df -h;cat commands.sh > cp_commands.sh; chmod 775 cp_commands.sh; ./cp_commands.sh; df -h;exit 0"]
+        volumeMounts:
+           - mountPath: /datadir
+             name: demo-vol1
+           - mountPath: templates/file/basic-rw
+             subPath: basic-rw
+             name: basic-configmap-read
+           - mountPath: /commands.sh
+             subPath: commands.sh
+             name: commandconfig
+        tty: true
+
+      volumes:
+      - name: demo-vol1
+        persistentVolumeClaim:
+          claimName: demo-vol1-claim
+      - name: basic-configmap-read
+        configMap:
+          name: basic-read
+      - name: commandconfig
+        configMap:
+          name: commandfile

--- a/apps/fio/tests/pool_capacity/fio-write.yml
+++ b/apps/fio/tests/pool_capacity/fio-write.yml
@@ -1,0 +1,54 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: basic
+data:
+
+ basic-rw : |-
+
+     [global]
+     directory=/datadir
+
+     [basic-fio]
+     rw=randwrite
+     bs=4k
+     time_based=1
+     runtime=60
+     verify=crc32c
+     verify=pattern
+     verify_pattern=%o
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: fio
+spec:
+  template:
+    metadata:
+      name: fio
+      labels:
+        name: fio-write
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: perfrunner
+        image: openebs/tests-fio:latest
+        imagePullPolicy: Always
+        command: ["/bin/bash"]
+        args: ["-c", "./fio_runner.sh --size 256m; sync;exit 0"]
+        volumeMounts:
+           - mountPath: /datadir
+             name: demo-vol1
+           - mountPath: templates/file/basic-rw
+             subPath: basic-rw
+             name: basic-configmap
+        tty: true
+
+      volumes:
+      - name: demo-vol1
+        persistentVolumeClaim:
+          claimName: demo-vol1-claim
+      - name: basic-configmap
+        configMap:
+          name: basic

--- a/apps/fio/tests/pool_capacity/pvc.yml
+++ b/apps/fio/tests/pool_capacity/pvc.yml
@@ -1,0 +1,12 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1-claim
+spec:
+  storageClassName: openebs-cstor-sparse
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "5G"

--- a/apps/fio/tests/pool_capacity/run_litmus_test.yml
+++ b/apps/fio/tests/pool_capacity/run_litmus_test.yml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-fill-pool-capacity-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      labels:
+        name: litmus
+        app: fio-pool-capacity-litmus
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-standard
+
+          - name: FIO_NAMESPACE
+            value: fio
+
+          - name: FIO_TESTRUN_PERIOD
+            value: "60"
+
+          - name: POOL_LABEL
+            value: "app=cstor-pool"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./fio/tests/pool_capacity/test.yml -i /etc/ansible/hosts -v; exit 0"]
+        volumeMounts:
+          - name: logs
+            mountPath: /var/log/ansible
+        tty: true
+
+      - name: logger
+        image: openebs/logger
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # spec.volumes is not supported via downward API
+          - name: MY_POD_HOSTPATH
+            value: /mnt/fio
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d ansibletest -r maya,openebs,pvc,fio; exit 0"]
+        volumeMounts:
+          - name: kubeconfig
+            mountPath: /root/admin.conf
+            subPath: admin.conf
+          - name: logs
+            mountPath: /mnt
+        tty: true
+      volumes:
+        - name: kubeconfig
+          configMap:
+            name: kubeconfig
+        - name: logs
+          hostPath:
+            path: /mnt/fio
+            type: ""

--- a/apps/fio/tests/pool_capacity/test.yml
+++ b/apps/fio/tests/pool_capacity/test.yml
@@ -1,0 +1,295 @@
+# TODO
+# Change pod status checks to container status checks (containerStatuses)
+# O/P result
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+   - block:
+
+       - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+         when: lookup('env','RUN_ID')
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+       - include_tasks: /common/utils/update_litmus_result_resource.yml
+         vars:
+           status: 'SOT'
+
+       ## VERIFY AVAILABILITY OF SELECTED STORAGE CLASS
+
+       - name: Check whether the provider storageclass is applied
+         shell: kubectl get sc {{ lookup('env','PROVIDER_STORAGE_CLASS') }}
+         args:
+           executable: /bin/bash
+         register: result
+
+       - name: Replace the storageclass placeholder with provider
+         replace:
+           path: "{{ fio_write_yml }}"
+           regexp: "testclass"
+           replace: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+       - name: Create test specific namespace.
+         shell: kubectl create ns {{ app_ns }}
+         args:
+           executable: /bin/bash
+         when: app_ns != 'litmus'
+
+       - name: Checking the status  of test specific namespace.
+         shell: kubectl get ns {{ app_ns }} -o jsonpath='{.status.phase}'
+         args:
+           executable: /bin/bash
+         register: npstatus
+         until: "'Active' in npstatus.stdout"
+         delay: 30
+         retries: 10
+
+       - name: Get the no.of pods present
+         shell: kubectl get po -n {{ operator_ns }} -l {{ pool_label }} --no-headers | wc -l
+         register: total_pool_pods
+
+       - name: Fetch running Pool names
+         shell:  kubectl get po -l {{ pool_label }} -n {{ operator_ns }} -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}'
+         args:
+           executable: /bin/bash
+         register: pool_names
+
+       - name: Cross check no.of pools pods are in running state
+         shell:  echo "{{ pool_names.stdout }}" | wc -w
+         args:
+           executable: /bin/bash
+         register: no_of_pools
+         failed_when: "{{ no_of_pools.stdout }} != {{ total_pool_pods.stdout }}"
+
+       - set_fact:
+           single_pool: "{{ pool_names.stdout.split(\"\ \")[0] }}"
+
+       - name: Fetch the pool Capacity
+         shell: kubectl exec {{ single_pool }} -n {{ operator_ns }} -c cstor-pool zpool list | awk 'FNR==2 {print $2}'
+         args:
+           executable: /bin/bash
+         register: pool_capacity
+
+       - name: Fetch the alphabet(G,M,m,g) from storage capacity
+         shell: echo "{{ pool_capacity.stdout }}" | grep -o -E '[A-Za-z]+'
+         args:
+           executable: /bin/bash
+         register: symbol
+
+       - name: Fetch the size from storage capacity
+         shell: echo "{{ pool_capacity.stdout }}" | grep -o -E '[0-9]+.[0-9]+'
+         args:
+           executable: /bin/bash
+         register: value_str
+
+       - set_fact:
+           value_num: '{{ value_str.stdout | float - 0.05}}'
+
+       - name: Increase the volume capacity in {{ pvc_yml }} to 98% of pool size
+         replace:
+           dest: "{{ pvc_yml }}"
+           regexp: "5G"
+           replace: "{{ value_num }}{{ symbol.stdout }}"
+
+       - name: Display
+         shell: "cat {{ pvc_yml }}"
+
+       - name: Deploy PVC to get size of volume requested application namespace
+         shell: kubectl apply -f {{ pvc_yml }} -n {{ app_ns }}
+         args:
+           executable: /bin/bash
+
+       - include_tasks: /common/utils/disable_compression_on_pools.yml
+         when: compression == 'off'
+
+       - set_fact:
+           value_num: '{{ ( (value_str.stdout | float - 0.2) * 0.94 * 1024) |  int }}'
+         when: "'G' in symbol.stdout"
+
+       - set_fact:
+           value_num: '{{ ((value_str.stdout | float - 0.2) * 0.94 * 1024 * 1024) | int }}'
+         when: "'T' in symbol.stdout"
+
+       - debug:
+           msg: "{{ value_num }}"
+
+       - name: Replace the data sample size with 90% of pvc size in {{ fio_write_yml }}
+         replace:
+           path: "{{ fio_write_yml }}"
+           regexp: "256m"
+           replace: "{{ value_num }}m"
+         when: "'G' in symbol.stdout or 'T' in symbol.stdout"
+
+       - name: Replace the data sample size with 90% 0f pvc size in {{ fio_read_yml }}
+         replace:
+           path: "{{ fio_read_yml }}"
+           regexp: "256m"
+           replace: "{{ value_num }}m"
+         when: "'G' in symbol.stdout or 'T' in symbol.stdout"
+
+       - name: Replace the default I/O test duration with user-defined period
+         replace:
+           path: "{{ fio_write_yml }}"
+           regexp: "60"
+           replace: "{{ lookup('env','FIO_TESTRUN_PERIOD') }}"
+
+       ## RUN FIO WORKLOAD TEST
+
+       - name: Deploy fio write test job
+         shell: kubectl apply -f {{ fio_write_yml }} -n {{ app_ns }}
+         args:
+           executable: /bin/bash
+
+       - name: Fetch the pod name in {{ app_ns }}
+         shell: >
+           kubectl get pods -n {{ app_ns }} -l name=fio-write -o custom-columns=:metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: fio_pod_name
+
+       - name: Check the status of pod
+         shell: kubectl get po {{ fio_pod_name.stdout }} -n {{ app_ns }} -o jsonpath={.status.phase}
+         args:
+           executable: /bin/bash
+         register: status_fio_pod
+         until: "'Running' in status_fio_pod.stdout"
+         delay: 5
+         retries: 100
+
+       - name: Fetch the remaining space from application side
+         shell: kubectl exec {{ fio_pod_name.stdout }} -n {{ app_ns }} df /datadir | awk 'NR==2 {print $4}'
+         args:
+           executable: /bin/bash
+         register: space_left
+
+        ## Convert GB into Mb
+       - set_fact:
+           space_left_mb: '{{ (space_left.stdout| int / 20480) | round | int }}'
+
+       - set_fact:
+           fill_value: '{{ space_left_mb | int - 5 }}'
+         when: space_left_mb > 10
+
+       - name: Replace the space_left in commands.sh file with calculated value
+         replace:
+           path: "commands.sh"
+           regexp: "space_left"
+           replace: "{{ fill_value }}"
+         when: fill_value is defined
+
+       - name: Replace the space_left in commands.sh file with calculated value
+         replace:
+           path: "commands.sh"
+           regexp: "space_left"
+           replace: "{{ space_left_mb }}"
+         when: fill_value is not defined
+
+       - name: Check if fio write job is completed
+         shell: >
+           kubectl get pods -n {{ app_ns }} -o jsonpath='{.items[?(@.metadata.labels.name=="fio-write")].status.containerStatuses[*].state.terminated.reason}'
+         args:
+           executable: /bin/bash
+         register: result_fio_pod
+         until: "'Completed' in result_fio_pod.stdout"
+         delay: 60
+         retries: 900
+
+       - name: Verify the fio logs to check if run is complete w/o errors
+         shell: >
+           kubectl logs {{ fio_pod_name.stdout }} -n {{ app_ns }}
+           | grep -i error | cut -d ":" -f 2
+           | sort | uniq
+         args:
+           executable: /bin/bash
+         register: result
+         failed_when: result.stdout != " 0,"
+
+       - name: Replace the default I/O test duration with user-defined period
+         replace:
+           path: "{{ fio_read_yml }}"
+           regexp: "60"
+           replace: "{{ lookup('env','FIO_TESTRUN_PERIOD') }}"
+
+       - name: Checking for configmap
+         shell: kubectl get configmap -n {{ app_ns }}
+         register: configmap
+
+       - name: Create the configmap
+         shell: kubectl create cm commandfile --from-file=commands.sh -n {{ app_ns }}
+         args:
+           executable: /bin/bash
+         when: "'commandfile' not in configmap.stdout"
+
+       - name: Verify Successfull creation of configmap
+         shell: kubectl describe cm commandfile -n {{ app_ns }}
+         register: config
+         until: "'commandfile' in config.stdout"
+         delay: 5
+         retries: 20
+
+       - name: Deploy fio read test job
+         shell: kubectl apply -f {{ fio_read_yml }} -n {{ app_ns }}
+         args:
+           executable: /bin/bash
+
+       - name: Obtaining the fio read job pod name
+         shell: >
+           kubectl get pods -n {{ app_ns }} -l name=fio-read -o custom-columns=:metadata.name --no-headers
+         args:
+           executable: /bin/bash
+         register: read_pod
+
+       - name: Check if fio read job is completed
+         shell: >
+           kubectl get pods -n {{ app_ns }} -o jsonpath='{.items[?(@.metadata.labels.name=="fio-read")].status.containerStatuses[*].state.terminated.reason}'
+         args:
+           executable: /bin/bash
+         register: result_read_job
+         until: "'Completed' in result_read_job.stdout"
+         delay: 60
+         retries: 100
+
+       - name: Verify the data integrity check
+         shell: >
+           kubectl logs {{ read_pod.stdout }} -n {{ app_ns }}
+           | grep -i error | cut -d ":" -f 2
+           | sort | uniq
+         args:
+           executable: /bin/bash
+         register: result_di
+         failed_when: result_di.stdout != " 0,"
+#         ignore-errors: true
+
+       - name: Check for error while writing
+         shell: >
+           kubectl get logs {{ read_pod.stdout }} -n {{ app_ns }} | grep 'error caught' | wc -l
+         register: final_result
+         failed_when: final_result.stdout > 0
+
+       - set_fact:
+           flag: "Pass"
+
+     rescue:
+       - set_fact:
+           flag: "Fail"
+
+     always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+
+        ####Container status check is in WIP #######

--- a/apps/fio/tests/pool_capacity/test_vars.yml
+++ b/apps/fio/tests/pool_capacity/test_vars.yml
@@ -1,0 +1,11 @@
+---
+## TEST-SPECIFIC PARAMS
+
+test_name: fio-data-integrity
+fio_write_yml: fio-write.yml
+fio_read_yml: fio-read.yml
+app_ns: "{{ lookup('env','FIO_NAMESPACE') }}"
+pool_label: "{{ lookup('env','POOL_LABEL') }}"
+pvc_yml: pvc.yml
+operator_ns: "openebs"
+compression: "off"


### PR DESCRIPTION
**What this PR does / why we need it**:
1. This litmusbook is capable of filling the ~97% of pool capacity.
2. Using fio read job verfies written data and also performs
   RW operations after filling ~95% of volume capacity.

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->
```
**Logs of litmus job**

PLAY [localhost] ***************************************************************
2018-12-29T22:31:45.026325 (delta: 0.035086)         elapsed: 0.035086 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2018-12-29T22:31:45.034819 (delta: 0.008468)         elapsed: 0.04358 ********* 
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
2018-12-29T22:31:47.744735 (delta: 2.709895)         elapsed: 2.753496 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2018-12-29T22:31:47.782471 (delta: 0.037708)         elapsed: 2.791232 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2018-12-29T22:31:47.818297 (delta: 0.0358)         elapsed: 2.827058 ********** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2018-12-29T22:31:47.884197 (delta: 0.065875)         elapsed: 2.892958 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "146d56191547cf1ef37fc24f1c32123c685a3ba2", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "1858ec125d0913cc89507969a9190901", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1546122707.92-132664771865141/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2018-12-29T22:31:48.274930 (delta: 0.390685)         elapsed: 3.283691 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.278155", "end": "2018-12-29 22:31:48.745545", "rc": 0, "start": "2018-12-29 22:31:48.467390", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-data-integrity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-data-integrity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2018-12-29T22:31:48.779506 (delta: 0.504549)         elapsed: 3.788267 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.631244", "end": "2018-12-29 22:31:49.519311", "failed_when_result": false, "rc": 0, "start": "2018-12-29 22:31:48.888067", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-data-integrity configured", "stdout_lines": ["litmusresult.litmus.io/fio-data-integrity configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2018-12-29T22:31:49.557588 (delta: 0.778051)         elapsed: 4.566349 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2018-12-29T22:31:49.592764 (delta: 0.035146)         elapsed: 4.601525 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2018-12-29T22:31:49.624506 (delta: 0.031713)         elapsed: 4.633267 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the provider storageclass is applied] **********************
2018-12-29T22:31:49.656249 (delta: 0.031715)         elapsed: 4.66501 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse", "delta": "0:00:00.347559", "end": "2018-12-29 22:31:50.110165", "rc": 0, "start": "2018-12-29 22:31:49.762606", "stderr": "", "stderr_lines": [], "stdout": "NAME                   PROVISIONER                    AGE\nopenebs-cstor-sparse   openebs.io/provisioner-iscsi   3h", "stdout_lines": ["NAME                   PROVISIONER                    AGE", "openebs-cstor-sparse   openebs.io/provisioner-iscsi   3h"]}

TASK [Replace the storageclass placeholder with provider] **********************
2018-12-29T22:31:50.144449 (delta: 0.488174)         elapsed: 5.15321 ********* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Create test specific namespace.] *****************************************
2018-12-29T22:31:50.372924 (delta: 0.228447)         elapsed: 5.381685 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns fio", "delta": "0:00:00.347072", "end": "2018-12-29 22:31:50.833225", "rc": 0, "start": "2018-12-29 22:31:50.486153", "stderr": "", "stderr_lines": [], "stdout": "namespace/fio created", "stdout_lines": ["namespace/fio created"]}

TASK [Checking the status  of test specific namespace.] ************************
2018-12-29T22:31:50.867595 (delta: 0.494643)         elapsed: 5.876356 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns fio -o jsonpath='{.status.phase}'", "delta": "0:00:00.350142", "end": "2018-12-29 22:31:51.329214", "rc": 0, "start": "2018-12-29 22:31:50.979072", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Get the no.of pods present] **********************************************
2018-12-29T22:31:51.366038 (delta: 0.498413)         elapsed: 6.374799 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n openebs -l app=cstor-pool --no-headers | wc -l", "delta": "0:00:00.349337", "end": "2018-12-29 22:31:51.823724", "rc": 0, "start": "2018-12-29 22:31:51.474387", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Fetch running Pool names] ************************************************
2018-12-29T22:31:51.858973 (delta: 0.492908)         elapsed: 6.867734 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -l app=cstor-pool -n openebs -o jsonpath='{.items[?(@.status.phase==\"Running\")].metadata.name}'", "delta": "0:00:00.358198", "end": "2018-12-29 22:31:52.330394", "rc": 0, "start": "2018-12-29 22:31:51.972196", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-l8zg-5448f995d6-kj878 cstor-sparse-pool-llt9-5d587d7fdf-fgsbf cstor-sparse-pool-vvu2-689f44b89c-scmfp", "stdout_lines": ["cstor-sparse-pool-l8zg-5448f995d6-kj878 cstor-sparse-pool-llt9-5d587d7fdf-fgsbf cstor-sparse-pool-vvu2-689f44b89c-scmfp"]}

TASK [Cross check no.of pools pods are in running state] ***********************
2018-12-29T22:31:52.364340 (delta: 0.505335)         elapsed: 7.373101 ******** 
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: {{ no_of_pools.stdout }} != {{
total_pool_pods.stdout }}
changed: [127.0.0.1] => {"changed": true, "cmd": "echo \"cstor-sparse-pool-l8zg-5448f995d6-kj878 cstor-sparse-pool-llt9-5d587d7fdf-fgsbf cstor-sparse-pool-vvu2-689f44b89c-scmfp\" | wc -w", "delta": "0:00:00.279086", "end": "2018-12-29 22:31:52.747244", "failed_when_result": false, "rc": 0, "start": "2018-12-29 22:31:52.468158", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [set_fact] ****************************************************************
2018-12-29T22:31:52.786264 (delta: 0.421897)         elapsed: 7.795025 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"single_pool": "cstor-sparse-pool-l8zg-5448f995d6-kj878"}, "changed": false}

TASK [Fetch the pool Capacity] *************************************************
2018-12-29T22:31:52.835809 (delta: 0.049517)         elapsed: 7.84457 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-l8zg-5448f995d6-kj878 -n openebs -c cstor-pool zpool list | awk 'FNR==2 {print $2}'", "delta": "0:00:00.456390", "end": "2018-12-29 22:31:53.396813", "rc": 0, "start": "2018-12-29 22:31:52.940423", "stderr": "", "stderr_lines": [], "stdout": "9.94G", "stdout_lines": ["9.94G"]}

TASK [Fetch the alphabet(G,M,m,g) from storage capacity] ***********************
2018-12-29T22:31:53.431207 (delta: 0.595368)         elapsed: 8.439968 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "echo \"9.94G\" | grep -o -E '[A-Za-z]+'", "delta": "0:00:00.286569", "end": "2018-12-29 22:31:53.821716", "rc": 0, "start": "2018-12-29 22:31:53.535147", "stderr": "", "stderr_lines": [], "stdout": "G", "stdout_lines": ["G"]}

TASK [Fetch the size from storage capacity] ************************************
2018-12-29T22:31:53.855771 (delta: 0.424535)         elapsed: 8.864532 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "echo \"9.94G\" | grep -o -E '[0-9]+.[0-9]+'", "delta": "0:00:00.279642", "end": "2018-12-29 22:31:54.241210", "rc": 0, "start": "2018-12-29 22:31:53.961568", "stderr": "", "stderr_lines": [], "stdout": "9.94", "stdout_lines": ["9.94"]}

TASK [set_fact] ****************************************************************
2018-12-29T22:31:54.275520 (delta: 0.41972)         elapsed: 9.284281 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"value_num": "9.89"}, "changed": false}

TASK [Increase the volume capacity in pvc.yml to 98% of pool size] *************
2018-12-29T22:31:54.326077 (delta: 0.050528)         elapsed: 9.334838 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Display] *****************************************************************
2018-12-29T22:31:54.461225 (delta: 0.13512)         elapsed: 9.469986 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat pvc.yml", "delta": "0:00:00.282876", "end": "2018-12-29 22:31:54.848085", "rc": 0, "start": "2018-12-29 22:31:54.565209", "stderr": "", "stderr_lines": [], "stdout": "---\nkind: PersistentVolumeClaim\napiVersion: v1\nmetadata:\n  name: demo-vol1-claim\nspec:\n  storageClassName: openebs-cstor-sparse\n  accessModes:\n    - ReadWriteOnce\n  resources:\n    requests:\n      storage: \"9.89G\"", "stdout_lines": ["---", "kind: PersistentVolumeClaim", "apiVersion: v1", "metadata:", "  name: demo-vol1-claim", "spec:", "  storageClassName: openebs-cstor-sparse", "  accessModes:", "    - ReadWriteOnce", "  resources:", "    requests:", "      storage: \"9.89G\""]}

TASK [Deploy PVC to get size of volume requested application namespace] ********
2018-12-29T22:31:54.881744 (delta: 0.420491)         elapsed: 9.890505 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f pvc.yml -n fio", "delta": "0:00:00.425317", "end": "2018-12-29 22:31:55.418665", "rc": 0, "start": "2018-12-29 22:31:54.993348", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/demo-vol1-claim created", "stdout_lines": ["persistentvolumeclaim/demo-vol1-claim created"]}

TASK [include_tasks] ***********************************************************
2018-12-29T22:31:55.452158 (delta: 0.570386)         elapsed: 10.460919 ******* 
included: /common/utils/disable_compression_on_pools.yml for 127.0.0.1

TASK [Wait for 15s for target pod to deploy] ***********************************
2018-12-29T22:31:55.533096 (delta: 0.080911)         elapsed: 10.541857 ******* 
ok: [127.0.0.1] => {"changed": false, "elapsed": 15, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Get the pv name from application namespace] ******************************
2018-12-29T22:32:10.796227 (delta: 15.263102)         elapsed: 25.804988 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc -n fio -o jsonpath={.items[0].spec.volumeName}", "delta": "0:00:00.349437", "end": "2018-12-29 22:32:11.247900", "rc": 0, "start": "2018-12-29 22:32:10.898463", "stderr": "", "stderr_lines": [], "stdout": "pvc-8bd18cc7-0bb9-11e9-9e8d-06290e1d565c", "stdout_lines": ["pvc-8bd18cc7-0bb9-11e9-9e8d-06290e1d565c"]}

TASK [Get the target name associated to PVC] ***********************************
2018-12-29T22:32:11.282498 (delta: 0.486244)         elapsed: 26.291259 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n openebs --no-headers | grep pvc-8bd18cc7-0bb9-11e9-9e8d-06290e1d565c | awk '{ print $1 }'", "delta": "0:00:00.351166", "end": "2018-12-29 22:32:11.738392", "rc": 0, "start": "2018-12-29 22:32:11.387226", "stderr": "", "stderr_lines": [], "stdout": "pvc-8bd18cc7-0bb9-11e9-9e8d-06290e1d565c-target-757ffc495cw6sm8", "stdout_lines": ["pvc-8bd18cc7-0bb9-11e9-9e8d-06290e1d565c-target-757ffc495cw6sm8"]}

TASK [Check the status of the target pod] **************************************
2018-12-29T22:32:11.772715 (delta: 0.490185)         elapsed: 26.781476 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod pvc-8bd18cc7-0bb9-11e9-9e8d-06290e1d565c-target-757ffc495cw6sm8 -n openebs -o jsonpath={.status.phase}", "delta": "0:00:00.349613", "end": "2018-12-29 22:32:12.228463", "rc": 0, "start": "2018-12-29 22:32:11.878850", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get list of pool deployments from cvr] ***********************************
2018-12-29T22:32:12.265157 (delta: 0.492412)         elapsed: 27.273918 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-8bd18cc7-0bb9-11e9-9e8d-06290e1d565c --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}' | awk '{print $1}'", "delta": "0:00:00.350419", "end": "2018-12-29 22:32:12.719714", "rc": 0, "start": "2018-12-29 22:32:12.369295", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-l8zg\ncstor-sparse-pool-llt9\ncstor-sparse-pool-vvu2", "stdout_lines": ["cstor-sparse-pool-l8zg", "cstor-sparse-pool-llt9", "cstor-sparse-pool-vvu2"]}

TASK [Obtaining the replicasets corresponding to pool deployements.] ***********
2018-12-29T22:32:12.754771 (delta: 0.489584)         elapsed: 27.763532 ******* 
changed: [127.0.0.1] => (item=cstor-sparse-pool-l8zg) => {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-l8zg\")].metadata.name}'", "delta": "0:00:00.351740", "end": "2018-12-29 22:32:13.216133", "item": "cstor-sparse-pool-l8zg", "rc": 0, "start": "2018-12-29 22:32:12.864393", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-l8zg-5448f995d6", "stdout_lines": ["cstor-sparse-pool-l8zg-5448f995d6"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-llt9) => {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-llt9\")].metadata.name}'", "delta": "0:00:00.356448", "end": "2018-12-29 22:32:13.667757", "item": "cstor-sparse-pool-llt9", "rc": 0, "start": "2018-12-29 22:32:13.311309", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-llt9-5d587d7fdf", "stdout_lines": ["cstor-sparse-pool-llt9-5d587d7fdf"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-vvu2) => {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-vvu2\")].metadata.name}'", "delta": "0:00:00.353595", "end": "2018-12-29 22:32:14.114612", "item": "cstor-sparse-pool-vvu2", "rc": 0, "start": "2018-12-29 22:32:13.761017", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-vvu2-689f44b89c", "stdout_lines": ["cstor-sparse-pool-vvu2-689f44b89c"]}

TASK [Obtaining the pool pods] *************************************************
2018-12-29T22:32:14.150170 (delta: 1.395366)         elapsed: 29.158931 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-l8zg-5448f995d6', '_ansible_item_result': True, u'delta': u'0:00:00.351740', 'stdout_lines': [u'cstor-sparse-pool-l8zg-5448f995d6'], '_ansible_item_label': u'cstor-sparse-pool-l8zg', u'end': u'2018-12-29 22:32:13.216133', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-l8zg")].metadata.name}\'', 'item': u'cstor-sparse-pool-l8zg', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-l8zg")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-29 22:32:12.864393', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-l8zg-5448f995d6\")].metadata.name}'", "delta": "0:00:00.356162", "end": "2018-12-29 22:32:14.616700", "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-l8zg\")].metadata.name}'", "delta": "0:00:00.351740", "end": "2018-12-29 22:32:13.216133", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-l8zg\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-l8zg", "rc": 0, "start": "2018-12-29 22:32:12.864393", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-l8zg-5448f995d6", "stdout_lines": ["cstor-sparse-pool-l8zg-5448f995d6"]}, "rc": 0, "start": "2018-12-29 22:32:14.260538", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-l8zg-5448f995d6-kj878", "stdout_lines": ["cstor-sparse-pool-l8zg-5448f995d6-kj878"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-llt9-5d587d7fdf', '_ansible_item_result': True, u'delta': u'0:00:00.356448', 'stdout_lines': [u'cstor-sparse-pool-llt9-5d587d7fdf'], '_ansible_item_label': u'cstor-sparse-pool-llt9', u'end': u'2018-12-29 22:32:13.667757', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-llt9")].metadata.name}\'', 'item': u'cstor-sparse-pool-llt9', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-llt9")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-29 22:32:13.311309', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-llt9-5d587d7fdf\")].metadata.name}'", "delta": "0:00:00.356297", "end": "2018-12-29 22:32:15.090879", "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-llt9\")].metadata.name}'", "delta": "0:00:00.356448", "end": "2018-12-29 22:32:13.667757", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-llt9\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-llt9", "rc": 0, "start": "2018-12-29 22:32:13.311309", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-llt9-5d587d7fdf", "stdout_lines": ["cstor-sparse-pool-llt9-5d587d7fdf"]}, "rc": 0, "start": "2018-12-29 22:32:14.734582", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-llt9-5d587d7fdf-fgsbf", "stdout_lines": ["cstor-sparse-pool-llt9-5d587d7fdf-fgsbf"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-vvu2-689f44b89c', '_ansible_item_result': True, u'delta': u'0:00:00.353595', 'stdout_lines': [u'cstor-sparse-pool-vvu2-689f44b89c'], '_ansible_item_label': u'cstor-sparse-pool-vvu2', u'end': u'2018-12-29 22:32:14.114612', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-vvu2")].metadata.name}\'', 'item': u'cstor-sparse-pool-vvu2', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-vvu2")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-29 22:32:13.761017', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-vvu2-689f44b89c\")].metadata.name}'", "delta": "0:00:00.355872", "end": "2018-12-29 22:32:15.542752", "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-vvu2\")].metadata.name}'", "delta": "0:00:00.353595", "end": "2018-12-29 22:32:14.114612", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-vvu2\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-vvu2", "rc": 0, "start": "2018-12-29 22:32:13.761017", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-vvu2-689f44b89c", "stdout_lines": ["cstor-sparse-pool-vvu2-689f44b89c"]}, "rc": 0, "start": "2018-12-29 22:32:15.186880", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-vvu2-689f44b89c-scmfp", "stdout_lines": ["cstor-sparse-pool-vvu2-689f44b89c-scmfp"]}

TASK [set_fact] ****************************************************************
2018-12-29T22:32:15.580722 (delta: 1.430524)         elapsed: 30.589483 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pool_pod_named_list": []}, "changed": false}

TASK [Build a list of replica pods] ********************************************
2018-12-29T22:32:15.630542 (delta: 0.049789)         elapsed: 30.639303 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-l8zg-5448f995d6-kj878', '_ansible_item_result': True, u'delta': u'0:00:00.356162', 'stdout_lines': [u'cstor-sparse-pool-l8zg-5448f995d6-kj878'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-l8zg-5448f995d6', '_ansible_item_result': True, u'delta': u'0:00:00.351740', 'stdout_lines': [u'cstor-sparse-pool-l8zg-5448f995d6'], '_ansible_item_label': u'cstor-sparse-pool-l8zg', u'end': u'2018-12-29 22:32:13.216133', '_ansible_no_log': False, u'start': u'2018-12-29 22:32:12.864393', u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-l8zg")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-l8zg', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-l8zg")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2018-12-29 22:32:14.616700', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-l8zg-5448f995d6")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-l8zg-5448f995d6', '_ansible_item_result': True, u'delta': u'0:00:00.351740', 'stdout_lines': [u'cstor-sparse-pool-l8zg-5448f995d6'], '_ansible_item_label': u'cstor-sparse-pool-l8zg', u'end': u'2018-12-29 22:32:13.216133', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-l8zg")].metadata.name}\'', u'start': u'2018-12-29 22:32:12.864393', 'item': u'cstor-sparse-pool-l8zg', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-l8zg")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-l8zg-5448f995d6")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-29 22:32:14.260538', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_pod_named_list": ["cstor-sparse-pool-l8zg-5448f995d6-kj878"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-l8zg-5448f995d6\")].metadata.name}'", "delta": "0:00:00.356162", "end": "2018-12-29 22:32:14.616700", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-l8zg-5448f995d6\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-l8zg\")].metadata.name}'", "delta": "0:00:00.351740", "end": "2018-12-29 22:32:13.216133", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-l8zg\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-l8zg", "rc": 0, "start": "2018-12-29 22:32:12.864393", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-l8zg-5448f995d6", "stdout_lines": ["cstor-sparse-pool-l8zg-5448f995d6"]}, "rc": 0, "start": "2018-12-29 22:32:14.260538", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-l8zg-5448f995d6-kj878", "stdout_lines": ["cstor-sparse-pool-l8zg-5448f995d6-kj878"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-llt9-5d587d7fdf-fgsbf', '_ansible_item_result': True, u'delta': u'0:00:00.356297', 'stdout_lines': [u'cstor-sparse-pool-llt9-5d587d7fdf-fgsbf'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-llt9-5d587d7fdf', '_ansible_item_result': True, u'delta': u'0:00:00.356448', 'stdout_lines': [u'cstor-sparse-pool-llt9-5d587d7fdf'], '_ansible_item_label': u'cstor-sparse-pool-llt9', u'end': u'2018-12-29 22:32:13.667757', '_ansible_no_log': False, u'start': u'2018-12-29 22:32:13.311309', u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-llt9")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-llt9', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-llt9")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2018-12-29 22:32:15.090879', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-llt9-5d587d7fdf")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-llt9-5d587d7fdf', '_ansible_item_result': True, u'delta': u'0:00:00.356448', 'stdout_lines': [u'cstor-sparse-pool-llt9-5d587d7fdf'], '_ansible_item_label': u'cstor-sparse-pool-llt9', u'end': u'2018-12-29 22:32:13.667757', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-llt9")].metadata.name}\'', u'start': u'2018-12-29 22:32:13.311309', 'item': u'cstor-sparse-pool-llt9', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-llt9")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-llt9-5d587d7fdf")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-29 22:32:14.734582', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_pod_named_list": ["cstor-sparse-pool-l8zg-5448f995d6-kj878", "cstor-sparse-pool-llt9-5d587d7fdf-fgsbf"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-llt9-5d587d7fdf\")].metadata.name}'", "delta": "0:00:00.356297", "end": "2018-12-29 22:32:15.090879", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-llt9-5d587d7fdf\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-llt9\")].metadata.name}'", "delta": "0:00:00.356448", "end": "2018-12-29 22:32:13.667757", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-llt9\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-llt9", "rc": 0, "start": "2018-12-29 22:32:13.311309", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-llt9-5d587d7fdf", "stdout_lines": ["cstor-sparse-pool-llt9-5d587d7fdf"]}, "rc": 0, "start": "2018-12-29 22:32:14.734582", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-llt9-5d587d7fdf-fgsbf", "stdout_lines": ["cstor-sparse-pool-llt9-5d587d7fdf-fgsbf"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-vvu2-689f44b89c-scmfp', '_ansible_item_result': True, u'delta': u'0:00:00.355872', 'stdout_lines': [u'cstor-sparse-pool-vvu2-689f44b89c-scmfp'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-vvu2-689f44b89c', '_ansible_item_result': True, u'delta': u'0:00:00.353595', 'stdout_lines': [u'cstor-sparse-pool-vvu2-689f44b89c'], '_ansible_item_label': u'cstor-sparse-pool-vvu2', u'end': u'2018-12-29 22:32:14.114612', '_ansible_no_log': False, u'start': u'2018-12-29 22:32:13.761017', u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-vvu2")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-vvu2', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-vvu2")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2018-12-29 22:32:15.542752', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-vvu2-689f44b89c")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-vvu2-689f44b89c', '_ansible_item_result': True, u'delta': u'0:00:00.353595', 'stdout_lines': [u'cstor-sparse-pool-vvu2-689f44b89c'], '_ansible_item_label': u'cstor-sparse-pool-vvu2', u'end': u'2018-12-29 22:32:14.114612', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-vvu2")].metadata.name}\'', u'start': u'2018-12-29 22:32:13.761017', 'item': u'cstor-sparse-pool-vvu2', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-vvu2")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-vvu2-689f44b89c")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-29 22:32:15.186880', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_pod_named_list": ["cstor-sparse-pool-l8zg-5448f995d6-kj878", "cstor-sparse-pool-llt9-5d587d7fdf-fgsbf", "cstor-sparse-pool-vvu2-689f44b89c-scmfp"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-vvu2-689f44b89c\")].metadata.name}'", "delta": "0:00:00.355872", "end": "2018-12-29 22:32:15.542752", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-vvu2-689f44b89c\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-vvu2\")].metadata.name}'", "delta": "0:00:00.353595", "end": "2018-12-29 22:32:14.114612", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs -l app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-vvu2\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-vvu2", "rc": 0, "start": "2018-12-29 22:32:13.761017", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-vvu2-689f44b89c", "stdout_lines": ["cstor-sparse-pool-vvu2-689f44b89c"]}, "rc": 0, "start": "2018-12-29 22:32:15.186880", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-vvu2-689f44b89c-scmfp", "stdout_lines": ["cstor-sparse-pool-vvu2-689f44b89c-scmfp"]}}

TASK [Get pool name from first pool pod] ***************************************
2018-12-29T22:32:15.736370 (delta: 0.105801)         elapsed: 30.745131 ******* 
changed: [127.0.0.1] => (item=cstor-sparse-pool-l8zg-5448f995d6-kj878) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-l8zg-5448f995d6-kj878 -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.452960", "end": "2018-12-29 22:32:16.299450", "item": "cstor-sparse-pool-l8zg-5448f995d6-kj878", "rc": 0, "start": "2018-12-29 22:32:15.846490", "stderr": "", "stderr_lines": [], "stdout": "cstor-985f03de-0b99-11e9-9e8d-06290e1d565c", "stdout_lines": ["cstor-985f03de-0b99-11e9-9e8d-06290e1d565c"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-llt9-5d587d7fdf-fgsbf) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-llt9-5d587d7fdf-fgsbf -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.484744", "end": "2018-12-29 22:32:16.902584", "item": "cstor-sparse-pool-llt9-5d587d7fdf-fgsbf", "rc": 0, "start": "2018-12-29 22:32:16.417840", "stderr": "", "stderr_lines": [], "stdout": "cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c", "stdout_lines": ["cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-vvu2-689f44b89c-scmfp) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-vvu2-689f44b89c-scmfp -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.431630", "end": "2018-12-29 22:32:17.427965", "item": "cstor-sparse-pool-vvu2-689f44b89c-scmfp", "rc": 0, "start": "2018-12-29 22:32:16.996335", "stderr": "", "stderr_lines": [], "stdout": "cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c", "stdout_lines": ["cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c"]}

TASK [set_fact] ****************************************************************
2018-12-29T22:32:17.464117 (delta: 1.727717)         elapsed: 32.472878 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"pool_names_list": []}, "changed": false}

TASK [Build a list of replica pods] ********************************************
2018-12-29T22:32:17.514321 (delta: 0.050175)         elapsed: 32.523082 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-985f03de-0b99-11e9-9e8d-06290e1d565c', '_ansible_item_result': True, u'delta': u'0:00:00.452960', 'stdout_lines': [u'cstor-985f03de-0b99-11e9-9e8d-06290e1d565c'], '_ansible_item_label': u'cstor-sparse-pool-l8zg-5448f995d6-kj878', u'end': u'2018-12-29 22:32:16.299450', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl exec cstor-sparse-pool-l8zg-5448f995d6-kj878 -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", 'item': u'cstor-sparse-pool-l8zg-5448f995d6-kj878', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u"kubectl exec cstor-sparse-pool-l8zg-5448f995d6-kj878 -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-29 22:32:15.846490', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_names_list": ["cstor-985f03de-0b99-11e9-9e8d-06290e1d565c"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-l8zg-5448f995d6-kj878 -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.452960", "end": "2018-12-29 22:32:16.299450", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl exec cstor-sparse-pool-l8zg-5448f995d6-kj878 -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-l8zg-5448f995d6-kj878", "rc": 0, "start": "2018-12-29 22:32:15.846490", "stderr": "", "stderr_lines": [], "stdout": "cstor-985f03de-0b99-11e9-9e8d-06290e1d565c", "stdout_lines": ["cstor-985f03de-0b99-11e9-9e8d-06290e1d565c"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c', '_ansible_item_result': True, u'delta': u'0:00:00.484744', 'stdout_lines': [u'cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c'], '_ansible_item_label': u'cstor-sparse-pool-llt9-5d587d7fdf-fgsbf', u'end': u'2018-12-29 22:32:16.902584', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl exec cstor-sparse-pool-llt9-5d587d7fdf-fgsbf -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", 'item': u'cstor-sparse-pool-llt9-5d587d7fdf-fgsbf', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u"kubectl exec cstor-sparse-pool-llt9-5d587d7fdf-fgsbf -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-29 22:32:16.417840', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_names_list": ["cstor-985f03de-0b99-11e9-9e8d-06290e1d565c", "cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-llt9-5d587d7fdf-fgsbf -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.484744", "end": "2018-12-29 22:32:16.902584", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl exec cstor-sparse-pool-llt9-5d587d7fdf-fgsbf -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-llt9-5d587d7fdf-fgsbf", "rc": 0, "start": "2018-12-29 22:32:16.417840", "stderr": "", "stderr_lines": [], "stdout": "cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c", "stdout_lines": ["cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c', '_ansible_item_result': True, u'delta': u'0:00:00.431630', 'stdout_lines': [u'cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c'], '_ansible_item_label': u'cstor-sparse-pool-vvu2-689f44b89c-scmfp', u'end': u'2018-12-29 22:32:17.427965', '_ansible_no_log': False, 'failed': False, u'cmd': u"kubectl exec cstor-sparse-pool-vvu2-689f44b89c-scmfp -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", 'item': u'cstor-sparse-pool-vvu2-689f44b89c-scmfp', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u"kubectl exec cstor-sparse-pool-vvu2-689f44b89c-scmfp -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2018-12-29 22:32:16.996335', '_ansible_ignore_errors': None}) => {"ansible_facts": {"pool_names_list": ["cstor-985f03de-0b99-11e9-9e8d-06290e1d565c", "cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c", "cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-vvu2-689f44b89c-scmfp -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "delta": "0:00:00.431630", "end": "2018-12-29 22:32:17.427965", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl exec cstor-sparse-pool-vvu2-689f44b89c-scmfp -n openebs -c cstor-pool zpool list | awk 'NR==2 {print $1}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-vvu2-689f44b89c-scmfp", "rc": 0, "start": "2018-12-29 22:32:16.996335", "stderr": "", "stderr_lines": [], "stdout": "cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c", "stdout_lines": ["cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c"]}}

TASK [debug] *******************************************************************
2018-12-29T22:32:17.586923 (delta: 0.072572)         elapsed: 32.595684 ******* 
ok: [127.0.0.1] => (item=cstor-985f03de-0b99-11e9-9e8d-06290e1d565c) => {
    "msg": "cstor-985f03de-0b99-11e9-9e8d-06290e1d565c are pool name"
}
ok: [127.0.0.1] => (item=cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c) => {
    "msg": "cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c are pool name"
}
ok: [127.0.0.1] => (item=cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c) => {
    "msg": "cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c are pool name"
}

TASK [Disable compression factor on pool/volumes] ******************************
2018-12-29T22:32:17.676817 (delta: 0.089861)         elapsed: 32.685578 ******* 
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-l8zg-5448f995d6-kj878', u'cstor-985f03de-0b99-11e9-9e8d-06290e1d565c']) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-l8zg-5448f995d6-kj878 -n openebs -c cstor-pool zfs set compression=off cstor-985f03de-0b99-11e9-9e8d-06290e1d565c/pvc-8bd18cc7-0bb9-11e9-9e8d-06290e1d565c", "delta": "0:00:00.498108", "end": "2018-12-29 22:32:18.312012", "item": ["cstor-sparse-pool-l8zg-5448f995d6-kj878", "cstor-985f03de-0b99-11e9-9e8d-06290e1d565c"], "rc": 0, "start": "2018-12-29 22:32:17.813904", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-llt9-5d587d7fdf-fgsbf', u'cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c']) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-llt9-5d587d7fdf-fgsbf -n openebs -c cstor-pool zfs set compression=off cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c/pvc-8bd18cc7-0bb9-11e9-9e8d-06290e1d565c", "delta": "0:00:00.504638", "end": "2018-12-29 22:32:18.910752", "item": ["cstor-sparse-pool-llt9-5d587d7fdf-fgsbf", "cstor-985e0e15-0b99-11e9-9e8d-06290e1d565c"], "rc": 0, "start": "2018-12-29 22:32:18.406114", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=[u'cstor-sparse-pool-vvu2-689f44b89c-scmfp', u'cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c']) => {"changed": true, "cmd": "kubectl exec cstor-sparse-pool-vvu2-689f44b89c-scmfp -n openebs -c cstor-pool zfs set compression=off cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c/pvc-8bd18cc7-0bb9-11e9-9e8d-06290e1d565c", "delta": "0:00:00.434113", "end": "2018-12-29 22:32:19.438684", "item": ["cstor-sparse-pool-vvu2-689f44b89c-scmfp", "cstor-985e9dd1-0b99-11e9-9e8d-06290e1d565c"], "rc": 0, "start": "2018-12-29 22:32:19.004571", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [set_fact] ****************************************************************
2018-12-29T22:32:19.474161 (delta: 1.797313)         elapsed: 34.482922 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"value_num": "9375"}, "changed": false}

TASK [set_fact] ****************************************************************
2018-12-29T22:32:19.527529 (delta: 0.05334)         elapsed: 34.53629 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [debug] *******************************************************************
2018-12-29T22:32:19.560889 (delta: 0.033334)         elapsed: 34.56965 ******** 
ok: [127.0.0.1] => {
    "msg": "9375"
}

TASK [Replace the data sample size with 90% of pvc size in fio-write.yml] ******
2018-12-29T22:32:19.614191 (delta: 0.053274)         elapsed: 34.622952 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the data sample size with 90% 0f pvc size in fio-read.yml] *******
2018-12-29T22:32:19.759067 (delta: 0.144847)         elapsed: 34.767828 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the default I/O test duration with user-defined period] **********
2018-12-29T22:32:19.901458 (delta: 0.142361)         elapsed: 34.910219 ******* 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Deploy fio write test job] ***********************************************
2018-12-29T22:32:20.043249 (delta: 0.14176)         elapsed: 35.05201 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f fio-write.yml -n fio", "delta": "0:00:00.430076", "end": "2018-12-29 22:32:20.582910", "rc": 0, "start": "2018-12-29 22:32:20.152834", "stderr": "", "stderr_lines": [], "stdout": "configmap/basic created\njob.batch/fio created", "stdout_lines": ["configmap/basic created", "job.batch/fio created"]}

TASK [Fetch the pod name in fio] ***********************************************
2018-12-29T22:32:20.622964 (delta: 0.579685)         elapsed: 35.631725 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n fio -l name=fio-write -o custom-columns=:metadata.name --no-headers", "delta": "0:00:00.354694", "end": "2018-12-29 22:32:21.085378", "rc": 0, "start": "2018-12-29 22:32:20.730684", "stderr": "", "stderr_lines": [], "stdout": "fio-nwzqs", "stdout_lines": ["fio-nwzqs"]}

TASK [Check the status of pod] *************************************************
2018-12-29T22:32:21.121374 (delta: 0.498383)         elapsed: 36.130135 ******* 
FAILED - RETRYING: Check the status of pod (100 retries left).
FAILED - RETRYING: Check the status of pod (99 retries left).
FAILED - RETRYING: Check the status of pod (98 retries left).
FAILED - RETRYING: Check the status of pod (97 retries left).
FAILED - RETRYING: Check the status of pod (96 retries left).
FAILED - RETRYING: Check the status of pod (95 retries left).
FAILED - RETRYING: Check the status of pod (94 retries left).
FAILED - RETRYING: Check the status of pod (93 retries left).
changed: [127.0.0.1] => {"attempts": 9, "changed": true, "cmd": "kubectl get po fio-nwzqs -n fio -o jsonpath={.status.phase}", "delta": "0:00:00.357241", "end": "2018-12-29 22:33:05.177190", "rc": 0, "start": "2018-12-29 22:33:04.819949", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Fetch the remaining space from application side] *************************
2018-12-29T22:33:05.214561 (delta: 44.093158)         elapsed: 80.223322 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec fio-nwzqs -n fio df /datadir | awk 'NR==2 {print $4}'", "delta": "0:00:00.410325", "end": "2018-12-29 22:33:05.734678", "rc": 0, "start": "2018-12-29 22:33:05.324353", "stderr": "", "stderr_lines": [], "stdout": "198416", "stdout_lines": ["198416"]}

TASK [set_fact] ****************************************************************
2018-12-29T22:33:05.770229 (delta: 0.555639)         elapsed: 80.77899 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"space_left_mb": "10"}, "changed": false}

TASK [set_fact] ****************************************************************
2018-12-29T22:33:05.822343 (delta: 0.052084)         elapsed: 80.831104 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"fill_value": "5"}, "changed": false}

TASK [Replace the space_left in commands.sh file with calculated value] ********
2018-12-29T22:33:05.878476 (delta: 0.056103)         elapsed: 80.887237 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the space_left in commands.sh file with calculated value] ********
2018-12-29T22:33:06.022833 (delta: 0.144323)         elapsed: 81.031594 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if fio write job is completed] *************************************
2018-12-29T22:33:06.056133 (delta: 0.033272)         elapsed: 81.064894 ******* 
FAILED - RETRYING: Check if fio write job is completed (900 retries left).
FAILED - RETRYING: Check if fio write job is completed (899 retries left).
FAILED - RETRYING: Check if fio write job is completed (898 retries left).
FAILED - RETRYING: Check if fio write job is completed (897 retries left).
FAILED - RETRYING: Check if fio write job is completed (896 retries left).
FAILED - RETRYING: Check if fio write job is completed (895 retries left).
FAILED - RETRYING: Check if fio write job is completed (894 retries left).
FAILED - RETRYING: Check if fio write job is completed (893 retries left).
FAILED - RETRYING: Check if fio write job is completed (892 retries left).
FAILED - RETRYING: Check if fio write job is completed (891 retries left).
FAILED - RETRYING: Check if fio write job is completed (890 retries left).
FAILED - RETRYING: Check if fio write job is completed (889 retries left).
FAILED - RETRYING: Check if fio write job is completed (888 retries left).
FAILED - RETRYING: Check if fio write job is completed (887 retries left).
FAILED - RETRYING: Check if fio write job is completed (886 retries left).
FAILED - RETRYING: Check if fio write job is completed (885 retries left).
changed: [127.0.0.1] => {"attempts": 17, "changed": true, "cmd": "kubectl get pods -n fio -o jsonpath='{.items[?(@.metadata.labels.name==\"fio-write\")].status.containerStatuses[*].state.terminated.reason}'", "delta": "0:00:00.355104", "end": "2018-12-29 22:49:14.825104", "rc": 0, "start": "2018-12-29 22:49:14.470000", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Verify the fio logs to check if run is complete w/o errors] **************
2018-12-29T22:49:14.861835 (delta: 968.80567)         elapsed: 1049.870596 **** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl logs fio-nwzqs -n fio | grep -i error | cut -d \":\" -f 2 | sort | uniq", "delta": "0:00:00.366138", "end": "2018-12-29 22:49:15.337033", "failed_when_result": false, "rc": 0, "start": "2018-12-29 22:49:14.970895", "stderr": "", "stderr_lines": [], "stdout": " 0,", "stdout_lines": [" 0,"]}

TASK [Replace the default I/O test duration with user-defined period] **********
2018-12-29T22:49:15.374476 (delta: 0.512614)         elapsed: 1050.383237 ***** 
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Checking for configmap] **************************************************
2018-12-29T22:49:15.510376 (delta: 0.13587)         elapsed: 1050.519137 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get configmap -n fio", "delta": "0:00:00.352705", "end": "2018-12-29 22:49:15.967585", "rc": 0, "start": "2018-12-29 22:49:15.614880", "stderr": "", "stderr_lines": [], "stdout": "NAME    DATA   AGE\nbasic   1      16m", "stdout_lines": ["NAME    DATA   AGE", "basic   1      16m"]}

TASK [Create the configmap] ****************************************************
2018-12-29T22:49:16.002202 (delta: 0.4918)         elapsed: 1051.010963 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create cm commandfile --from-file=commands.sh -n fio", "delta": "0:00:00.348789", "end": "2018-12-29 22:49:16.479560", "rc": 0, "start": "2018-12-29 22:49:16.130771", "stderr": "", "stderr_lines": [], "stdout": "configmap/commandfile created", "stdout_lines": ["configmap/commandfile created"]}

TASK [Verify Successfull creation of configmap] ********************************
2018-12-29T22:49:16.528628 (delta: 0.526397)         elapsed: 1051.537389 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl describe cm commandfile -n fio", "delta": "0:00:00.354084", "end": "2018-12-29 22:49:16.986847", "rc": 0, "start": "2018-12-29 22:49:16.632763", "stderr": "", "stderr_lines": [], "stdout": "Name:         commandfile\nNamespace:    fio\nLabels:       <none>\nAnnotations:  <none>\n\nData\n====\ncommands.sh:\n----\ncd datadir\nerror_check()\n{\n  if [ $? != 0 ]\n  then\n    echo \"error caught\"\n    exit 1\n  fi\n}\n\nperform_data_write()\n{\n        value=5\n  i=0\n  while [ $i -le $value ]\n  do\n    ls -all\n    error_check\n    touch file$i\n    error_check\n    dd if=/dev/urandom of=file$i bs=4k count=5000\n    error_check\n    sync\n    read_data\n    i=$(( i + 1 ))\n    error_check\n  done\n}\nread_data()\n{\n  touch testfile\n  error_check\n  echo \"OpenEBS Released newer version\"\n  error_check\n  cat testfile\n  error_check\n  rm testfile\n}\nperform_data_write\n\nEvents:  <none>", "stdout_lines": ["Name:         commandfile", "Namespace:    fio", "Labels:       <none>", "Annotations:  <none>", "", "Data", "====", "commands.sh:", "----", "cd datadir", "error_check()", "{", "  if [ $? != 0 ]", "  then", "    echo \"error caught\"", "    exit 1", "  fi", "}", "", "perform_data_write()", "{", "        value=5", "  i=0", "  while [ $i -le $value ]", "  do", "    ls -all", "    error_check", "    touch file$i", "    error_check", "    dd if=/dev/urandom of=file$i bs=4k count=5000", "    error_check", "    sync", "    read_data", "    i=$(( i + 1 ))", "    error_check", "  done", "}", "read_data()", "{", "  touch testfile", "  error_check", "  echo \"OpenEBS Released newer version\"", "  error_check", "  cat testfile", "  error_check", "  rm testfile", "}", "perform_data_write", "", "Events:  <none>"]}

TASK [Deploy fio read test job] ************************************************
2018-12-29T22:49:17.025377 (delta: 0.496724)         elapsed: 1052.034138 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f fio-read.yml -n fio", "delta": "0:00:00.425646", "end": "2018-12-29 22:49:17.556539", "rc": 0, "start": "2018-12-29 22:49:17.130893", "stderr": "", "stderr_lines": [], "stdout": "configmap/basic-read created\njob.batch/fio-read created", "stdout_lines": ["configmap/basic-read created", "job.batch/fio-read created"]}

TASK [Obtaining the fio read job pod name] *************************************
2018-12-29T22:49:17.594541 (delta: 0.569137)         elapsed: 1052.603302 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n fio -l name=fio-read -o custom-columns=:metadata.name --no-headers", "delta": "0:00:00.351846", "end": "2018-12-29 22:49:18.051477", "rc": 0, "start": "2018-12-29 22:49:17.699631", "stderr": "", "stderr_lines": [], "stdout": "fio-read-56jsg", "stdout_lines": ["fio-read-56jsg"]}

TASK [Check if fio read job is completed] **************************************
2018-12-29T22:49:18.086295 (delta: 0.491723)         elapsed: 1053.095056 ***** 
FAILED - RETRYING: Check if fio read job is completed (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n fio -o jsonpath='{.items[?(@.metadata.labels.name==\"fio-read\")].status.containerStatuses[*].state.terminated.reason}'", "delta": "0:00:00.354788", "end": "2018-12-29 22:50:19.049178", "rc": 0, "start": "2018-12-29 22:50:18.694390", "stderr": "", "stderr_lines": [], "stdout": "Completed", "stdout_lines": ["Completed"]}

TASK [Verify the data integrity check] *****************************************
2018-12-29T22:50:19.085254 (delta: 60.998929)         elapsed: 1114.094015 **** 
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "kubectl logs fio-read-56jsg -n fio | grep -i error | cut -d \":\" -f 2 | sort | uniq", "delta": "0:00:00.363386", "end": "2018-12-29 22:50:19.556112", "failed_when_result": true, "rc": 0, "start": "2018-12-29 22:50:19.192726", "stderr": "", "stderr_lines": [], "stdout": " 84,\r\n pid=15, err=84/file", "stdout_lines": [" 84,", " pid=15, err=84/file"]}

TASK [set_fact] ****************************************************************
2018-12-29T22:50:19.593746 (delta: 0.508462)         elapsed: 1114.602507 ***** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Fail"}, "changed": false}

TASK [include_tasks] ***********************************************************
2018-12-29T22:50:19.642028 (delta: 0.048255)         elapsed: 1114.650789 ***** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2018-12-29T22:50:19.704623 (delta: 0.062567)         elapsed: 1114.713384 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2018-12-29T22:50:19.738575 (delta: 0.033922)         elapsed: 1114.747336 ***** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2018-12-29T22:50:19.772079 (delta: 0.033476)         elapsed: 1114.78084 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2018-12-29T22:50:19.805625 (delta: 0.033517)         elapsed: 1114.814386 ***** 
changed: [127.0.0.1] => {"changed": true, "checksum": "b6a18896984a5fcca00b4f2ce1a2b1a21ccf9ff8", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "d759608761d7e7a9e4117ff629d8cb25", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1546123819.84-105837754829804/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2018-12-29T22:50:20.595434 (delta: 0.78978)         elapsed: 1115.604195 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.283000", "end": "2018-12-29 22:50:20.986323", "rc": 0, "start": "2018-12-29 22:50:20.703323", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: fio-data-integrity \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Fail ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: fio-data-integrity ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Fail "]}

TASK [Apply the litmus result CR] **********************************************
2018-12-29T22:50:21.020586 (delta: 0.425122)         elapsed: 1116.029347 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.428970", "end": "2018-12-29 22:50:21.556676", "failed_when_result": false, "rc": 0, "start": "2018-12-29 22:50:21.127706", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/fio-data-integrity configured", "stdout_lines": ["litmusresult.litmus.io/fio-data-integrity configured"]}

TASK [Wait (soak) for I/O on pools] ********************************************
2018-12-29T22:50:21.594098 (delta: 0.573481)         elapsed: 1116.602859 ***** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 1000, "path": null, "port": null, "search_regex": null, "state": "started"}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=62   changed=41   unreachable=0    failed=1   

2018-12-29T23:07:01.800708 (delta: 1000.20658)         elapsed: 2116.809469 *** 
=============================================================================== 
```
```
**fio read job logs**
kubectl logs -f fio-read-56jsg -n fio

Running basic-rw test with size=9375m, runtime=60... Wait for results !!

fio: got pattern '00', wanted '80'. Bad bits 1
fio: bad pattern block offset 1
fio: verify type mismatch (0 media, 14 given)
fio: pid=15, err=84/file:io_u.c:1805, func=io_u_sync_complete, error=Invalid or incomplete multibyte or wide character
{
  "fio version" : "fio-2.2.10",
  "timestamp" : 1546123775,
  "time" : "Sat Dec 29 22:49:35 2018",
  "jobs" : [
    {
      "jobname" : "basic-fio",
      "groupid" : 0,
      "error" : 84,
      "eta" : 2147483647,
      "elapsed" : 1,
      "read" : {
        "io_bytes" : 36,
        "bw" : 3000,
        "iops" : 750.00,
        "runtime" : 12,
        "total_ios" : 9,
        "short_ios" : 0,
        "drop_ios" : 0,
        "slat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00
        },
        "clat" : {
          "min" : 1,
          "max" : 6085,
          "mean" : 1293.56,
          "stddev" : 2561.32,
          "percentile" : {
            "1.000000" : 1,
            "5.000000" : 1,
            "10.000000" : 1,
            "20.000000" : 1,
            "30.000000" : 1,
            "40.000000" : 2,
            "50.000000" : 2,
            "60.000000" : 3,
            "70.000000" : 23,
            "80.000000" : 5536,
            "90.000000" : 6112,
            "95.000000" : 6112,
            "99.000000" : 6112,
            "99.500000" : 6112,
            "99.900000" : 6112,
            "99.950000" : 6112,
            "99.990000" : 6112,
            "0.00" : 0,
            "0.00" : 0,
            "0.00" : 0
          }
        },
        "lat" : {
          "min" : 1,
          "max" : 6086,
          "mean" : 1293.89,
          "stddev" : 2561.43
        },
        "bw_min" : 0,
        "bw_max" : 0,
        "bw_agg" : 0.00,
        "bw_mean" : 0.00,
        "bw_dev" : 0.00
      },
      "write" : {
        "io_bytes" : 0,
        "bw" : 0,
        "iops" : 0.00,
        "runtime" : 0,
        "total_ios" : 0,
        "short_ios" : 0,
        "drop_ios" : 0,
        "slat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00
        },
        "clat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00,
          "percentile" : {
            "1.000000" : 0,
            "5.000000" : 0,
            "10.000000" : 0,
            "20.000000" : 0,
            "30.000000" : 0,
            "40.000000" : 0,
            "50.000000" : 0,
            "60.000000" : 0,
            "70.000000" : 0,
            "80.000000" : 0,
            "90.000000" : 0,
            "95.000000" : 0,
            "99.000000" : 0,
            "99.500000" : 0,
            "99.900000" : 0,
            "99.950000" : 0,
            "99.990000" : 0,
            "0.00" : 0,
            "0.00" : 0,
            "0.00" : 0
          }
        },
        "lat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00
        },
        "bw_min" : 0,
        "bw_max" : 0,
        "bw_agg" : 0.00,
        "bw_mean" : 0.00,
        "bw_dev" : 0.00
      },
      "trim" : {
        "io_bytes" : 0,
        "bw" : 0,
        "iops" : 0.00,
        "runtime" : 0,
        "total_ios" : 0,
        "short_ios" : 0,
        "drop_ios" : 0,
        "slat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00
        },
        "clat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00,
          "percentile" : {
            "1.000000" : 0,
            "5.000000" : 0,
            "10.000000" : 0,
            "20.000000" : 0,
            "30.000000" : 0,
            "40.000000" : 0,
            "50.000000" : 0,
            "60.000000" : 0,
            "70.000000" : 0,
            "80.000000" : 0,
            "90.000000" : 0,
            "95.000000" : 0,
            "99.000000" : 0,
            "99.500000" : 0,
            "99.900000" : 0,
            "99.950000" : 0,
            "99.990000" : 0,
            "0.00" : 0,
            "0.00" : 0,
            "0.00" : 0
          }
        },
        "lat" : {
          "min" : 0,
          "max" : 0,
          "mean" : 0.00,
          "stddev" : 0.00
        },
        "bw_min" : 0,
        "bw_max" : 0,
        "bw_agg" : 0.00,
        "bw_mean" : 0.00,
        "bw_dev" : 0.00
      },
      "usr_cpu" : 0.00,
      "sys_cpu" : 0.00,
      "ctx" : 6,
      "majf" : 0,
      "minf" : 19,
      "iodepth_level" : {
        "1" : 100.00,
        "2" : 0.00,
        "4" : 0.00,
        "8" : 0.00,
        "16" : 0.00,
        "32" : 0.00,
        ">=64" : 0.00
      },
      "latency_us" : {
        "2" : 33.33,
        "4" : 33.33,
        "10" : 0.00,
        "20" : 0.00,
        "50" : 11.11,
        "100" : 0.00,
        "250" : 0.00,
        "500" : 0.00,
        "750" : 0.00,
        "1000" : 0.00
      },
      "latency_ms" : {
        "2" : 0.00,
        "4" : 0.00,
        "10" : 22.22,
        "20" : 0.00,
        "50" : 0.00,
        "100" : 0.00,
        "250" : 0.00,
        "500" : 0.00,
        "750" : 0.00,
        "1000" : 0.00,
        "2000" : 0.00,
        ">=2000" : 0.00
      },
      "latency_depth" : 1,
      "latency_target" : 0,
      "latency_percentile" : 100.00,
      "latency_window" : 0
    }
  ],
  "disk_util" : [
    {
      "name" : "sda",
      "read_ios" : 0,
      "write_ios" : 0,
      "read_merges" : 0,
      "write_merges" : 0,
      "read_ticks" : 0,
      "write_ticks" : 0,
      "in_queue" : 0,
      "util" : 0.00
    }
  ]
}
Filesystem      Size  Used Avail Use% Mounted on
overlay         125G   12G  113G  10% /
tmpfs           7.9G     0  7.9G   0% /dev
tmpfs           7.9G     0  7.9G   0% /sys/fs/cgroup
/dev/sda        9.4G  9.2G  192M  99% /datadir
/dev/xvda1      125G   12G  113G  10% /etc/hosts
shm              64M     0   64M   0% /dev/shm
tmpfs           7.9G   12K  7.9G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs           7.9G     0  7.9G   0% /sys/firmware
total 9602396
drwxr-xr-x 3 root root       4096 Dec 29 22:33 .
drwxr-xr-x 1 root root       4096 Dec 29 22:49 ..
-rw-r--r-- 1 root root 9830400000 Dec 29 22:34 basic-fio.0.0
drwx------ 2 root root      16384 Dec 29 22:32 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.57593 s, 13.0 MB/s
OpenEBS Released newer version
total 9622396
drwxr-xr-x 3 root root       4096 Dec 29 22:49 .
drwxr-xr-x 1 root root       4096 Dec 29 22:49 ..
-rw-r--r-- 1 root root 9830400000 Dec 29 22:34 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file0
drwx------ 2 root root      16384 Dec 29 22:32 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.61315 s, 12.7 MB/s
OpenEBS Released newer version
total 9642396
drwxr-xr-x 3 root root       4096 Dec 29 22:49 .
drwxr-xr-x 1 root root       4096 Dec 29 22:49 ..
-rw-r--r-- 1 root root 9830400000 Dec 29 22:34 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file0
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file1
drwx------ 2 root root      16384 Dec 29 22:32 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.60181 s, 12.8 MB/s
OpenEBS Released newer version
total 9662396
drwxr-xr-x 3 root root       4096 Dec 29 22:49 .
drwxr-xr-x 1 root root       4096 Dec 29 22:49 ..
-rw-r--r-- 1 root root 9830400000 Dec 29 22:34 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file0
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file1
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file2
drwx------ 2 root root      16384 Dec 29 22:32 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.58269 s, 12.9 MB/s
OpenEBS Released newer version
total 9682396
drwxr-xr-x 3 root root       4096 Dec 29 22:49 .
drwxr-xr-x 1 root root       4096 Dec 29 22:49 ..
-rw-r--r-- 1 root root 9830400000 Dec 29 22:34 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file0
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file1
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file2
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file3
drwx------ 2 root root      16384 Dec 29 22:32 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.6142 s, 12.7 MB/s
OpenEBS Released newer version
total 9702396
drwxr-xr-x 3 root root       4096 Dec 29 22:49 .
drwxr-xr-x 1 root root       4096 Dec 29 22:49 ..
-rw-r--r-- 1 root root 9830400000 Dec 29 22:34 basic-fio.0.0
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file0
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file1
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file2
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file3
-rw-r--r-- 1 root root   20480000 Dec 29 22:49 file4
drwx------ 2 root root      16384 Dec 29 22:32 lost+found
5000+0 records in
5000+0 records out
20480000 bytes (20 MB, 20 MiB) copied, 1.5832 s, 12.9 MB/s
OpenEBS Released newer version
Filesystem      Size  Used Avail Use% Mounted on
overlay         125G   12G  113G  10% /
tmpfs           7.9G     0  7.9G   0% /dev
tmpfs           7.9G     0  7.9G   0% /sys/fs/cgroup
/dev/sda        9.4G  9.3G   75M 100% /datadir
/dev/xvda1      125G   12G  113G  10% /etc/hosts
shm              64M     0   64M   0% /dev/shm
tmpfs           7.9G   12K  7.9G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs           7.9G     0  7.9G   0% /sys/firmware
```