### PR TITLE
Obtaining the resource version and checking it after restart

### DIFF
--- a/chaoslib/openebs/jiva_replica_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_replica_pod_failure.yaml
@@ -23,7 +23,7 @@
 - name: Get the resourceVersion of the replica deploy before fault injection
   shell: >
     kubectl get deploy {{ jiva_replica_deploy }} -n {{ app_ns }} 
-    -o yaml | grep resourceVersion | awk '{print $2}' | sed 's|"||g'
+    -o yaml | grep resourceVersion | awk '{print $2}' | sed 's|"||g' | awk 'FNR == 2 {print}'
   args:
     executable: /bin/bash
   register: rv_bef
@@ -57,7 +57,7 @@
 - name: Get the resourceVersion of the replica deploy after fault injection
   shell: >
     kubectl get deploy {{ jiva_replica_deploy }} -n {{ app_ns }} 
-    -o yaml | grep resourceVersion | awk '{print $2}' | sed 's|"||g'
+    -o yaml | grep resourceVersion | awk '{print $2}' | sed 's|"||g' | awk 'FNR == 2 {print}'
   args:
     executable: /bin/bash
   register: rv_aft


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

- Obtaining the second row of the resourceversion object.
- It was impacting the single replica failure where we compare the earlier resourceversion with the one after restart. 