### PR TITLE
Litmusbook for generating load on elasticsearch statefulset.

### DIFF
--- a/apps/elasticsearch/deployers/es-statefulset.yaml
+++ b/apps/elasticsearch/deployers/es-statefulset.yaml
@@ -88,6 +88,6 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 5G
+          storage: 20G
 
          

--- a/apps/elasticsearch/deployers/es-statefulset.yaml
+++ b/apps/elasticsearch/deployers/es-statefulset.yaml
@@ -20,6 +20,8 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elasticsearch-logging
+  labels:
+    lkey: lvalue
 spec:
   serviceName: elasticsearch-logging
   rkey: rvalue

--- a/apps/elasticsearch/workload/elasticsearch_loadgen.yml
+++ b/apps/elasticsearch/workload/elasticsearch_loadgen.yml
@@ -13,7 +13,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: elasticsearch-loadgen
-        image: vvibhr995/elastic-load:latest
+        image: openebs/tests-elasticsearch-stress
         command: [ "/bin/bash"]
         args: ["-c" ,"./elasticsearch-stress-test.py --es_address elasticsearch-logging-0.elasticsearch-logging  --indices 1 --documents 2 --seconds 120 --not-green --clients 3 --forever --no-cleanup"]
         tty: true 

--- a/apps/elasticsearch/workload/elasticsearch_loadgen.yml
+++ b/apps/elasticsearch/workload/elasticsearch_loadgen.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: elasticsearch-loadgen
+spec:
+  template:
+    metadata:
+      name: elasticsearch-loadgen
+      labels:
+        loadgen_lkey: loadgen_lvalue
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: elasticsearch-loadgen
+        image: vvibhr995/elastic-load:latest
+        command: [ "/bin/bash"]
+        args: ["-c" ,"./elasticsearch-stress-test.py --es_address elasticsearch-logging-0.elasticsearch-logging  --indices 1 --documents 2 --seconds 120 --not-green --clients 3 --forever --no-cleanup"]
+        tty: true 
+

--- a/apps/elasticsearch/workload/run_litmus_test.yml
+++ b/apps/elasticsearch/workload/run_litmus_test.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: elasticsearch-loadgen-
+  namespace: litmus 
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        loadgen: elasticsearch-loadjob
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: default
+
+          - name: LOADGEN_NS
+            value: app-esearch-ns
+
+          - name: LOADGEN_LABEL
+            value: 'loadgen=elasticsearch-loadgen'
+
+          - name: APPLICATION_LABEL
+            value: 'app=elasticsearch'
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./elasticsearch/workload/test.yml -i /etc/ansible/hosts -v; exit 0"]       

--- a/apps/elasticsearch/workload/test.yml
+++ b/apps/elasticsearch/workload/test.yml
@@ -1,0 +1,116 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+        
+            # - include_tasks: /common/utils/application_liveness_check.yml
+            # when: liveness_label != ''
+
+         ## RECORD START OF THE TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/create_testname.yml
+    
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+          
+        ## Checking the status of test specific namespace.   
+        - include_tasks: /common/utils/status_testns.yml
+          vars:
+            app_ns: "{{namespace}}"       
+
+        # Checking if the application is deployed before starting load generation.
+        - include_tasks: /common/utils/check_statefulset_status.yml
+          vars:
+            app_ns: "{{ namespace }}"    
+
+        - name: Obtaining the loadgen pod label from env.
+          set_fact:
+            loadgen_lkey: "{{ loadgen_label.split('=')[0] }}"
+            loadgen_lvalue: "{{ loadgen_label.split('=')[1] }}"
+
+        - name: Replace the label in loadgen job spec.
+          replace:
+            path: "{{ elasticsearch_loadgen }}"
+            regexp: "loadgen_lkey: loadgen_lvalue"
+            replace: "{{ loadgen_lkey }}: {{ loadgen_lvalue }}"
+
+        - name: Create Elasticsearch loadgen Job
+          shell: kubectl create -f {{ elasticsearch_loadgen }} -n {{ namespace }}
+          args:
+            executable: /bin/bash
+          register: result   
+          failed_when: "result.rc !=0"
+
+        - name: Verify load is running for specified duration
+          shell: kubectl get pods -n {{ namespace }} -l {{ loadgen_label }}
+          args:
+            executable: /bin/bash
+          register: result
+          until: "'Running' in result.stdout"
+          delay: 30
+          retries: 15
+
+        - name: Wait for {{ (io_minutes) | int *60 }} secs to run load.
+          wait_for:
+            timeout: "{{ (io_minutes) | int *60 }}"
+
+        - name: Obtaining the application pod name.
+          shell: kubectl get statefulset -n {{ namespace }} --no-headers -l {{ app_label }} -o custom-columns=:metadata.name
+          args:
+            executable: /bin/bash
+          register: result
+
+        - name: Recording the application pod name.
+          set_fact:
+            app_name: "{{ result.stdout }}"
+
+        - name: Forming one of the replicas name statefulset application name.
+          set_fact:
+            replica_name: "{{ app_name }}-0"
+
+
+        ## Load generation  verification steps.##
+
+        - name: Check the CPU write operations active status.
+          shell: > 
+            kubectl exec -it {{ replica_name }}  -n {{ namespace}}      
+            -- curl -s http://localhost:9200/_cat/thread_pool/write?h=active
+          args:
+            executable: /bin/bash
+          register: writeStatus
+          until:  "writeStatus.stdout == \"1\" " 
+          delay: 10
+          retries: 5  
+
+        - name: Verify load by checking document count.
+          shell: >
+            kubectl exec {{ replica_name }} -n {{ namespace }}
+            -- curl -s http://localhost:9200/_cat/thread_pool/write?h=completed
+          args:
+            executable: /bin/bash
+          register: DocCount
+          failed_when: "DocCount.stdout == \"0\" "
+
+        - name: Number of document written on volume.
+          debug:
+            msg: "Number of Documents {{ DocCount.stdout }}"     
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/apps/elasticsearch/workload/test_vars.yml
+++ b/apps/elasticsearch/workload/test_vars.yml
@@ -1,0 +1,6 @@
+elasticsearch_loadgen: elasticsearch_loadgen.yml
+namespace: "{{ lookup('env','LOADGEN_NS') }}"
+test_name: cassandra-loadgen
+loadgen_label: "{{ lookup('env','LOADGEN_LABEL') }}"
+io_minutes: 2
+app_label: "{{ lookup('env','APPLICATION_LABEL') }}"

--- a/apps/percona/chaos/node_freeze/run_litmus_test.yml
+++ b/apps/percona/chaos/node_freeze/run_litmus_test.yml
@@ -19,7 +19,7 @@ spec:
 
       containers:
       - name: ansibletest
-        image: openenbs/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
         env: 
           - name: ANSIBLE_STDOUT_CALLBACK


### PR DESCRIPTION
Signed-off-by: vibhor995 <vibhor.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
1) This Pr consist of litmus-book for generating load (I/O) on elasticsearch statefulset using elasticsearch-stress-test tool.
2) This PR also consists of small changes of other files .

PR for elasticsearch-stress-tool: https://github.com/openebs/test-tools/pull/81


**Special notes for your reviewer**:
@dargasudarshan @gprasath @nsathyaseelan 

logs
```+ kubectl logs -f elasticsearch-loadgen-wjbpd-pghgm -n litmus
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-01-26T20:03:23.892053 (delta: 0.037374)         elapsed: 0.037374 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-01-26T20:03:23.901630 (delta: 0.009549)         elapsed: 0.046951 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-01-26T20:03:28.314901 (delta: 4.413246)         elapsed: 4.460222 ******** 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-01-26T20:03:28.395690 (delta: 0.080653)         elapsed: 4.541011 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-01-26T20:03:28.456539 (delta: 0.060808)         elapsed: 4.60186 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-01-26T20:03:28.515579 (delta: 0.059003)         elapsed: 4.6609 ********** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-01-26T20:03:28.591812 (delta: 0.076192)         elapsed: 4.737133 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "e15b5ba56a61b982d95fdeef989dd0d812a4c80c", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "328845c7f1f3b6bbeac33236cfec4d93", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1548533008.63-223541031595548/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-01-26T20:03:29.108503 (delta: 0.516607)         elapsed: 5.253824 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.409740", "end": "2019-01-26 20:03:29.868091", "rc": 0, "start": "2019-01-26 20:03:29.458351", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cassandra-loadgen \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cassandra-loadgen ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-01-26T20:03:29.915149 (delta: 0.806605)         elapsed: 6.06047 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.176945", "end": "2019-01-26 20:03:31.257597", "failed_when_result": false, "rc": 0, "start": "2019-01-26 20:03:30.080652", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cassandra-loadgen configured", "stdout_lines": ["litmusresult.litmus.io/cassandra-loadgen configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-01-26T20:03:31.320809 (delta: 1.405556)         elapsed: 7.46613 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-01-26T20:03:31.363216 (delta: 0.042341)         elapsed: 7.508537 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-01-26T20:03:31.397065 (delta: 0.033812)         elapsed: 7.542386 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-01-26T20:03:31.431467 (delta: 0.034304)         elapsed: 7.576788 ******** 
included: /common/utils/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-01-26T20:03:31.494076 (delta: 0.062496)         elapsed: 7.639397 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-esearch-ns -o custom-columns=:status.phase --no-headers", "delta": "0:00:00.586608", "end": "2019-01-26 20:03:32.232677", "rc": 0, "start": "2019-01-26 20:03:31.646069", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [include_tasks] ***********************************************************
2019-01-26T20:03:32.300315 (delta: 0.806195)         elapsed: 8.445636 ******** 
included: /common/utils/check_statefulset_status.yml for 127.0.0.1

TASK [Obtain the number of replicas.] ******************************************
2019-01-26T20:03:32.392818 (delta: 0.091392)         elapsed: 8.538139 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-esearch-ns -l app=elasticsearch -o custom-columns=:spec.replicas", "delta": "0:00:00.522782", "end": "2019-01-26 20:03:33.104500", "rc": 0, "start": "2019-01-26 20:03:32.581718", "stderr": "", "stderr_lines": [], "stdout": "\n1", "stdout_lines": ["", "1"]}

TASK [Obtain the ready replica count and compare with the replica count.] ******
2019-01-26T20:03:33.161088 (delta: 0.768215)         elapsed: 9.306409 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get statefulset -n app-esearch-ns -l app=elasticsearch -o custom-columns=:..readyReplicas", "delta": "0:00:00.569911", "end": "2019-01-26 20:03:33.940731", "rc": 0, "start": "2019-01-26 20:03:33.370820", "stderr": "", "stderr_lines": [], "stdout": "\n1", "stdout_lines": ["", "1"]}

TASK [Obtaining the loadgen pod label from env.] *******************************
2019-01-26T20:03:33.989545 (delta: 0.828416)         elapsed: 10.134866 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"loadgen_lkey": "loadgen", "loadgen_lvalue": "elasticsearch-loadgen"}, "changed": false}

TASK [Replace the label in loadgen job spec.] **********************************
2019-01-26T20:03:34.084769 (delta: 0.095117)         elapsed: 10.23009 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Create Elasticsearch loadgen Job] ****************************************
2019-01-26T20:03:34.505090 (delta: 0.420278)         elapsed: 10.650411 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f elasticsearch_loadgen.yml -n app-esearch-ns", "delta": "0:00:00.732189", "end": "2019-01-26 20:03:35.408600", "failed_when_result": false, "rc": 0, "start": "2019-01-26 20:03:34.676411", "stderr": "", "stderr_lines": [], "stdout": "job.batch/elasticsearch-loadgen created", "stdout_lines": ["job.batch/elasticsearch-loadgen created"]}

TASK [Verify load is running for specified duration] ***************************
2019-01-26T20:03:35.498511 (delta: 0.993381)         elapsed: 11.643832 ******* 
FAILED - RETRYING: Verify load is running for specified duration (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n app-esearch-ns -l loadgen=elasticsearch-loadgen", "delta": "0:00:00.535700", "end": "2019-01-26 20:04:07.154816", "rc": 0, "start": "2019-01-26 20:04:06.619116", "stderr": "", "stderr_lines": [], "stdout": "NAME                          READY   STATUS    RESTARTS   AGE\nelasticsearch-loadgen-rnjlh   1/1     Running   0          32s", "stdout_lines": ["NAME                          READY   STATUS    RESTARTS   AGE", "elasticsearch-loadgen-rnjlh   1/1     Running   0          32s"]}

TASK [Wait for 60 secs to run load.] *******************************************
2019-01-26T20:04:07.208754 (delta: 31.7102)         elapsed: 43.354075 ******** 
ok: [127.0.0.1] => {"changed": false, "elapsed": 60, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Obtaining the application pod name.] *************************************
2019-01-26T20:05:07.767579 (delta: 60.558791)         elapsed: 103.9129 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get statefulset -n app-esearch-ns --no-headers -l app=elasticsearch -o custom-columns=:metadata.name", "delta": "0:00:00.824394", "end": "2019-01-26 20:05:08.732676", "rc": 0, "start": "2019-01-26 20:05:07.908282", "stderr": "", "stderr_lines": [], "stdout": "elasticsearch-logging", "stdout_lines": ["elasticsearch-logging"]}

TASK [Recording the application pod name.] *************************************
2019-01-26T20:05:08.799710 (delta: 1.032094)         elapsed: 104.945031 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"app_name": "elasticsearch-logging"}, "changed": false}

TASK [Forming one of the replicas name statefulset application name.] **********
2019-01-26T20:05:08.881739 (delta: 0.081951)         elapsed: 105.02706 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replica_name": "elasticsearch-logging-0"}, "changed": false}

TASK [Check the CPU write operations active status.] ***************************
2019-01-26T20:05:08.968999 (delta: 0.087183)         elapsed: 105.11432 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it elasticsearch-logging-0 -n app-esearch-ns -- curl -s http://localhost:9200/_cat/thread_pool/write?h=active", "delta": "0:00:01.693378", "end": "2019-01-26 20:05:10.950538", "rc": 0, "start": "2019-01-26 20:05:09.257160", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "1", "stdout_lines": ["1"]}

TASK [Verify load by checking document count.] *********************************
2019-01-26T20:05:10.998028 (delta: 2.028518)         elapsed: 107.143349 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec elasticsearch-logging-0 -n app-esearch-ns -- curl -s http://localhost:9200/_cat/thread_pool/write?h=completed", "delta": "0:00:00.809020", "end": "2019-01-26 20:05:12.027190", "failed_when_result": false, "rc": 0, "start": "2019-01-26 20:05:11.218170", "stderr": "", "stderr_lines": [], "stdout": "56", "stdout_lines": ["56"]}

TASK [Number of document written on volume.] ***********************************
2019-01-26T20:05:12.077673 (delta: 1.079606)         elapsed: 108.222994 ****** 
ok: [127.0.0.1] => {
    "msg": "Number of Documents 56"
}

TASK [set_fact] ****************************************************************
2019-01-26T20:05:12.164985 (delta: 0.087274)         elapsed: 108.310306 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-01-26T20:05:12.245667 (delta: 0.080636)         elapsed: 108.390988 ****** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-01-26T20:05:12.334912 (delta: 0.089203)         elapsed: 108.480233 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-01-26T20:05:12.391468 (delta: 0.056516)         elapsed: 108.536789 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-01-26T20:05:12.462696 (delta: 0.071185)         elapsed: 108.608017 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-01-26T20:05:12.583677 (delta: 0.120925)         elapsed: 108.728998 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "30c8112116b3665c4fb41d89a4414053a0ed7978", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f332866195403d7a86182acbdb6648e6", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1548533112.67-12556752932600/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-01-26T20:05:14.416866 (delta: 1.833145)         elapsed: 110.562187 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.448240", "end": "2019-01-26 20:05:15.106076", "rc": 0, "start": "2019-01-26 20:05:14.657836", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: cassandra-loadgen \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: cassandra-loadgen ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-01-26T20:05:15.160330 (delta: 0.743422)         elapsed: 111.305651 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.867058", "end": "2019-01-26 20:05:16.231268", "failed_when_result": false, "rc": 0, "start": "2019-01-26 20:05:15.364210", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/cassandra-loadgen configured", "stdout_lines": ["litmusresult.litmus.io/cassandra-loadgen configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=27   changed=15   unreachable=0    failed=0   

2019-01-26T20:05:16.345627 (delta: 1.185255)         elapsed: 112.490948 ****** 
=============================================================================== ```