### PR TITLE
Changed chaostype value in update_litmus_resource_result task

### DIFF
--- a/apps/percona/chaos/openebs_pool_failure/test.yml
+++ b/apps/percona/chaos/openebs_pool_failure/test.yml
@@ -54,7 +54,7 @@
         - include_tasks: /common/utils/update_litmus_result_resource.yml
           vars:
             status: 'SOT'
-            chaostype: "{{ chaosutil.split('.')[0] }}"
+            chaostype: "{{ test_name }}"
 
         ## DISPLAY APP INFORMATION 
  


### PR DESCRIPTION
Signed-off-by: vibhor995 <vibhor.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Special notes for your reviewer**:
@nsathyaseelan 

logs:

```+ kubectl logs -f openebs-pool-failure-nwh8g-fwwq8 -n litmus -c ansibletest
[0;34mansible-playbook 2.7.6[0m
[0;34m  config file = None[0m
[0;34m  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules'][0m
[0;34m  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible[0m
[0;34m  executable location = /usr/local/bin/ansible-playbook[0m
[0;34m  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0][0m
[0;34mNo config file found; using defaults[0m
[0;34m/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected[0m
[0;34m/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected[0m
[0;35m[DEPRECATION WARNING]: Specifying include variables at the top-level of the [0m
[0;35mtask is deprecated. Please see: [0m
[0;35mhttps://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-[0m
[0;35mencouraging-reuse   for currently supported syntax regarding included files and[0m
[0;35m variables. This feature will be removed in version 2.12. Deprecation warnings [0m
[0;35mcan be disabled by setting deprecation_warnings=False in ansible.cfg.[0m

PLAYBOOK: test.yml *************************************************************
[0;34m1 plays in ./percona/chaos/openebs_pool_failure/test.yml[0m

PLAY [localhost] ***************************************************************
2019-01-23T06:06:01.059895 (delta: 0.124008)         elapsed: 0.124008 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:2[0m
2019-01-23T06:06:01.072688 (delta: 0.01271)         elapsed: 0.136801 ********* 
[0;32mok: [127.0.0.1][0m
[0;34mMETA: ran handlers[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:12[0m
2019-01-23T06:06:07.600498 (delta: 6.527707)         elapsed: 6.664611 ******** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Get application pod name] ************************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:15[0m
2019-01-23T06:06:07.706005 (delta: 0.105458)         elapsed: 6.770118 ******** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.121411", "end": "2019-01-23 06:06:09.310453", "rc": 0, "start": "2019-01-23 06:06:08.189042", "stderr": "", "stderr_lines": [], "stdout": "percona-59b8d9c9c9-8nqcx", "stdout_lines": ["percona-59b8d9c9c9-8nqcx"]}[0m

TASK [Generate unique string for use in dbname] ********************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:23[0m
2019-01-23T06:06:09.358961 (delta: 1.652906)         elapsed: 8.423074 ******** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "echo $(mktemp) | cut -d '.' -f 2", "delta": "0:00:00.609952", "end": "2019-01-23 06:06:10.204366", "rc": 0, "start": "2019-01-23 06:06:09.594414", "stderr": "", "stderr_lines": [], "stdout": "oZkwJ4otU4", "stdout_lines": ["oZkwJ4otU4"]}[0m

TASK [Create some test data in the mysql database] *****************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:29[0m
2019-01-23T06:06:10.278942 (delta: 0.919822)         elapsed: 9.343055 ******** 
[0;36mincluded: /common/utils/mysql_data_persistence.yml for 127.0.0.1[0m

TASK [Create some test data in the mysql database] *****************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:4[0m
2019-01-23T06:06:10.464929 (delta: 0.185901)         elapsed: 9.529042 ******** 
[0;33mchanged: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdboZkwJ4otU4;') => {"changed": true, "cmd": "kubectl exec percona-59b8d9c9c9-8nqcx -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database tdboZkwJ4otU4;'", "delta": "0:00:00.760937", "end": "2019-01-23 06:06:11.593102", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdboZkwJ4otU4;'", "rc": 0, "start": "2019-01-23 06:06:10.832165", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}[0m
[0;33mchanged: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdboZkwJ4otU4) => {"changed": true, "cmd": "kubectl exec percona-59b8d9c9c9-8nqcx -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdboZkwJ4otU4", "delta": "0:00:01.676575", "end": "2019-01-23 06:06:13.516103", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdboZkwJ4otU4", "rc": 0, "start": "2019-01-23 06:06:11.839528", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}[0m
[0;33mchanged: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdboZkwJ4otU4) => {"changed": true, "cmd": "kubectl exec percona-59b8d9c9c9-8nqcx -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdboZkwJ4otU4", "delta": "0:00:00.778964", "end": "2019-01-23 06:06:14.552716", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdboZkwJ4otU4", "rc": 0, "start": "2019-01-23 06:06:13.773752", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}[0m

TASK [Checking for the Corrupted tables] ***************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:21[0m
2019-01-23T06:06:14.654802 (delta: 4.189816)         elapsed: 13.718915 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Verify mysql data persistence] *******************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:30[0m
2019-01-23T06:06:14.748965 (delta: 0.094101)         elapsed: 13.813078 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Delete/drop MySQL database] **********************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:43[0m
2019-01-23T06:06:14.846423 (delta: 0.097403)         elapsed: 13.910536 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Verify successful db delete] *********************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:51[0m
2019-01-23T06:06:15.001959 (delta: 0.155356)         elapsed: 14.066072 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Record the chaos util path] **********************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:40[0m
2019-01-23T06:06:15.138747 (delta: 0.136694)         elapsed: 14.20286 ******** 
[0;32mok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/cstor_pool_kill.yml"}, "changed": false}[0m

TASK [Record the chaos util path] **********************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:45[0m
2019-01-23T06:06:15.226758 (delta: 0.08789)         elapsed: 14.290871 ******** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:52[0m
2019-01-23T06:06:15.273294 (delta: 0.046482)         elapsed: 14.337407 ******* 
[0;36mincluded: /common/utils/create_testname.yml for 127.0.0.1[0m

TASK [Record test instance/run ID] *********************************************
[1;30mtask path: /common/utils/create_testname.yml:3[0m
2019-01-23T06:06:15.332902 (delta: 0.059542)         elapsed: 14.397015 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Construct testname appended with runID] **********************************
[1;30mtask path: /common/utils/create_testname.yml:7[0m
2019-01-23T06:06:15.380548 (delta: 0.047565)         elapsed: 14.444661 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:54[0m
2019-01-23T06:06:15.439255 (delta: 0.058645)         elapsed: 14.503368 ******* 
[0;36mincluded: /common/utils/update_litmus_result_resource.yml for 127.0.0.1[0m

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:3[0m
2019-01-23T06:06:15.559562 (delta: 0.12022)         elapsed: 14.623675 ******** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "checksum": "9ddf35b64ae0f3b9a88fea5edef725569109e5ae", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "2bfe37373405567d5a83ca51f429d50f", "mode": "0644", "owner": "root", "size": 441, "src": "/root/.ansible/tmp/ansible-tmp-1548223575.63-166509350358973/source", "state": "file", "uid": 0}[0m

TASK [Analyze the cr yaml] *****************************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:14[0m
2019-01-23T06:06:16.496498 (delta: 0.936849)         elapsed: 15.560611 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.515624", "end": "2019-01-23 06:06:17.286705", "rc": 0, "start": "2019-01-23 06:06:16.771081", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-pool-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs-pool-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-pool-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs-pool-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}[0m

TASK [Apply the litmus result CR] **********************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:17[0m
2019-01-23T06:06:17.326711 (delta: 0.830115)         elapsed: 16.390824 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.119788", "end": "2019-01-23 06:06:18.629359", "failed_when_result": false, "rc": 0, "start": "2019-01-23 06:06:17.509571", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-pool-failure created", "stdout_lines": ["litmusresult.litmus.io/openebs-pool-failure created"]}[0m

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:27[0m
2019-01-23T06:06:18.703049 (delta: 1.376246)         elapsed: 17.767162 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Analyze the cr yaml] *****************************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:38[0m
2019-01-23T06:06:18.775123 (delta: 0.071996)         elapsed: 17.839236 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Apply the litmus result CR] **********************************************
[1;30mtask path: /common/utils/update_litmus_result_resource.yml:41[0m
2019-01-23T06:06:18.843013 (delta: 0.067696)         elapsed: 17.907126 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Display the app information passed via the test job] *********************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:61[0m
2019-01-23T06:06:18.911717 (delta: 0.068643)         elapsed: 17.97583 ******** 
[0;32mok: [127.0.0.1] => {[0m
[0;32m    "msg": [[0m
[0;32m        "The application info is as follows:", [0m
[0;32m        "Namespace    : app-percona-ns", [0m
[0;32m        "Label        : name=percona", [0m
[0;32m        "PVC          : percona-mysql-claim"[0m
[0;32m    ][0m
[0;32m}[0m

TASK [Verify that the AUT (Application Under Test) is running] *****************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:70[0m
2019-01-23T06:06:19.030526 (delta: 0.118699)         elapsed: 18.094639 ******* 
[0;36mincluded: /common/utils/status_app_pod.yml for 127.0.0.1[0m

TASK [Get the container status of application.] ********************************
[1;30mtask path: /common/utils/status_app_pod.yml:2[0m
2019-01-23T06:06:19.097585 (delta: 0.067001)         elapsed: 18.161698 ******* 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.777862", "end": "2019-01-23 06:06:20.046970", "rc": 0, "start": "2019-01-23 06:06:19.269108", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-01-22T17:52:40Z]]", "stdout_lines": ["map[running:map[startedAt:2019-01-22T17:52:40Z]]"]}[0m

TASK [Checking {{ application_name }} pod is in running state] *****************
[1;30mtask path: /common/utils/status_app_pod.yml:13[0m
2019-01-23T06:06:20.100853 (delta: 1.003217)         elapsed: 19.164966 ******* 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.862036", "end": "2019-01-23 06:06:21.112631", "rc": 0, "start": "2019-01-23 06:06:20.250595", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}[0m

TASK [include] *****************************************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:81[0m
2019-01-23T06:06:21.204915 (delta: 1.103996)         elapsed: 20.269028 ******* 
[0;36mincluded: /chaoslib/openebs/cstor_pool_kill.yml for 127.0.0.1[0m

TASK [include] *****************************************************************
[1;30mtask path: /chaoslib/openebs/cstor_pool_kill.yml:1[0m
2019-01-23T06:06:21.282792 (delta: 0.077542)         elapsed: 20.346905 ******* 
[0;36mincluded: /chaoslib/openebs/cstor_kill_and_verify_pool.yml for 127.0.0.1 => (item=0)[0m
[0;36mincluded: /chaoslib/openebs/cstor_kill_and_verify_pool.yml for 127.0.0.1 => (item=1)[0m

TASK [Derive PV from application PVC] ******************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:1[0m
2019-01-23T06:06:21.423325 (delta: 0.140478)         elapsed: 20.487438 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n app-percona-ns --no-headers", "delta": "0:00:00.792602", "end": "2019-01-23 06:06:22.483478", "rc": 0, "start": "2019-01-23 06:06:21.690876", "stderr": "", "stderr_lines": [], "stdout": "pvc-10c18a73-1e6e-11e9-bf34-42010a800281", "stdout_lines": ["pvc-10c18a73-1e6e-11e9-bf34-42010a800281"]}[0m

TASK [Randomly select the pool deployment from cvr] ****************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:10[0m
2019-01-23T06:06:22.590718 (delta: 1.167337)         elapsed: 21.654831 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-10c18a73-1e6e-11e9-bf34-42010a800281 --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}' | shuf -n1 | awk '{print $1}'", "delta": "0:00:00.661750", "end": "2019-01-23 06:06:23.660358", "rc": 0, "start": "2019-01-23 06:06:22.998608", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-ha1k", "stdout_lines": ["cstor-sparse-pool-ha1k"]}[0m

TASK [Get the pod of pool deployment] ******************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:20[0m
2019-01-23T06:06:23.724132 (delta: 1.132943)         elapsed: 22.788245 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs | grep cstor-sparse-pool-ha1k | grep -w \"Running\" | awk '{print $1}'", "delta": "0:00:00.901802", "end": "2019-01-23 06:06:24.972174", "rc": 0, "start": "2019-01-23 06:06:24.070372", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-ha1k-548ffc6498-6rv46", "stdout_lines": ["cstor-sparse-pool-ha1k-548ffc6498-6rv46"]}[0m

TASK [Get the runningStatus of pool pod] ***************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:28[0m
2019-01-23T06:06:25.124347 (delta: 1.400163)         elapsed: 24.18846 ******** 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-ha1k-548ffc6498-6rv46 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:00.897005", "end": "2019-01-23 06:06:26.189385", "rc": 0, "start": "2019-01-23 06:06:25.292380", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:40[0m
2019-01-23T06:06:26.243516 (delta: 1.119076)         elapsed: 25.307629 ******* 
[0;36mincluded: /chaoslib/pumba/pod_failure_by_sigkill.yaml for 127.0.0.1[0m

TASK [Setup pumba chaos infrastructure] ****************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:2[0m
2019-01-23T06:06:26.354661 (delta: 0.11105)         elapsed: 25.418774 ******** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n openebs", "delta": "0:00:01.346960", "end": "2019-01-23 06:06:27.934831", "rc": 0, "start": "2019-01-23 06:06:26.587871", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}[0m

TASK [Confirm that the pumba ds is running on all nodes] ***********************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:10[0m
2019-01-23T06:06:28.002801 (delta: 1.647802)         elapsed: 27.066914 ******* 
[1;30mFAILED - RETRYING: Confirm that the pumba ds is running on all nodes (150 retries left).[0m
[1;30mFAILED - RETRYING: Confirm that the pumba ds is running on all nodes (149 retries left).[0m
[0;33mchanged: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n openebs | sort | uniq", "delta": "0:00:00.966287", "end": "2019-01-23 06:06:35.827632", "rc": 0, "start": "2019-01-23 06:06:34.861345", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}[0m

TASK [Identify the application node] *******************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:22[0m
2019-01-23T06:06:35.900750 (delta: 7.897898)         elapsed: 34.964863 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod cstor-sparse-pool-ha1k-548ffc6498-6rv46 -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.857229", "end": "2019-01-23 06:06:37.005613", "rc": 0, "start": "2019-01-23 06:06:36.148384", "stderr": "", "stderr_lines": [], "stdout": "gke-e2e-cluster-dev-default-pool-ccc0254f-xw73", "stdout_lines": ["gke-e2e-cluster-dev-default-pool-ccc0254f-xw73"]}[0m

TASK [Record the application node name] ****************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:30[0m
2019-01-23T06:06:37.063202 (delta: 1.162361)         elapsed: 36.127315 ******* 
[0;32mok: [127.0.0.1] => {"ansible_facts": {"app_node": "gke-e2e-cluster-dev-default-pool-ccc0254f-xw73"}, "changed": false}[0m

TASK [Record the application container] ****************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:36[0m
2019-01-23T06:06:37.131671 (delta: 0.068407)         elapsed: 36.195784 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Record the app_container] ************************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:43[0m
2019-01-23T06:06:37.177074 (delta: 0.045327)         elapsed: 36.241187 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Record the pumba pod on app node] ****************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:49[0m
2019-01-23T06:06:37.231352 (delta: 0.054174)         elapsed: 36.295465 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l app=pumba -o wide -n openebs | grep gke-e2e-cluster-dev-default-pool-ccc0254f-xw73 | awk '{print $1}'", "delta": "0:00:00.983563", "end": "2019-01-23 06:06:38.374160", "rc": 0, "start": "2019-01-23 06:06:37.390597", "stderr": "", "stderr_lines": [], "stdout": "pumba-7b5r9", "stdout_lines": ["pumba-7b5r9"]}[0m

TASK [Record restartCount] *****************************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:58[0m
2019-01-23T06:06:38.440634 (delta: 1.209206)         elapsed: 37.504747 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod cstor-sparse-pool-ha1k-548ffc6498-6rv46 -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-pool\")].restartCount}'", "delta": "0:00:00.837605", "end": "2019-01-23 06:06:39.519349", "rc": 0, "start": "2019-01-23 06:06:38.681744", "stderr": "", "stderr_lines": [], "stdout": "0", "stdout_lines": ["0"]}[0m

TASK [Force kill the application pod using pumba] ******************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:66[0m
2019-01-23T06:06:39.592921 (delta: 1.152239)         elapsed: 38.657034 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-7b5r9 -n openebs -- pumba kill --signal SIGKILL re2:k8s_cstor-pool_;", "delta": "0:00:01.516967", "end": "2019-01-23 06:06:41.352947", "rc": 0, "start": "2019-01-23 06:06:39.835980", "stderr": "time=\"2019-01-23T06:06:40Z\" level=info msg=\"Kill containers\" \ntime=\"2019-01-23T06:06:41Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-sparse-pool-ha1k-548ffc6498-6rv46_openebs_cb79a513-1e6d-11e9-bf34-42010a800281_0 (94c44316177c162fb1e7942e47edfe4fc85bd8248c7f786998dc9e826072342a) with signal SIGKILL\" ", "stderr_lines": ["time=\"2019-01-23T06:06:40Z\" level=info msg=\"Kill containers\" ", "time=\"2019-01-23T06:06:41Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-sparse-pool-ha1k-548ffc6498-6rv46_openebs_cb79a513-1e6d-11e9-bf34-42010a800281_0 (94c44316177c162fb1e7942e47edfe4fc85bd8248c7f786998dc9e826072342a) with signal SIGKILL\" "], "stdout": "", "stdout_lines": []}[0m

TASK [Verify restartCount] *****************************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:75[0m
2019-01-23T06:06:41.403782 (delta: 1.810783)         elapsed: 40.467895 ******* 
[1;30mFAILED - RETRYING: Verify restartCount (30 retries left).[0m
[0;33mchanged: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-ha1k-548ffc6498-6rv46 -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-pool\")].restartCount}'", "delta": "0:00:00.964761", "end": "2019-01-23 06:06:46.153697", "rc": 0, "start": "2019-01-23 06:06:45.188936", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}[0m

TASK [Delete the pumba daemonset] **********************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:89[0m
2019-01-23T06:06:46.201483 (delta: 4.797646)         elapsed: 45.265596 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Confirm that the pumba ds is deleted successfully] ***********************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:96[0m
2019-01-23T06:06:46.274341 (delta: 0.072801)         elapsed: 45.338454 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Check for pool pod in running state] *************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:47[0m
2019-01-23T06:06:46.337829 (delta: 0.063321)         elapsed: 45.401942 ******* 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-ha1k-548ffc6498-6rv46 -n openebs | grep -w \"Running\" | wc -l", "delta": "0:00:00.805437", "end": "2019-01-23 06:06:47.486500", "rc": 0, "start": "2019-01-23 06:06:46.681063", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}[0m

TASK [Get the runningStatus of pool pod] ***************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:58[0m
2019-01-23T06:06:47.559816 (delta: 1.221925)         elapsed: 46.623929 ******* 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-ha1k-548ffc6498-6rv46 -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:00.764590", "end": "2019-01-23 06:06:48.573050", "rc": 0, "start": "2019-01-23 06:06:47.808460", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}[0m

TASK [Derive PV from application PVC] ******************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:1[0m
2019-01-23T06:06:48.638683 (delta: 1.078811)         elapsed: 47.702796 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n app-percona-ns --no-headers", "delta": "0:00:00.728516", "end": "2019-01-23 06:06:49.634015", "rc": 0, "start": "2019-01-23 06:06:48.905499", "stderr": "", "stderr_lines": [], "stdout": "pvc-10c18a73-1e6e-11e9-bf34-42010a800281", "stdout_lines": ["pvc-10c18a73-1e6e-11e9-bf34-42010a800281"]}[0m

TASK [Randomly select the pool deployment from cvr] ****************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:10[0m
2019-01-23T06:06:49.719441 (delta: 1.080689)         elapsed: 48.783554 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-10c18a73-1e6e-11e9-bf34-42010a800281 --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}' | shuf -n1 | awk '{print $1}'", "delta": "0:00:00.696597", "end": "2019-01-23 06:06:50.903557", "rc": 0, "start": "2019-01-23 06:06:50.206960", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-z8tw", "stdout_lines": ["cstor-sparse-pool-z8tw"]}[0m

TASK [Get the pod of pool deployment] ******************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:20[0m
2019-01-23T06:06:50.996534 (delta: 1.276971)         elapsed: 50.060647 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs | grep cstor-sparse-pool-z8tw | grep -w \"Running\" | awk '{print $1}'", "delta": "0:00:00.755335", "end": "2019-01-23 06:06:51.921092", "rc": 0, "start": "2019-01-23 06:06:51.165757", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-z8tw-5975584fb4-pwhsf", "stdout_lines": ["cstor-sparse-pool-z8tw-5975584fb4-pwhsf"]}[0m

TASK [Get the runningStatus of pool pod] ***************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:28[0m
2019-01-23T06:06:52.073512 (delta: 1.076765)         elapsed: 51.137625 ******* 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-z8tw-5975584fb4-pwhsf -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:00.946142", "end": "2019-01-23 06:06:53.183664", "rc": 0, "start": "2019-01-23 06:06:52.237522", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:40[0m
2019-01-23T06:06:53.253302 (delta: 1.179738)         elapsed: 52.317415 ******* 
[0;36mincluded: /chaoslib/pumba/pod_failure_by_sigkill.yaml for 127.0.0.1[0m

TASK [Setup pumba chaos infrastructure] ****************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:2[0m
2019-01-23T06:06:53.341574 (delta: 0.088219)         elapsed: 52.405687 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n openebs", "delta": "0:00:00.835955", "end": "2019-01-23 06:06:54.364031", "rc": 0, "start": "2019-01-23 06:06:53.528076", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba unchanged", "stdout_lines": ["daemonset.extensions/pumba unchanged"]}[0m

TASK [Confirm that the pumba ds is running on all nodes] ***********************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:10[0m
2019-01-23T06:06:54.426099 (delta: 1.084477)         elapsed: 53.490212 ******* 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n openebs | sort | uniq", "delta": "0:00:00.760071", "end": "2019-01-23 06:06:55.480148", "rc": 0, "start": "2019-01-23 06:06:54.720077", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}[0m

TASK [Identify the application node] *******************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:22[0m
2019-01-23T06:06:55.548418 (delta: 1.122049)         elapsed: 54.612531 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod cstor-sparse-pool-z8tw-5975584fb4-pwhsf -n openebs --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.880315", "end": "2019-01-23 06:06:56.686550", "rc": 0, "start": "2019-01-23 06:06:55.806235", "stderr": "", "stderr_lines": [], "stdout": "gke-e2e-cluster-dev-default-pool-ccc0254f-wrx7", "stdout_lines": ["gke-e2e-cluster-dev-default-pool-ccc0254f-wrx7"]}[0m

TASK [Record the application node name] ****************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:30[0m
2019-01-23T06:06:56.773899 (delta: 1.225424)         elapsed: 55.838012 ******* 
[0;32mok: [127.0.0.1] => {"ansible_facts": {"app_node": "gke-e2e-cluster-dev-default-pool-ccc0254f-wrx7"}, "changed": false}[0m

TASK [Record the application container] ****************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:36[0m
2019-01-23T06:06:56.894957 (delta: 0.121006)         elapsed: 55.95907 ******** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Record the app_container] ************************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:43[0m
2019-01-23T06:06:56.997669 (delta: 0.102662)         elapsed: 56.061782 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Record the pumba pod on app node] ****************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:49[0m
2019-01-23T06:06:57.059692 (delta: 0.061516)         elapsed: 56.123805 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -l app=pumba -o wide -n openebs | grep gke-e2e-cluster-dev-default-pool-ccc0254f-wrx7 | awk '{print $1}'", "delta": "0:00:00.892026", "end": "2019-01-23 06:06:58.135925", "rc": 0, "start": "2019-01-23 06:06:57.243899", "stderr": "", "stderr_lines": [], "stdout": "pumba-dq2jm", "stdout_lines": ["pumba-dq2jm"]}[0m

TASK [Record restartCount] *****************************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:58[0m
2019-01-23T06:06:58.190841 (delta: 1.131024)         elapsed: 57.254954 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod cstor-sparse-pool-z8tw-5975584fb4-pwhsf -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-pool\")].restartCount}'", "delta": "0:00:00.852373", "end": "2019-01-23 06:06:59.223450", "rc": 0, "start": "2019-01-23 06:06:58.371077", "stderr": "", "stderr_lines": [], "stdout": "0", "stdout_lines": ["0"]}[0m

TASK [Force kill the application pod using pumba] ******************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:66[0m
2019-01-23T06:06:59.266761 (delta: 1.075873)         elapsed: 58.330874 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-dq2jm -n openebs -- pumba kill --signal SIGKILL re2:k8s_cstor-pool_;", "delta": "0:00:02.294161", "end": "2019-01-23 06:07:01.724926", "rc": 0, "start": "2019-01-23 06:06:59.430765", "stderr": "time=\"2019-01-23T06:07:00Z\" level=info msg=\"Kill containers\" \ntime=\"2019-01-23T06:07:01Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-sparse-pool-z8tw-5975584fb4-pwhsf_openebs_cb705d93-1e6d-11e9-bf34-42010a800281_0 (a9b42d70325782208922d572e13da76d03de913f8aaa3649f8c2637d7cfebd27) with signal SIGKILL\" ", "stderr_lines": ["time=\"2019-01-23T06:07:00Z\" level=info msg=\"Kill containers\" ", "time=\"2019-01-23T06:07:01Z\" level=info msg=\"Killing /k8s_cstor-pool_cstor-sparse-pool-z8tw-5975584fb4-pwhsf_openebs_cb705d93-1e6d-11e9-bf34-42010a800281_0 (a9b42d70325782208922d572e13da76d03de913f8aaa3649f8c2637d7cfebd27) with signal SIGKILL\" "], "stdout": "", "stdout_lines": []}[0m

TASK [Verify restartCount] *****************************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:75[0m
2019-01-23T06:07:01.845535 (delta: 2.57868)         elapsed: 60.909648 ******** 
[1;30mFAILED - RETRYING: Verify restartCount (30 retries left).[0m
[0;33mchanged: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-z8tw-5975584fb4-pwhsf -n openebs -o=jsonpath='{.status.containerStatuses[?(@.name==\"cstor-pool\")].restartCount}'", "delta": "0:00:00.808585", "end": "2019-01-23 06:07:06.177111", "rc": 0, "start": "2019-01-23 06:07:05.368526", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}[0m

TASK [Delete the pumba daemonset] **********************************************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:89[0m
2019-01-23T06:07:06.226721 (delta: 4.381128)         elapsed: 65.290834 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Confirm that the pumba ds is deleted successfully] ***********************
[1;30mtask path: /chaoslib/pumba/pod_failure_by_sigkill.yaml:96[0m
2019-01-23T06:07:06.276896 (delta: 0.050031)         elapsed: 65.341009 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Check for pool pod in running state] *************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:47[0m
2019-01-23T06:07:06.336333 (delta: 0.059279)         elapsed: 65.400446 ******* 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-z8tw-5975584fb4-pwhsf -n openebs | grep -w \"Running\" | wc -l", "delta": "0:00:00.702992", "end": "2019-01-23 06:07:07.220638", "rc": 0, "start": "2019-01-23 06:07:06.517646", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}[0m

TASK [Get the runningStatus of pool pod] ***************************************
[1;30mtask path: /chaoslib/openebs/cstor_kill_and_verify_pool.yml:58[0m
2019-01-23T06:07:07.294394 (delta: 0.958008)         elapsed: 66.358507 ******* 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod cstor-sparse-pool-z8tw-5975584fb4-pwhsf -n openebs -o=jsonpath='{range .status.containerStatuses[*]}{.state}{\"\\n\"}{end}' | grep -w running | wc -l", "delta": "0:00:00.713835", "end": "2019-01-23 06:07:08.343427", "rc": 0, "start": "2019-01-23 06:07:07.629592", "stderr": "", "stderr_lines": [], "stdout": "2", "stdout_lines": ["2"]}[0m

TASK [Verify AUT liveness post fault-injection] ********************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:90[0m
2019-01-23T06:07:08.396741 (delta: 1.102287)         elapsed: 67.460854 ******* 
[0;36mincluded: /common/utils/status_app_pod.yml for 127.0.0.1[0m

TASK [Get the container status of application.] ********************************
[1;30mtask path: /common/utils/status_app_pod.yml:2[0m
2019-01-23T06:07:08.578251 (delta: 0.181425)         elapsed: 67.642364 ******* 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.071248", "end": "2019-01-23 06:07:10.284212", "rc": 0, "start": "2019-01-23 06:07:09.212964", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-01-22T17:52:40Z]]", "stdout_lines": ["map[running:map[startedAt:2019-01-22T17:52:40Z]]"]}[0m

TASK [Checking {{ application_name }} pod is in running state] *****************
[1;30mtask path: /common/utils/status_app_pod.yml:13[0m
2019-01-23T06:07:10.449897 (delta: 1.871588)         elapsed: 69.51401 ******** 
[0;33mchanged: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.828971", "end": "2019-01-23 06:07:12.130712", "rc": 0, "start": "2019-01-23 06:07:11.301741", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}[0m

TASK [Verify mysql data persistence] *******************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:100[0m
2019-01-23T06:07:12.177922 (delta: 1.72743)         elapsed: 71.242035 ******** 
[0;36mincluded: /common/utils/mysql_data_persistence.yml for 127.0.0.1[0m

TASK [Create some test data in the mysql database] *****************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:4[0m
2019-01-23T06:07:12.271948 (delta: 0.093979)         elapsed: 71.336061 ******* 
[0;36mskipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdboZkwJ4otU4;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdboZkwJ4otU4;'", "skip_reason": "Conditional result was False"}[0m
[0;36mskipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdboZkwJ4otU4)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdboZkwJ4otU4", "skip_reason": "Conditional result was False"}[0m
[0;36mskipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdboZkwJ4otU4)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdboZkwJ4otU4", "skip_reason": "Conditional result was False"}[0m

TASK [Checking for the Corrupted tables] ***************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:21[0m
2019-01-23T06:07:12.393134 (delta: 0.12109)         elapsed: 71.457247 ******** 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-59b8d9c9c9-8nqcx -n app-percona-ns -- mysqlcheck -c tdboZkwJ4otU4 -uroot -pk8sDem0", "delta": "0:00:00.784968", "end": "2019-01-23 06:07:13.565326", "failed_when_result": false, "rc": 0, "start": "2019-01-23 06:07:12.780358", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "tdboZkwJ4otU4.ttbl                                 OK", "stdout_lines": ["tdboZkwJ4otU4.ttbl                                 OK"]}[0m

TASK [Verify mysql data persistence] *******************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:30[0m
2019-01-23T06:07:13.625953 (delta: 1.232442)         elapsed: 72.690066 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-59b8d9c9c9-8nqcx -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' tdboZkwJ4otU4;", "delta": "0:00:00.907688", "end": "2019-01-23 06:07:14.829436", "failed_when_result": false, "rc": 0, "start": "2019-01-23 06:07:13.921748", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}[0m

TASK [Delete/drop MySQL database] **********************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:43[0m
2019-01-23T06:07:14.908852 (delta: 1.282796)         elapsed: 73.972965 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Verify successful db delete] *********************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:51[0m
2019-01-23T06:07:14.990443 (delta: 0.081543)         elapsed: 74.054556 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Verify successful database delete] ***************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:111[0m
2019-01-23T06:07:15.035038 (delta: 0.044519)         elapsed: 74.099151 ******* 
[0;36mincluded: /common/utils/mysql_data_persistence.yml for 127.0.0.1[0m

TASK [Create some test data in the mysql database] *****************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:4[0m
2019-01-23T06:07:15.122577 (delta: 0.087483)         elapsed: 74.18669 ******** 
[0;36mskipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdboZkwJ4otU4;')  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdboZkwJ4otU4;'", "skip_reason": "Conditional result was False"}[0m
[0;36mskipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdboZkwJ4otU4)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdboZkwJ4otU4", "skip_reason": "Conditional result was False"}[0m
[0;36mskipping: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdboZkwJ4otU4)  => {"changed": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdboZkwJ4otU4", "skip_reason": "Conditional result was False"}[0m

TASK [Checking for the Corrupted tables] ***************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:21[0m
2019-01-23T06:07:15.193001 (delta: 0.07033)         elapsed: 74.257114 ******** 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Verify mysql data persistence] *******************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:30[0m
2019-01-23T06:07:15.251335 (delta: 0.058283)         elapsed: 74.315448 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [Delete/drop MySQL database] **********************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:43[0m
2019-01-23T06:07:15.334061 (delta: 0.082461)         elapsed: 74.398174 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-59b8d9c9c9-8nqcx -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'drop database tdboZkwJ4otU4';", "delta": "0:00:01.366768", "end": "2019-01-23 06:07:17.116570", "rc": 0, "start": "2019-01-23 06:07:15.749802", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}[0m

TASK [Verify successful db delete] *********************************************
[1;30mtask path: /common/utils/mysql_data_persistence.yml:51[0m
2019-01-23T06:07:17.157962 (delta: 1.823847)         elapsed: 76.222075 ******* 
[0;33mchanged: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-59b8d9c9c9-8nqcx -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'show databases';", "delta": "0:00:00.805794", "end": "2019-01-23 06:07:18.132920", "failed_when_result": false, "rc": 0, "start": "2019-01-23 06:07:17.327126", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Database\ninformation_schema\nInventory_vpGJSrSQs3\nmysql\nperformance_schema\nsys\ntdb0XoLD0YpC6", "stdout_lines": ["Database", "information_schema", "Inventory_vpGJSrSQs3", "mysql", "performance_schema", "sys", "tdb0XoLD0YpC6"]}[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:123[0m
2019-01-23T06:07:18.214811 (delta: 1.056791)         elapsed: 77.278924 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m

TASK [set_fact] ****************************************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:126[0m
2019-01-23T06:07:18.290942 (delta: 0.075965)         elapsed: 77.355055 ******* 
[0;32mok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}[0m

TASK [include_tasks] ***********************************************************
[1;30mtask path: /percona/chaos/openebs_pool_failure/test.yml:137[0m
2019-01-23T06:07:18.425180 (delta: 0.134058)         elapsed: 77.489293 ******* 
[0;36mskipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}[0m
[0;34mMETA: ran handlers[0m
[0;34mMETA: ran handlers[0m

PLAY RECAP *********************************************************************
[0;33m127.0.0.1[0m                  : [0;32mok=58  [0m [0;33mchanged=40  [0m unreachable=0    failed=0   

2019-01-23T06:07:18.474165 (delta: 0.048843)         elapsed: 77.538278 ******* 
=============================================================================== ```