### PR TITLE
Litmusbook for upgrading cstor and jiva volume from 0.8.0 to 0.8.1

### DIFF
--- a/common/utils/openebs/openebs_upgrade.yml
+++ b/common/utils/openebs/openebs_upgrade.yml
@@ -80,7 +80,7 @@
           register: value
           failed_when: "'off' in value.stdout"
 
-        - name: Verify the conatiner image of cstor pool pods.
+        - name: Verify the conatiner image of cstor pool pods post upgrade.
           shell: >
               kubectl get pod {{ cstor_pool_pod.stdout }} -n {{ operator_ns }}
               -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c
@@ -110,7 +110,7 @@
           delay: 30
           retries: 10
 
-        - name: verify the containers image of target pod.
+        - name: Verify the containers image of target pod post upgrade.
           shell: >
               kubectl get pod {{ cstor_target_pod.stdout }} -n 
               {{ operator_ns }} -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c
@@ -160,7 +160,7 @@
           retries: 5
           delay: 10
 
-        - name: Check the upgraded image of ctrl pod containers.
+        - name: Check the ctrl pod container image post upgrade.
           shell: >
               kubectl get pod {{ jiva_ctrl_pod_after_upgrde.stdout }} -n {{ app_ns }}
               -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c
@@ -178,7 +178,7 @@
             executable: /bin/bash
           register: jiva_replica_pod
 
-        - name: Verify the jiva  containers upgraded image.
+        - name: Verify the jiva replica container image post upgrade.
           shell: >
                 kubectl get pod {{ jiva_replica_pod.stdout }} -n {{ app_ns }}
                 -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c

--- a/common/utils/openebs/openebs_upgrade.yml
+++ b/common/utils/openebs/openebs_upgrade.yml
@@ -1,0 +1,192 @@
+
+- name: Obtain the PV.
+  shell: kubectl get pvc {{ pv_claim }} -n {{ app_ns }} --no-headers -o custom-columns=:spec.volumeName
+  register: pv
+
+- name: Record volume name.
+  set_fact:
+     vol_name: "{{ pv.stdout }}"
+
+- block:
+
+    - block:
+        - name: Obtain the storage pool claim name.
+          shell: kubectl get spc --no-headers -o=custom-columns=NAME:.metadata.name
+          register: spc
+
+        - name: Record the spc.
+          set_fact:
+             storage_pool_claim: "{{ spc.stdout }}"
+
+        - name: Subtitute the cstor pool and volume script with  upgrade version release tag.
+          lineinfile:
+           path: "{{ item.path }}"
+           regexp: "{{ item.regexp }}"
+           line: "{{ item.line }}"
+          with_items:
+           - { path: '/openebs_upgrade/cstor_pool_upgrade.sh', regexp: '^pool_upgrade_version=', line: 'pool_upgrade_version={{ new_tag }}'}
+           - { path: '/openebs_upgrade/cstor_volume_upgrade.sh', regexp: '^target_upgrade_version=', line: 'target_upgrade_version={{ new_tag }}'}
+
+        #  containers cstor_pool and cstor_pool_mgmt  upgrade from cstor_pool_upgrade.sh #
+        #  containers cstor_istgt,maya-volume-exporter,cstor-volume-mgmt upgrade from cstor_volume_upgrade.sh 
+
+        - name: Trigger the cstor pool and  volume upgrade.
+          shell: "{{ item }}"
+          args:
+            chdir: "/openebs_upgrade"
+            executable: "/bin/bash"
+          with_items:
+            - "./cstor_pool_upgrade.sh {{ storage_pool_claim }} {{ operator_ns }} "
+            - "./cstor_volume_upgrade.sh {{ vol_name }} {{ operator_ns }}"
+
+        - include_tasks: /common/utils/check_deployment_status.yml
+
+        - name: Randomly select the pool deployment from cvr
+          shell: >
+              kubectl get cvr -n {{ operator_ns }}
+              -l openebs.io/persistent-volume={{ vol_name }} --no-headers
+              -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}' |
+              shuf -n1 | awk '{print $1}'
+          args:
+            executable: /bin/bash
+          register: pool_deployment
+
+        - name: Get the pod of pool deployment
+          shell: >
+            kubectl get pods -n {{ operator_ns }} |
+            grep {{ pool_deployment.stdout }} | grep -w "Running" | awk '{print $1}'
+          args:
+            executable: /bin/bash
+          register: cstor_pool_pod
+
+        - name: Get the runningStatus of pool pod
+          shell: >
+             kubectl get pod {{ cstor_pool_pod.stdout }} -n {{ operator_ns }}
+             -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
+             grep -w running | wc -l
+          args:
+            executable: /bin/bash
+          register: runningStatusCount
+          until: "runningStatusCount.stdout == \"2\""
+          delay: 2
+          retries: 150
+
+        - name: Verify the pool pod quorum value is set to on.
+          shell: >
+             kubectl exec {{ cstor_pool_pod.stdout }} -n {{ operator_ns }}
+             -c cstor-pool-mgmt -- zfs get quorum | grep -ow off | wc -l
+          args:
+            executable: /bin/bash
+          register: value
+          failed_when: "'off' in value.stdout"
+
+        - name: Verify the conatiner image of cstor pool pods.
+          shell: >
+              kubectl get pod {{ cstor_pool_pod.stdout }} -n {{ operator_ns }}
+              -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c
+          args:
+            executable: /bin/bash
+          register: cpool_image
+          failed_when: " new_tag not in cpool_image.stdout "
+
+        - name: Pick a cStor target pod belonging to the PV
+          shell: >
+            kubectl get pods -l openebs.io/target=cstor-target
+            -n {{ operator_ns }} --no-headers | grep {{ vol_name }}
+            | shuf -n1 | awk '{print $1}'
+          args:
+            executable: /bin/bash
+          register: cstor_target_pod
+
+        - name: Get the runningStatus of target pod
+          shell: >
+            kubectl get pod {{ cstor_target_pod.stdout }} -n {{ operator_ns }}
+            -o=jsonpath='{range .status.containerStatuses[*]}{.state}{"\n"}{end}' |
+            grep -w running | wc -l
+          args:
+            executable: /bin/bash
+          register: runningStatusCount
+          until: "runningStatusCount.stdout == \"3\""
+          delay: 30
+          retries: 10
+
+        - name: verify the containers image of target pod.
+          shell: >
+              kubectl get pod {{ cstor_target_pod.stdout }} -n 
+              {{ operator_ns }} -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c
+          args: 
+            executable: /bin/bash
+          register: target_images
+          failed_when: "new_tag not in target_images.stdout"
+
+      when: lookup('env','STORAGE_ENGINE') == 'cstor'
+
+    - block:
+
+        - name: Identify the initial jiva ctrl pod name before upgrade.
+          shell: >
+             kubectl get pods -l openebs.io/controller=jiva-controller
+             -n {{ app_ns }} --no-headers | grep {{ vol_name }}
+             | awk '{print $1}'
+          args:
+            executable: /bin/bash
+          register: jiva_ctrl_pod_bfr_upgrd
+
+        - name: Subtitute the target upgrade version release tag.
+          lineinfile:
+            path: /openebs_upgrade/jiva_volume_upgrade.sh
+            regexp: '^target_upgrade_version='
+            line: 'target_upgrade_version={{ new_tag }}'
+
+        ## ctrl containers jiva and m-exporter + replica container jiva upgrade ##
+
+        - name: Trigger the jiva volume upgrade.
+          shell: "/openebs_upgrade/jiva_volume_upgrade.sh {{ vol_name }}"
+          args:
+            chdir: "/openebs_upgrade"
+            executable: "/bin/bash"
+
+        - include_tasks: /common/utils/check_deployment_status.yml
+
+        - name: Checking the presence of initial jiva ctrl pod.
+          shell: >
+              kubectl get pods -l openebs.io/controller=jiva-controller
+              -n {{ app_ns }} --no-headers | grep {{ vol_name }}
+              | awk '{print $1}'
+          args:
+            executable: /bin/bash
+          register: jiva_ctrl_pod_after_upgrde
+          until: "jiva_ctrl_pod_bfr_upgrd.stdout not in jiva_ctrl_pod_after_upgrde.stdout"
+          retries: 5
+          delay: 10
+
+        - name: Check the upgraded image of ctrl pod containers.
+          shell: >
+              kubectl get pod {{ jiva_ctrl_pod_after_upgrde.stdout }} -n {{ app_ns }}
+              -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c
+          args:
+            executable: /bin/bash
+          register: ctrl_image
+          failed_when: " new_tag not in ctrl_image.stdout "
+
+        - name: Identify the jiva replica pod belonging to the PV
+          shell: >
+            kubectl get pods -l openebs.io/replica=jiva-replica
+            -n {{ app_ns }} --no-headers | grep {{ pv.stdout }}
+            | awk 'FNR == 1 {print}'| awk {'print $1'}
+          args:
+            executable: /bin/bash
+          register: jiva_replica_pod
+
+        - name: Verify the jiva  containers upgraded image.
+          shell: >
+                kubectl get pod {{ jiva_replica_pod.stdout }} -n {{ app_ns }}
+                -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c
+          args:
+             executable: /bin/bash
+          register: rep_image
+          failed_when: "new_tag not in rep_image.stdout"
+
+      when:  lookup('env','STORAGE_ENGINE')  == 'jiva'
+
+

--- a/common/utils/openebs/upgrade/run_litmus_test.yml
+++ b/common/utils/openebs/upgrade/run_litmus_test.yml
@@ -1,0 +1,55 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: openebs-upgrade-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: openebs-upgrade
+      namespace: litmus
+      labels:
+        loadgen: openebs-upgradejob
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays
+            value: default
+            
+          - name: APP_LABEL
+            value: name=percona
+
+          - name: APP_PVC
+            value: percona-mysql-claim
+  
+          - name: DEPLOY_TYPE
+            value: deployment
+
+            #Namespace in which loadgen pod will be deployed
+          - name: APP_NAMESPACE
+            value: app-percona-ns
+
+          - name: LIVENESS_APP_LABEL
+            value: "liveness=percona-liveness"
+
+          - name: LIVENESS_APP_NAMESPACE
+            value: "litmus" 
+
+          - name: SOURCE_DESTINATION_TAG
+            value: "0.8.0-0.8.1"
+
+          - name: STORAGE_ENGINE
+            value: "jiva"
+
+          - name: RELEASE_TAG
+            value: "0.8.1-RC1"
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./common/utils/openebs/upgrade/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/common/utils/openebs/upgrade/test.yml
+++ b/common/utils/openebs/upgrade/test.yml
@@ -8,8 +8,8 @@
   tasks:
     - block:
 
-#        - include_tasks: /common/utils/application_liveness_check.yml
-#          when: liveness_label != ''
+        - include_tasks: /common/utils/application_liveness_check.yml
+          when: liveness_label != ''
 
         - include: test_prerequisites.yml
 
@@ -36,7 +36,6 @@
           vars:
             app_ns: "{{ namespace }}"
             operator_ns: "{{ operator_namespace }}"
-            upgrade_duration: "{{ upgrade_time }}" 
             pv_claim : "{{pvc}}"
          
         # Ensuring if the application is running after upgrade.

--- a/common/utils/openebs/upgrade/test.yml
+++ b/common/utils/openebs/upgrade/test.yml
@@ -1,0 +1,62 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+#        - include_tasks: /common/utils/application_liveness_check.yml
+#          when: liveness_label != ''
+
+        - include: test_prerequisites.yml
+
+         ## RECORD START OF THE TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/create_testname.yml
+ 
+       ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        # Ensuring if the application is running before starting upgrade.
+        - include_tasks: /common/utils/status_app_pod.yml
+          vars:
+             app_ns: "{{ namespace }}"
+             app_lkey: "{{ app_label.split('=')[0] }}"
+             app_lvalue: "{{ app_label.split('=')[1] }}"
+             delay: 10
+             retries: 5
+       
+       # TRIGGER OPENEBS IMAGE UPGRADE UTILS
+
+        - include_tasks: /common/utils/openebs/openebs_upgrade.yml
+          vars:
+            app_ns: "{{ namespace }}"
+            operator_ns: "{{ operator_namespace }}"
+            upgrade_duration: "{{ upgrade_time }}" 
+            pv_claim : "{{pvc}}"
+         
+        # Ensuring if the application is running after upgrade.
+        - include_tasks: /common/utils/status_app_pod.yml
+          vars:
+              app_ns: '{{ namespace }}'
+              app_lkey: "{{ app_label.split('=')[0] }}"
+              app_lvalue: "{{ app_label.split('=')[1] }}"
+              delay: 10
+              retries: 5
+              
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'

--- a/common/utils/openebs/upgrade/test_prerequisites.yml
+++ b/common/utils/openebs/upgrade/test_prerequisites.yml
@@ -11,13 +11,12 @@
   register: version
   failed_when: "'no packages found' in version.stdout"
 
-
 # Get the openebs upgrade artifacts form openebs repository.
 - subversion:
     repo: "{{ git_repo }}{{ version_tag }}"
     dest: /openebs_upgrade/
 
-- name: Check presence required openebs_upgrade files
+- name: Check presence of required upgrade scripts.
   find:
     paths: /openebs_upgrade/
     recurse: no

--- a/common/utils/openebs/upgrade/test_prerequisites.yml
+++ b/common/utils/openebs/upgrade/test_prerequisites.yml
@@ -1,0 +1,30 @@
+---
+- name: Update repositories cache and install subversion package
+  apt:
+    name: subversion
+    update_cache: yes
+
+- name: check for subvsersion installation.
+  shell: dpkg-query -l 'subversion'
+  args:
+    executable: /bin/bash
+  register: version
+  failed_when: "'no packages found' in version.stdout"
+
+
+# Get the openebs upgrade artifacts form openebs repository.
+- subversion:
+    repo: "{{ git_repo }}{{ version_tag }}"
+    dest: /openebs_upgrade/
+
+- name: Check presence required openebs_upgrade files
+  find:
+    paths: /openebs_upgrade/
+    recurse: no
+    file_type: file
+  register: list 
+
+- debug: 
+    msg: "{{ list.files }}"
+
+

--- a/common/utils/openebs/upgrade/test_vars.yml
+++ b/common/utils/openebs/upgrade/test_vars.yml
@@ -1,0 +1,10 @@
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+test_name: openebs-upgrade-test
+app_label: "{{ lookup('env','APP_LABEL') }}"
+operator_namespace: openebs
+pvc: "{{ lookup('env','APP_PVC') }}"
+liveness_label: "{{ lookup('env','LIVENESS_APP_LABEL') }}"
+liveness_namespace: "{{ lookup('env','LIVENESS_APP_NAMESPACE') }}"
+version_tag: "{{ lookup('env','SOURCE_DESTINATION_TAG') }}"
+git_repo: https://github.com/openebs/openebs/trunk/k8s/upgrades/
+new_tag: "{{ lookup('env', 'RELEASE_TAG') }}"


### PR DESCRIPTION
Signed-off-by: Ubuntu <vibhor.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
1) This PR consist of automation of cstor volume and jiva volume upgrade with necessary pre and post checks.
2) Available 0.8.1-RC1 release tag is used here for upgrade.
3) Using a svn module to get the upgrade script from git with specified 0.8.0-0.8.1 upgrade script folder.




**Special notes for your reviewer**: This test is performed on percona deployment 
@dargasudarshan @nsathyaseelan @gprasath @vishnuitta @mittachaitu

FOR JIVA UPGRADE LOGS 
```ansible-playbook 2.7.6
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /common/utils/openebs/upgrade/test_prerequisites.yml

PLAYBOOK: test.yml *************************************************************
1 plays in ./common/utils/openebs/upgrade/test.yml

PLAY [localhost] ***************************************************************
2019-02-11T09:53:59.848944 (delta: 0.03544)         elapsed: 0.03544 ********** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /common/utils/openebs/upgrade/test.yml:2
2019-02-11T09:53:59.856768 (delta: 0.007799)         elapsed: 0.043264 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [Update repositories cache and install subversion package] ****************
task path: /common/utils/openebs/upgrade/test_prerequisites.yml:2
2019-02-11T09:54:02.813202 (delta: 2.956418)         elapsed: 2.999698 ******** 
changed: [127.0.0.1] => {"cache_update_time": 1549878845, "cache_updated": false, "changed": true, "stderr": "debconf: delaying package configuration, since apt-utils is not installed\n", "stderr_lines": ["debconf: delaying package configuration, since apt-utils is not installed"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libapr1 libaprutil1 libserf-1-1 libsvn1\nSuggested packages:\n  db5.3-util libapache2-mod-svn subversion-tools\nThe following NEW packages will be installed:\n  libapr1 libaprutil1 libserf-1-1 libsvn1 subversion\n0 upgraded, 5 newly installed, 0 to remove and 13 not upgraded.\nNeed to get 2237 kB of archives.\nAfter this operation, 9910 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 libapr1 amd64 1.6.3-2 [90.9 kB]\nGet:2 http://archive.ubuntu.com/ubuntu bionic/main amd64 libaprutil1 amd64 1.6.1-2 [84.4 kB]\nGet:3 http://archive.ubuntu.com/ubuntu bionic/universe amd64 libserf-1-1 amd64 1.3.9-6 [44.4 kB]\nGet:4 http://archive.ubuntu.com/ubuntu bionic/universe amd64 libsvn1 amd64 1.9.7-4ubuntu1 [1183 kB]\nGet:5 http://archive.ubuntu.com/ubuntu bionic/universe amd64 subversion amd64 1.9.7-4ubuntu1 [834 kB]\nFetched 2237 kB in 1s (1498 kB/s)\nSelecting previously unselected package libapr1:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 15493 files and directories currently installed.)\r\nPreparing to unpack .../libapr1_1.6.3-2_amd64.deb ...\r\nUnpacking libapr1:amd64 (1.6.3-2) ...\r\nSelecting previously unselected package libaprutil1:amd64.\r\nPreparing to unpack .../libaprutil1_1.6.1-2_amd64.deb ...\r\nUnpacking libaprutil1:amd64 (1.6.1-2) ...\r\nSelecting previously unselected package libserf-1-1:amd64.\r\nPreparing to unpack .../libserf-1-1_1.3.9-6_amd64.deb ...\r\nUnpacking libserf-1-1:amd64 (1.3.9-6) ...\r\nSelecting previously unselected package libsvn1:amd64.\r\nPreparing to unpack .../libsvn1_1.9.7-4ubuntu1_amd64.deb ...\r\nUnpacking libsvn1:amd64 (1.9.7-4ubuntu1) ...\r\nSelecting previously unselected package subversion.\r\nPreparing to unpack .../subversion_1.9.7-4ubuntu1_amd64.deb ...\r\nUnpacking subversion (1.9.7-4ubuntu1) ...\r\nSetting up libapr1:amd64 (1.6.3-2) ...\r\nProcessing triggers for libc-bin (2.27-3ubuntu1) ...\r\nSetting up libaprutil1:amd64 (1.6.1-2) ...\r\nSetting up libserf-1-1:amd64 (1.3.9-6) ...\r\nSetting up libsvn1:amd64 (1.9.7-4ubuntu1) ...\r\nSetting up subversion (1.9.7-4ubuntu1) ...\r\nProcessing triggers for libc-bin (2.27-3ubuntu1) ...\r\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libapr1 libaprutil1 libserf-1-1 libsvn1", "Suggested packages:", "  db5.3-util libapache2-mod-svn subversion-tools", "The following NEW packages will be installed:", "  libapr1 libaprutil1 libserf-1-1 libsvn1 subversion", "0 upgraded, 5 newly installed, 0 to remove and 13 not upgraded.", "Need to get 2237 kB of archives.", "After this operation, 9910 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu bionic/main amd64 libapr1 amd64 1.6.3-2 [90.9 kB]", "Get:2 http://archive.ubuntu.com/ubuntu bionic/main amd64 libaprutil1 amd64 1.6.1-2 [84.4 kB]", "Get:3 http://archive.ubuntu.com/ubuntu bionic/universe amd64 libserf-1-1 amd64 1.3.9-6 [44.4 kB]", "Get:4 http://archive.ubuntu.com/ubuntu bionic/universe amd64 libsvn1 amd64 1.9.7-4ubuntu1 [1183 kB]", "Get:5 http://archive.ubuntu.com/ubuntu bionic/universe amd64 subversion amd64 1.9.7-4ubuntu1 [834 kB]", "Fetched 2237 kB in 1s (1498 kB/s)", "Selecting previously unselected package libapr1:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 15493 files and directories currently installed.)", "Preparing to unpack .../libapr1_1.6.3-2_amd64.deb ...", "Unpacking libapr1:amd64 (1.6.3-2) ...", "Selecting previously unselected package libaprutil1:amd64.", "Preparing to unpack .../libaprutil1_1.6.1-2_amd64.deb ...", "Unpacking libaprutil1:amd64 (1.6.1-2) ...", "Selecting previously unselected package libserf-1-1:amd64.", "Preparing to unpack .../libserf-1-1_1.3.9-6_amd64.deb ...", "Unpacking libserf-1-1:amd64 (1.3.9-6) ...", "Selecting previously unselected package libsvn1:amd64.", "Preparing to unpack .../libsvn1_1.9.7-4ubuntu1_amd64.deb ...", "Unpacking libsvn1:amd64 (1.9.7-4ubuntu1) ...", "Selecting previously unselected package subversion.", "Preparing to unpack .../subversion_1.9.7-4ubuntu1_amd64.deb ...", "Unpacking subversion (1.9.7-4ubuntu1) ...", "Setting up libapr1:amd64 (1.6.3-2) ...", "Processing triggers for libc-bin (2.27-3ubuntu1) ...", "Setting up libaprutil1:amd64 (1.6.1-2) ...", "Setting up libserf-1-1:amd64 (1.3.9-6) ...", "Setting up libsvn1:amd64 (1.9.7-4ubuntu1) ...", "Setting up subversion (1.9.7-4ubuntu1) ...", "Processing triggers for libc-bin (2.27-3ubuntu1) ..."]}

TASK [check for subvsersion installation.] *************************************
task path: /common/utils/openebs/upgrade/test_prerequisites.yml:7
2019-02-11T09:54:17.269870 (delta: 14.456641)         elapsed: 17.456366 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "dpkg-query -l 'subversion'", "delta": "0:00:00.319533", "end": "2019-02-11 09:54:17.773764", "failed_when_result": false, "rc": 0, "start": "2019-02-11 09:54:17.454231", "stderr": "", "stderr_lines": [], "stdout": "Desired=Unknown/Install/Remove/Purge/Hold\n| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend\n|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)\n||/ Name           Version        Architecture Description\n+++-==============-==============-============-=================================\nii  subversion     1.9.7-4ubuntu1 amd64        Advanced version control system", "stdout_lines": ["Desired=Unknown/Install/Remove/Purge/Hold", "| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend", "|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)", "||/ Name           Version        Architecture Description", "+++-==============-==============-============-=================================", "ii  subversion     1.9.7-4ubuntu1 amd64        Advanced version control system"]}

TASK [subversion] **************************************************************
task path: /common/utils/openebs/upgrade/test_prerequisites.yml:16
2019-02-11T09:54:17.811461 (delta: 0.541565)         elapsed: 17.997957 ******* 
changed: [127.0.0.1] => {"after": ["Revision: 2553", "URL: https://github.com/openebs/openebs/trunk/k8s/upgrades/0.8.0-0.8.1"], "before": null, "changed": true}

TASK [Check presence required openebs_upgrade files] ***************************
task path: /common/utils/openebs/upgrade/test_prerequisites.yml:20
2019-02-11T09:54:21.039874 (delta: 3.228386)         elapsed: 21.22637 ******** 
ok: [127.0.0.1] => {"changed": false, "examined": 16, "files": [{"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876192, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/jiva-target-patch.tpl.json", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 835, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876184, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/cstor-target-patch.tpl.json", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 1101, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876186, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/cstor-volume-patch.tpl.json", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 234, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876190, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0755", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/cstor_volume_upgrade.sh", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 9465, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": true, "xoth": true, "xusr": true}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876187, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/cstor-volume-replica-patch.tpl.json", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 234, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, {"atime": 1549878860.676315, "ctime": 1549878860.676315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876181, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1549878860.676315, "nlink": 1, "path": "/openebs_upgrade/README.md", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 5221, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876189, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0755", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/cstor_pool_upgrade.sh", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 5812, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": true, "xoth": true, "xusr": true}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876193, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/jiva-target-svc-patch.tpl.json", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 234, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, {"atime": 1549878860.676315, "ctime": 1549878860.676315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876182, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1549878860.676315, "nlink": 1, "path": "/openebs_upgrade/cr-patch.tpl.json", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 95, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876194, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0755", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/jiva_volume_upgrade.sh", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 9969, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": true, "xoth": true, "xusr": true}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876185, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/cstor-target-svc-patch.tpl.json", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 234, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876188, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0755", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/cstor_pool_post_upgrade.sh", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 1934, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": true, "xoth": true, "xusr": true}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876195, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/patch-strategy-recreate.json", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 140, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876191, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/jiva-replica-patch.tpl.json", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 784, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, {"atime": 1549878860.680315, "ctime": 1549878860.680315, "dev": 51713, "gid": 0, "gr_name": "root", "inode": 4876183, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1549878860.680315, "nlink": 1, "path": "/openebs_upgrade/cstor-pool-patch.tpl.json", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 1247, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}], "matched": 15, "msg": ""}

TASK [debug] *******************************************************************
task path: /common/utils/openebs/upgrade/test_prerequisites.yml:27
2019-02-11T09:54:21.307383 (delta: 0.267482)         elapsed: 21.493879 ******* 
ok: [127.0.0.1] => {
    "msg": [
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876192, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0644", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/jiva-target-patch.tpl.json", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 835, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": false, 
            "xoth": false, 
            "xusr": false
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876184, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0644", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/cstor-target-patch.tpl.json", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 1101, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": false, 
            "xoth": false, 
            "xusr": false
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876186, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0644", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/cstor-volume-patch.tpl.json", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 234, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": false, 
            "xoth": false, 
            "xusr": false
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876190, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0755", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/cstor_volume_upgrade.sh", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 9465, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": true, 
            "xoth": true, 
            "xusr": true
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876187, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0644", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/cstor-volume-replica-patch.tpl.json", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 234, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": false, 
            "xoth": false, 
            "xusr": false
        }, 
        {
            "atime": 1549878860.676315, 
            "ctime": 1549878860.676315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876181, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0644", 
            "mtime": 1549878860.676315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/README.md", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 5221, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": false, 
            "xoth": false, 
            "xusr": false
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876189, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0755", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/cstor_pool_upgrade.sh", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 5812, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": true, 
            "xoth": true, 
            "xusr": true
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876193, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0644", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/jiva-target-svc-patch.tpl.json", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 234, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": false, 
            "xoth": false, 
            "xusr": false
        }, 
        {
            "atime": 1549878860.676315, 
            "ctime": 1549878860.676315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876182, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0644", 
            "mtime": 1549878860.676315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/cr-patch.tpl.json", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 95, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": false, 
            "xoth": false, 
            "xusr": false
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876194, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0755", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/jiva_volume_upgrade.sh", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 9969, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": true, 
            "xoth": true, 
            "xusr": true
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876185, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0644", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/cstor-target-svc-patch.tpl.json", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 234, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": false, 
            "xoth": false, 
            "xusr": false
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876188, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0755", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/cstor_pool_post_upgrade.sh", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 1934, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": true, 
            "xoth": true, 
            "xusr": true
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876195, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0644", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/patch-strategy-recreate.json", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 140, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": false, 
            "xoth": false, 
            "xusr": false
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876191, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0644", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/jiva-replica-patch.tpl.json", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 784, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": false, 
            "xoth": false, 
            "xusr": false
        }, 
        {
            "atime": 1549878860.680315, 
            "ctime": 1549878860.680315, 
            "dev": 51713, 
            "gid": 0, 
            "gr_name": "root", 
            "inode": 4876183, 
            "isblk": false, 
            "ischr": false, 
            "isdir": false, 
            "isfifo": false, 
            "isgid": false, 
            "islnk": false, 
            "isreg": true, 
            "issock": false, 
            "isuid": false, 
            "mode": "0644", 
            "mtime": 1549878860.680315, 
            "nlink": 1, 
            "path": "/openebs_upgrade/cstor-pool-patch.tpl.json", 
            "pw_name": "root", 
            "rgrp": true, 
            "roth": true, 
            "rusr": true, 
            "size": 1247, 
            "uid": 0, 
            "wgrp": false, 
            "woth": false, 
            "wusr": true, 
            "xgrp": false, 
            "xoth": false, 
            "xusr": false
        }
    ]
}

TASK [include_tasks] ***********************************************************
task path: /common/utils/openebs/upgrade/test.yml:17
2019-02-11T09:54:21.370719 (delta: 0.063309)         elapsed: 21.557215 ******* 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /common/utils/create_testname.yml:3
2019-02-11T09:54:21.422201 (delta: 0.051456)         elapsed: 21.608697 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /common/utils/create_testname.yml:7
2019-02-11T09:54:21.459547 (delta: 0.037316)         elapsed: 21.646043 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /common/utils/openebs/upgrade/test.yml:20
2019-02-11T09:54:21.497147 (delta: 0.037572)         elapsed: 21.683643 ******* 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-02-11T09:54:21.560420 (delta: 0.063243)         elapsed: 21.746916 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "94e0d5772e35ea6ba61ad38cd046e0f67efcb400", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "e4ed2437b77b0dc3cc9c1f731cc35b70", "mode": "0644", "owner": "root", "size": 421, "src": "/root/.ansible/tmp/ansible-tmp-1549878861.59-109606584996114/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-02-11T09:54:21.963730 (delta: 0.403279)         elapsed: 22.150226 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.307916", "end": "2019-02-11 09:54:22.373110", "rc": 0, "start": "2019-02-11 09:54:22.065194", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-upgrade-test \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-upgrade-test ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-02-11T09:54:22.405199 (delta: 0.441444)         elapsed: 22.591695 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.096508", "end": "2019-02-11 09:54:24.602534", "failed_when_result": false, "rc": 0, "start": "2019-02-11 09:54:22.506026", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-upgrade-test configured", "stdout_lines": ["litmusresult.litmus.io/openebs-upgrade-test configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-02-11T09:54:24.638482 (delta: 2.233257)         elapsed: 24.824978 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-02-11T09:54:24.670589 (delta: 0.032079)         elapsed: 24.857085 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-02-11T09:54:24.701750 (delta: 0.031135)         elapsed: 24.888246 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /common/utils/openebs/upgrade/test.yml:25
2019-02-11T09:54:24.733213 (delta: 0.031436)         elapsed: 24.919709 ******* 
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /common/utils/status_app_pod.yml:2
2019-02-11T09:54:24.789008 (delta: 0.055769)         elapsed: 24.975504 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.377776", "end": "2019-02-11 09:54:25.275172", "rc": 0, "start": "2019-02-11 09:54:24.897396", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-02-11T09:53:03Z]]", "stdout_lines": ["map[running:map[startedAt:2019-02-11T09:53:03Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /common/utils/status_app_pod.yml:13
2019-02-11T09:54:25.312880 (delta: 0.523847)         elapsed: 25.499376 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.381489", "end": "2019-02-11 09:54:25.803488", "rc": 0, "start": "2019-02-11 09:54:25.421999", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /common/utils/openebs/upgrade/test.yml:35
2019-02-11T09:54:25.840840 (delta: 0.527933)         elapsed: 26.027336 ******* 
included: /common/utils/openebs/openebs_upgrade.yml for 127.0.0.1

TASK [Obtain the PV.] **********************************************************
task path: /common/utils/openebs/openebs_upgrade.yml:2
2019-02-11T09:54:25.941106 (delta: 0.100239)         elapsed: 26.127602 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.350703", "end": "2019-02-11 09:54:26.397721", "rc": 0, "start": "2019-02-11 09:54:26.047018", "stderr": "", "stderr_lines": [], "stdout": "pvc-b9a36e51-2de2-11e9-a340-069da208a730", "stdout_lines": ["pvc-b9a36e51-2de2-11e9-a340-069da208a730"]}

TASK [Record volume name.] *****************************************************
task path: /common/utils/openebs/openebs_upgrade.yml:6
2019-02-11T09:54:26.431893 (delta: 0.49076)         elapsed: 26.618389 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"vol_name": "pvc-b9a36e51-2de2-11e9-a340-069da208a730"}, "changed": false}

TASK [Obtain the storage pool claim name.] *************************************
task path: /common/utils/openebs/openebs_upgrade.yml:13
2019-02-11T09:54:26.481631 (delta: 0.049709)         elapsed: 26.668127 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Record the spc.] *********************************************************
task path: /common/utils/openebs/openebs_upgrade.yml:17
2019-02-11T09:54:26.518534 (delta: 0.036874)         elapsed: 26.70503 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Subtitute the cstor pool and volume script with  upgrade version release tag.] ***
task path: /common/utils/openebs/openebs_upgrade.yml:21
2019-02-11T09:54:26.553756 (delta: 0.035198)         elapsed: 26.740252 ******* 
skipping: [127.0.0.1] => (item={u'path': u'/openebs_upgrade/cstor_pool_upgrade.sh', u'line': u'pool_upgrade_version=0.8.1-RC1', u'regexp': u'^pool_upgrade_version='})  => {"changed": false, "item": {"line": "pool_upgrade_version=0.8.1-RC1", "path": "/openebs_upgrade/cstor_pool_upgrade.sh", "regexp": "^pool_upgrade_version="}, "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item={u'path': u'/openebs_upgrade/cstor_volume_upgrade.sh', u'line': u'target_upgrade_version=0.8.1-RC1', u'regexp': u'^target_upgrade_version='})  => {"changed": false, "item": {"line": "target_upgrade_version=0.8.1-RC1", "path": "/openebs_upgrade/cstor_volume_upgrade.sh", "regexp": "^target_upgrade_version="}, "skip_reason": "Conditional result was False"}

TASK [Trigger the cstor pool and  volume upgrade.] *****************************
task path: /common/utils/openebs/openebs_upgrade.yml:30
2019-02-11T09:54:26.603071 (delta: 0.049289)         elapsed: 26.789567 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /common/utils/openebs/openebs_upgrade.yml:40
2019-02-11T09:54:26.641091 (delta: 0.037995)         elapsed: 26.827587 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Randomly select the pool deployment from cvr] ****************************
task path: /common/utils/openebs/openebs_upgrade.yml:42
2019-02-11T09:54:26.676081 (delta: 0.034963)         elapsed: 26.862577 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the pod of pool deployment] ******************************************
task path: /common/utils/openebs/openebs_upgrade.yml:52
2019-02-11T09:54:26.710847 (delta: 0.034739)         elapsed: 26.897343 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the runningStatus of pool pod] ***************************************
task path: /common/utils/openebs/openebs_upgrade.yml:60
2019-02-11T09:54:26.745298 (delta: 0.034425)         elapsed: 26.931794 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify the pool pod quorum value is set to on.] **************************
task path: /common/utils/openebs/openebs_upgrade.yml:72
2019-02-11T09:54:26.779582 (delta: 0.034262)         elapsed: 26.966078 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify the conatiner image of cstor pool pods.] **************************
task path: /common/utils/openebs/openebs_upgrade.yml:81
2019-02-11T09:54:26.813995 (delta: 0.034389)         elapsed: 27.000491 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Pick a cStor target pod belonging to the PV] *****************************
task path: /common/utils/openebs/openebs_upgrade.yml:90
2019-02-11T09:54:26.848523 (delta: 0.034506)         elapsed: 27.035019 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the runningStatus of target pod] *************************************
task path: /common/utils/openebs/openebs_upgrade.yml:99
2019-02-11T09:54:26.887317 (delta: 0.038769)         elapsed: 27.073813 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [verify the containers image of target pod.] ******************************
task path: /common/utils/openebs/openebs_upgrade.yml:111
2019-02-11T09:54:26.922194 (delta: 0.034851)         elapsed: 27.10869 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the initial jiva ctrl pod name before upgrade.] *****************
task path: /common/utils/openebs/openebs_upgrade.yml:124
2019-02-11T09:54:26.957142 (delta: 0.034922)         elapsed: 27.143638 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/controller=jiva-controller -n app-percona-ns --no-headers | grep pvc-b9a36e51-2de2-11e9-a340-069da208a730 | awk '{print $1}'", "delta": "0:00:00.379637", "end": "2019-02-11 09:54:27.441952", "rc": 0, "start": "2019-02-11 09:54:27.062315", "stderr": "", "stderr_lines": [], "stdout": "pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl-7d96f549fb-kdt7x", "stdout_lines": ["pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl-7d96f549fb-kdt7x"]}

TASK [Subtitute the target upgrade version release tag.] ***********************
task path: /common/utils/openebs/openebs_upgrade.yml:133
2019-02-11T09:54:27.476253 (delta: 0.519087)         elapsed: 27.662749 ******* 
changed: [127.0.0.1] => {"backup": "", "changed": true, "msg": "line replaced"}

TASK [Trigger the jiva volume upgrade.] ****************************************
task path: /common/utils/openebs/openebs_upgrade.yml:139
2019-02-11T09:54:27.729557 (delta: 0.253276)         elapsed: 27.916053 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "/openebs_upgrade/jiva_volume_upgrade.sh pvc-b9a36e51-2de2-11e9-a340-069da208a730", "delta": "0:00:22.284016", "end": "2019-02-11 09:54:50.141244", "rc": 0, "start": "2019-02-11 09:54:27.857228", "stderr": "", "stderr_lines": [], "stdout": "Checking if the node with replica pod has been labeled with openebs-jiva\nLabeling ip-10-0-1-182.us-west-1.compute.internal\nnode/ip-10-0-1-182.us-west-1.compute.internal labeled\nLabeling ip-10-0-1-205.us-west-1.compute.internal\nnode/ip-10-0-1-205.us-west-1.compute.internal labeled\nLabeling ip-10-0-1-210.us-west-1.compute.internal\nnode/ip-10-0-1-210.us-west-1.compute.internal labeled\nUpgrading Replica Deployment to 0.8.1-RC1\ndeployment.extensions/pvc-b9a36e51-2de2-11e9-a340-069da208a730-rep patched\nDeployment upgrade strategy set as recreate\ndeployment.extensions/pvc-b9a36e51-2de2-11e9-a340-069da208a730-rep patched\nreplicaset.extensions \"pvc-b9a36e51-2de2-11e9-a340-069da208a730-rep-667cddc668\" deleted\nUpgrading Target Deployment to 0.8.1-RC1\ndeployment.extensions/pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl patched\nDeployment upgrade strategy set as recreate\ndeployment.extensions/pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl patched\nreplicaset.extensions \"pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl-7d96f549fb\" deleted\nUpgrading Target Service to 0.8.1-RC1\nservice/pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl-svc patched\nClearing temporary files\nSuccessfully upgraded pvc-b9a36e51-2de2-11e9-a340-069da208a730 to 0.8.1-RC1 Please run your application checks.", "stdout_lines": ["Checking if the node with replica pod has been labeled with openebs-jiva", "Labeling ip-10-0-1-182.us-west-1.compute.internal", "node/ip-10-0-1-182.us-west-1.compute.internal labeled", "Labeling ip-10-0-1-205.us-west-1.compute.internal", "node/ip-10-0-1-205.us-west-1.compute.internal labeled", "Labeling ip-10-0-1-210.us-west-1.compute.internal", "node/ip-10-0-1-210.us-west-1.compute.internal labeled", "Upgrading Replica Deployment to 0.8.1-RC1", "deployment.extensions/pvc-b9a36e51-2de2-11e9-a340-069da208a730-rep patched", "Deployment upgrade strategy set as recreate", "deployment.extensions/pvc-b9a36e51-2de2-11e9-a340-069da208a730-rep patched", "replicaset.extensions \"pvc-b9a36e51-2de2-11e9-a340-069da208a730-rep-667cddc668\" deleted", "Upgrading Target Deployment to 0.8.1-RC1", "deployment.extensions/pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl patched", "Deployment upgrade strategy set as recreate", "deployment.extensions/pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl patched", "replicaset.extensions \"pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl-7d96f549fb\" deleted", "Upgrading Target Service to 0.8.1-RC1", "service/pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl-svc patched", "Clearing temporary files", "Successfully upgraded pvc-b9a36e51-2de2-11e9-a340-069da208a730 to 0.8.1-RC1 Please run your application checks."]}

TASK [include_tasks] ***********************************************************
task path: /common/utils/openebs/openebs_upgrade.yml:145
2019-02-11T09:54:50.174350 (delta: 22.444766)         elapsed: 50.360846 ****** 
included: /common/utils/check_deployment_status.yml for 127.0.0.1

TASK [Check the pod status] ****************************************************
task path: /common/utils/check_deployment_status.yml:8
2019-02-11T09:54:50.239852 (delta: 0.065475)         elapsed: 50.426348 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.372263", "end": "2019-02-11 09:54:50.723797", "rc": 0, "start": "2019-02-11 09:54:50.351534", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [obtain the number of replicas.] ******************************************
task path: /common/utils/check_deployment_status.yml:22
2019-02-11T09:54:50.760986 (delta: 0.521107)         elapsed: 50.947482 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the ready replica count and compare with the replica count.] ******
task path: /common/utils/check_deployment_status.yml:29
2019-02-11T09:54:50.800354 (delta: 0.039342)         elapsed: 50.98685 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the presence of initial jiva ctrl pod.] *************************
task path: /common/utils/openebs/openebs_upgrade.yml:147
2019-02-11T09:54:50.879014 (delta: 0.07863)         elapsed: 51.06551 ********* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l openebs.io/controller=jiva-controller -n app-percona-ns --no-headers | grep pvc-b9a36e51-2de2-11e9-a340-069da208a730 | awk '{print $1}'", "delta": "0:00:00.386397", "end": "2019-02-11 09:54:51.373090", "rc": 0, "start": "2019-02-11 09:54:50.986693", "stderr": "", "stderr_lines": [], "stdout": "pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl-d54644d5f-24zgq", "stdout_lines": ["pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl-d54644d5f-24zgq"]}

TASK [Check the upgraded image of ctrl pod containers.] ************************
task path: /common/utils/openebs/openebs_upgrade.yml:159
2019-02-11T09:54:51.410030 (delta: 0.530991)         elapsed: 51.596526 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-b9a36e51-2de2-11e9-a340-069da208a730-ctrl-d54644d5f-24zgq -n app-percona-ns -o jsonpath=\"{..image}\" |tr -s '[[:space:]]' '\\n' |sort |uniq -c", "delta": "0:00:00.385330", "end": "2019-02-11 09:54:51.902817", "failed_when_result": false, "rc": 0, "start": "2019-02-11 09:54:51.517487", "stderr": "", "stderr_lines": [], "stdout": "      2 quay.io/openebs/jiva:0.8.1-RC1\n      2 quay.io/openebs/m-exporter:0.8.1-RC1", "stdout_lines": ["      2 quay.io/openebs/jiva:0.8.1-RC1", "      2 quay.io/openebs/m-exporter:0.8.1-RC1"]}

TASK [Identify the jiva replica pod belonging to the PV] ***********************
task path: /common/utils/openebs/openebs_upgrade.yml:168
2019-02-11T09:54:51.940428 (delta: 0.530372)         elapsed: 52.126924 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica -n app-percona-ns --no-headers | grep pvc-b9a36e51-2de2-11e9-a340-069da208a730 | awk 'FNR == 1 {print}'| awk {'print $1'}", "delta": "0:00:00.375625", "end": "2019-02-11 09:54:52.424151", "rc": 0, "start": "2019-02-11 09:54:52.048526", "stderr": "", "stderr_lines": [], "stdout": "pvc-b9a36e51-2de2-11e9-a340-069da208a730-rep-7df94cd4f9-8wzxn", "stdout_lines": ["pvc-b9a36e51-2de2-11e9-a340-069da208a730-rep-7df94cd4f9-8wzxn"]}

TASK [Verify the jiva  containers upgraded image.] *****************************
task path: /common/utils/openebs/openebs_upgrade.yml:177
2019-02-11T09:54:52.457802 (delta: 0.517348)         elapsed: 52.644298 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-b9a36e51-2de2-11e9-a340-069da208a730-rep-7df94cd4f9-8wzxn -n app-percona-ns -o jsonpath=\"{..image}\" |tr -s '[[:space:]]' '\\n' |sort |uniq -c", "delta": "0:00:00.374965", "end": "2019-02-11 09:54:52.941871", "failed_when_result": false, "rc": 0, "start": "2019-02-11 09:54:52.566906", "stderr": "", "stderr_lines": [], "stdout": "      2 quay.io/openebs/jiva:0.8.1-RC1", "stdout_lines": ["      2 quay.io/openebs/jiva:0.8.1-RC1"]}

TASK [include_tasks] ***********************************************************
task path: /common/utils/openebs/upgrade/test.yml:43
2019-02-11T09:54:52.979880 (delta: 0.522051)         elapsed: 53.166376 ******* 
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /common/utils/status_app_pod.yml:2
2019-02-11T09:54:53.038906 (delta: 0.058998)         elapsed: 53.225402 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.384247", "end": "2019-02-11 09:54:53.533678", "rc": 0, "start": "2019-02-11 09:54:53.149431", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-02-11T09:53:03Z]]", "stdout_lines": ["map[running:map[startedAt:2019-02-11T09:53:03Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /common/utils/status_app_pod.yml:13
2019-02-11T09:54:53.572190 (delta: 0.533254)         elapsed: 53.758686 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.392742", "end": "2019-02-11 09:54:54.076749", "rc": 0, "start": "2019-02-11 09:54:53.684007", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set_fact] ****************************************************************
task path: /common/utils/openebs/upgrade/test.yml:51
2019-02-11T09:54:54.114722 (delta: 0.542503)         elapsed: 54.301218 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /common/utils/openebs/upgrade/test.yml:60
2019-02-11T09:54:54.162110 (delta: 0.047362)         elapsed: 54.348606 ******* 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-02-11T09:54:54.227343 (delta: 0.065204)         elapsed: 54.413839 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-02-11T09:54:54.258720 (delta: 0.031352)         elapsed: 54.445216 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-02-11T09:54:54.290161 (delta: 0.031417)         elapsed: 54.476657 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-02-11T09:54:54.326110 (delta: 0.035924)         elapsed: 54.512606 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "e0e9a77553901a84a4327a78fa5f5e2b6e2ef6ab", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "58fb61d2588f761941761bcf988becab", "mode": "0644", "owner": "root", "size": 419, "src": "/root/.ansible/tmp/ansible-tmp-1549878894.36-119712115946383/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-02-11T09:54:55.180412 (delta: 0.854276)         elapsed: 55.366908 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.305319", "end": "2019-02-11 09:54:55.587172", "rc": 0, "start": "2019-02-11 09:54:55.281853", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-upgrade-test \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-upgrade-test ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-02-11T09:54:55.619487 (delta: 0.439048)         elapsed: 55.805983 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.451385", "end": "2019-02-11 09:54:56.175098", "failed_when_result": false, "rc": 0, "start": "2019-02-11 09:54:55.723713", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-upgrade-test configured", "stdout_lines": ["litmusresult.litmus.io/openebs-upgrade-test configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=34   changed=22   unreachable=0    failed=0   

2019-02-11T09:54:56.194916 (delta: 0.575404)         elapsed: 56.381412 ******* 
=============================================================================== 
```