### PR TITLE
refactor(yaml): Using spc name as cstor pool pod's label in disk failure litmusbook

### DIFF
--- a/apps/percona/chaos/disk_failure/test.yml
+++ b/apps/percona/chaos/disk_failure/test.yml
@@ -77,7 +77,8 @@
         ## INDUCE DISK FAILURE AND VERIFY CSTOR POOL AND APP STATUS
         - include_tasks: /chaoslib/aws_chaos/disk_failure.yml
           vars:
-            action: "disk-fail"      
+            action: "disk-fail"
+            pool_claim: "{{ spc.stdout }}"      
             app_ns: "{{ namespace }}"
             app: "{{ app_pod_name.stdout }}"
 
@@ -103,10 +104,14 @@
           delay: 10
           retries: 12
 
+        - name: sleep for 60 seconds and continue with play
+          wait_for: timeout=60
+
         ## RECOVER DISK AND VERIFY CSTOR POOL AND APP STATUS
         - include_tasks: /chaoslib/aws_chaos/disk_failure.yml
           vars:
-            action: "disk-recover"      
+            action: "disk-recover"
+            pool_claim: "{{ spc.stdout }}"      
             app_ns: "{{ namespace }}"
             app: "{{ app_pod_name.stdout }}"
 
@@ -167,7 +172,8 @@
         ## RECOVER DISK ALWAYS
         - include_tasks: /chaoslib/aws_chaos/disk_failure.yml
           vars:
-            action: "disk-recover"      
+            action: "disk-recover"
+            pool_claim: "{{ spc.stdout }}"      
             app_ns: "{{ namespace }}"
             app: "{{ app_pod_name.stdout }}"
           ignore_errors: true

--- a/chaoslib/aws_chaos/disk_failure.yml
+++ b/chaoslib/aws_chaos/disk_failure.yml
@@ -1,7 +1,7 @@
 --- 
 - name: Record the cstor-pool pod on given app node
   shell: >
-    kubectl get pod -l app=cstor-pool -l openebs.io/storage-pool-claim=cstor-disk-pool -o wide
+    kubectl get pod -l app=cstor-pool -l openebs.io/storage-pool-claim={{ pool_claim }} -o wide
     -n {{ operator_ns }} | grep {{ instance_name }}
     | awk '{print $1}'
   args:


### PR DESCRIPTION
Signed-off-by: giri <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- When a volume is created on cstor pool , the corresponding spc name should be passed as label to find out the pod.
- Fails to derive pod name if is created on pool other than 'cstor-disk-pool'

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
#478 

**Special notes for your reviewer**:

-  Finding out spc name and passing it as label for deriving pool name.
-  Sleeping for 60 seconds as AWS requires some time in between detaching and attaching drives to update. Attaching disk fails upon trying immediately as the disk status remains in detaching for some time.
