### PR TITLE
Using custom-column to derive resourceversion of replica deployment i…

### DIFF
--- a/chaoslib/openebs/jiva_replica_pod_failure.yaml
+++ b/chaoslib/openebs/jiva_replica_pod_failure.yaml
@@ -23,7 +23,7 @@
 - name: Get the resourceVersion of the replica deploy before fault injection
   shell: >
     kubectl get deploy {{ jiva_replica_deploy }} -n {{ app_ns }} 
-    -o yaml | grep resourceVersion | awk '{print $2}' | sed 's|"||g' | awk 'FNR == 2 {print}'
+    --no-headers -o custom-columns=:metadata.resourceVersion
   args:
     executable: /bin/bash
   register: rv_bef
@@ -57,7 +57,7 @@
 - name: Get the resourceVersion of the replica deploy after fault injection
   shell: >
     kubectl get deploy {{ jiva_replica_deploy }} -n {{ app_ns }} 
-    -o yaml | grep resourceVersion | awk '{print $2}' | sed 's|"||g' | awk 'FNR == 2 {print}'
+    --no-headers -o custom-columns=:metadata.resourceVersion
   args:
     executable: /bin/bash
   register: rv_aft


### PR DESCRIPTION
…n replica failure util

Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

- Rather than using awk , custom-columns has been used to derive the resourceVersion of replica deployment. 
