### PR TITLE
feat(test): Attempting to delete the parent volume which has clone

### DIFF
--- a/apps/percona/deployers/run_litmus_test.yml
+++ b/apps/percona/deployers/run_litmus_test.yml
@@ -25,8 +25,8 @@ spec:
             value: default
 
           - name: PROVIDER_STORAGE_CLASS
-            # Supported values: openebs-standard, local-storage, openebs-standalone
-            value: openebs-cstor-sparse
+            # Supported values: openebs-standard, local-storage, openebs-standalone, openebs-cstor-sparse
+            value: openebs-standard
 
           - name: APP_PVC
             value: percona-mysql-claim
@@ -37,7 +37,7 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: snap-percona
+            value: app-percona-ns
 
             # Use 'deprovision' for app-clean up
           - name: ACTION

--- a/apps/percona/deployers/run_litmus_test.yml
+++ b/apps/percona/deployers/run_litmus_test.yml
@@ -26,7 +26,7 @@ spec:
 
           - name: PROVIDER_STORAGE_CLASS
             # Supported values: openebs-standard, local-storage, openebs-standalone
-            value: openebs-standard
+            value: openebs-cstor-sparse
 
           - name: APP_PVC
             value: percona-mysql-claim
@@ -37,7 +37,7 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: app-percona-ns
+            value: snap-percona
 
             # Use 'deprovision' for app-clean up
           - name: ACTION

--- a/apps/percona/functional/k8s_snapshot/run_litmus_test.yml
+++ b/apps/percona/functional/k8s_snapshot/run_litmus_test.yml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: openebs/ansible-runner:ci
+        image: gprasath/ansible-runner:ci
         imagePullPolicy: Always
 
         env:
@@ -32,13 +32,7 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: app-percona-ns 
-
-          - name: SNAPSHOT
-            value: snap-percona
-
-          - name: CLONE_NAME
-            value: percona-clone-mysql-claim
+            value: snap-percona 
 
           - name: PROVIDER_STORAGE_CLASS
             value: openebs-snapshot-promoter

--- a/apps/percona/functional/k8s_snapshot/run_litmus_test.yml
+++ b/apps/percona/functional/k8s_snapshot/run_litmus_test.yml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: gprasath/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
 
         env:
@@ -32,7 +32,7 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: snap-percona 
+            value: app-percona-ns 
 
           - name: PROVIDER_STORAGE_CLASS
             value: openebs-snapshot-promoter

--- a/apps/percona/functional/k8s_snapshot/test.yml
+++ b/apps/percona/functional/k8s_snapshot/test.yml
@@ -220,6 +220,22 @@
           until: "'aws' in db_result.stdout"
           delay: 60
           retries: 15
+       
+        ### Attempting to delete parent PVC which has clone.
+
+        - name: Attempt deleting volume which has clones.
+          shell: kubectl delete pvc {{ pvc_name }} -n {{ app_ns }}
+          args:
+            executable: /bin/bash
+          register: delete_pvc
+          failed_when: delete_pvc.rc == 0
+
+        - name: Check if the PVC is not deleted.
+          shell: kubectl get pvc {{ pvc_name }} -n {{ app_ns }} --no-headers -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: pvc_state
+          failed_when: "'Bound' not in pvc_state.stdout"
 
         - set_fact:
             flag: "Pass"

--- a/apps/percona/functional/k8s_snapshot/test_vars.yml
+++ b/apps/percona/functional/k8s_snapshot/test_vars.yml
@@ -11,8 +11,6 @@ password: "{{ lookup('env','DB_PASSWORD') }}"
 
 pvc_name: "{{ lookup('env','APP_PVC') }}"
 
-snapshot_name: "{{ lookup('env','SNAPSHOT') }}"
-
 clone_claim: "{{ lookup('env','CLONE_VOL_CLAIM') }}"
 
 storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:

- Creating snapshot and clone based on the pvc provided.
- Checking if the parent volume can be deleted when the clone is present.
- Removed unused variables.

```

PLAY [localhost] ***************************************************************
2019-03-07T09:12:01.837543 (delta: 0.058754)         elapsed: 0.058754 ********
===============================================================================
TASK [Gathering Facts] *********************************************************
task path: /percona/functional/k8s_snapshot/test.yml:19
2019-03-07T09:12:01.852934 (delta: 0.015324)         elapsed: 0.074145 ********
ok: [127.0.0.1]
META: ran handlers
TASK [Record test instance/run ID] *********************************************
task path: /percona/functional/k8s_snapshot/test.yml:29
2019-03-07T09:12:07.053238 (delta: 5.200264)         elapsed: 5.274449 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /percona/functional/k8s_snapshot/test.yml:33
2019-03-07T09:12:07.106751 (delta: 0.053422)         elapsed: 5.327962 ********
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}
TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /percona/functional/k8s_snapshot/test.yml:40
2019-03-07T09:12:07.178272 (delta: 0.071463)         elapsed: 5.399483 ********
changed: [127.0.0.1] => {"changed": true, "checksum": "165d3319b38a884427b62c59461c8af6f4a0f6a7", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "78c03493459fd66f30bbd4206444a743", "mode": "0644", "owner": "root", "size": 433, "src": "/root/.ansible/tmp/ansible-tmp-1551949927.23-37227242519644/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
task path: /percona/functional/k8s_snapshot/test.yml:51
2019-03-07T09:12:07.989651 (delta: 0.811273)         elapsed: 6.210862 ********
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "apply", "-f", "litmus-result.yaml"], "delta": "0:00:01.180676", "end": "2019-03-07 09:12:09.457333", "failed_when_result": false, "rc": 0, "start": "2019-03-07 09:12:08.276657", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-k8s-snapshot-clone configured", "stdout_lines": ["litmusresult.litmus.io/create-k8s-snapshot-clone configured"]}
TASK [Check whether the snapshot specific storage class is created.] ***********
task path: /percona/functional/k8s_snapshot/test.yml:56
2019-03-07T09:12:09.533705 (delta: 1.544001)         elapsed: 7.754916 ********
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "get", "sc", "openebs-snapshot-promoter"], "delta": "0:00:00.555528", "end": "2019-03-07 09:12:10.398613", "rc": 0, "start": "2019-03-07 09:12:09.843085", "stderr": "", "stderr_lines": [], "stdout": "NAME                        PROVISIONER                                                AGE\nopenebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   147d", "stdout_lines": ["NAME                       PROVISIONER                                                AGE", "openebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   147d"]}
TASK [Checking if the application is running.] *********************************
task path: /percona/functional/k8s_snapshot/test.yml:60
2019-03-07T09:12:10.449313 (delta: 0.915536)         elapsed: 8.670524 ********
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n snap-percona --no-headers -l name=percona -o custom-columns=:status.phase", "delta": "0:00:00.549306", "end": "2019-03-07 09:12:11.177791", "rc": 0, "start": "2019-03-07 09:12:10.628485", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtaining the application pod name.] *************************************
task path: /percona/functional/k8s_snapshot/test.yml:69
2019-03-07T09:12:11.280229 (delta: 0.830807)         elapsed: 9.50144 *********
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n snap-percona -l name=percona --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.666297", "end": "2019-03-07 09:12:12.149107", "rc": 0, "start": "2019-03-07 09:12:11.482810", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-cfkd8", "stdout_lines": ["percona-cb697f8b4-cfkd8"]}
TASK [Recording application pod name in a variable.] ***************************
task path: /percona/functional/k8s_snapshot/test.yml:75
2019-03-07T09:12:12.210034 (delta: 0.92974)         elapsed: 10.431245 ********
ok: [127.0.0.1] => {"ansible_facts": {"pod_name": "percona-cb697f8b4-cfkd8"}, "changed": false}
TASK [Derive PV name from PVC] *************************************************
task path: /percona/functional/k8s_snapshot/test.yml:79
2019-03-07T09:12:12.318366 (delta: 0.108251)         elapsed: 10.539577 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n snap-percona --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:00.601520", "end": "2019-03-07 09:12:13.148164", "rc": 0, "start": "2019-03-07 09:12:12.546644", "stderr": "", "stderr_lines": [], "stdout": "pvc-5a682fbd-40b8-11e9-af96-42010a800043", "stdout_lines": ["pvc-5a682fbd-40b8-11e9-af96-42010a800043"]}
TASK [Obtaining the storage-engine name from PV.] ******************************
task path: /percona/functional/k8s_snapshot/test.yml:87
2019-03-07T09:12:13.198532 (delta: 0.87997)         elapsed: 11.419743 ********
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-5a682fbd-40b8-11e9-af96-42010a800043 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:00.605787", "end": "2019-03-07 09:12:13.993882", "rc": 0, "start": "2019-03-07 09:12:13.388095", "stderr": "", "stderr_lines": [], "stdout": "cstor", "stdout_lines": ["cstor"]}
TASK [Write a test database into percona mysql] ********************************
task path: /percona/functional/k8s_snapshot/test.yml:95
2019-03-07T09:12:14.055481 (delta: 0.856891)         elapsed: 12.276692 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it percona-cb697f8b4-cfkd8 -n snap-percona -- mysql -uroot -pk8sDem0 -e \"create database cloud;\"\n kubectl exec -it percona-cb697f8b4-cfkd8 -n snap-percona -- mysql -uroot -pk8sDem0 -e \"create table platforms (Data VARCHAR(20));\" cloud\n kubectl exec -it percona-cb697f8b4-cfkd8 -n snap-percona -- mysql -uroot -pk8sDem0 -e \"insert into platforms (Data) VALUES ('aws');\" cloud\n kubectl exec -it percona-cb697f8b4-cfkd8 -n snap-percona -- mysql -uroot -pk8sDem0 -e \"flush tables with read lock;\"", "delta": "0:00:03.259267", "end": "2019-03-07 09:12:17.560579", "failed_when_result": false, "rc": 0, "start": "2019-03-07 09:12:14.301312", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nmysql: [Warning] Using a password on the command line interface can be insecure.\nUnable to use a TTY - input is not a terminal or the right kind of file\nmysql: [Warning] Using a password on the command line interface can be insecure.\nUnable to use a TTY - input is not a terminal or the right kind of file\nmysql: [Warning] Using a password on the command line interface can be insecure.\nUnable to use a TTY - input is not a terminal or the right kind of file\nmysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["Unable to use a TTY - input is not a terminal orthe right kind of file", "mysql: [Warning] Using a password on the command line interface can be insecure.", "Unable to use a TTY - input is not a terminal or the right kind of file", "mysql: [Warning] Using a password on the command line interface can be insecure.", "Unable to use a TTY - input is not a terminal or the right kind of file", "mysql: [Warning] Using a password on the command line interface can be insecure.", "Unable to use a TTY - input is not a terminal or the right kind of file", "mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Perform filesystem sync on percona pod before creating snapshot.] ********
task path: /percona/functional/k8s_snapshot/test.yml:106
2019-03-07T09:12:17.615392 (delta: 3.559845)         elapsed: 15.836603 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-cb697f8b4-cfkd8 -n snap-percona -- bash -c \"sync;sync;sync\"", "delta": "0:00:00.932207", "end": "2019-03-07 09:12:18.728054", "rc": 0, "start": "2019-03-07 09:12:17.795847", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Creating snapshot.] ******************************************************
task path: /percona/functional/k8s_snapshot/test.yml:114
2019-03-07T09:12:18.773117 (delta: 1.157548)         elapsed: 16.994328 *******
included: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml for 127.0.0.1

TASK [Generate unique string for use as snapname] ******************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:4
2019-03-07T09:12:18.845992 (delta: 0.072818)         elapsed: 17.067203 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "cat /dev/urandom | tr -cd 'a-z0-9' | head -c 8", "delta": "0:00:00.446590", "end": "2019-03-07 09:12:19.496651", "rc": 0, "start": "2019-03-07 09:12:19.050061", "stderr": "", "stderr_lines": [], "stdout": "y73rz4ab", "stdout_lines": ["y73rz4ab"]}

TASK [Form the snap name being rebuilt.] ***************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:10
2019-03-07T09:12:19.604769 (delta: 0.758725)         elapsed: 17.82598 ********
ok: [127.0.0.1] => {"ansible_facts": {"snapshot_name": "y73rz4ab"}, "changed": false}

TASK [Display details] *********************************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:14
2019-03-07T09:12:19.713057 (delta: 0.108196)         elapsed: 17.934268 *******
ok: [127.0.0.1] => {
    "msg": [
        "app_ns: snap-percona",
        "pvc_name: percona-mysql-claim",
        "snapshot_name: y73rz4ab"
    ]
}

TASK [Update the snapshot template with the values provided.] ******************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:21
2019-03-07T09:12:19.854145 (delta: 0.140953)         elapsed: 18.075356 *******
changed: [127.0.0.1] => {"changed": true, "checksum": "6ea35d1a8aea363fb1ac14f673e2c034960f05f1", "dest": "./snapshot.yml", "gid": 0, "group": "root", "md5sum": "4b24bf2cd5b898d3ffb0161745ebd7b7", "mode": "0644", "owner": "root", "size": 184, "src": "/root/.ansible/tmp/ansible-tmp-1551949939.91-111126198930682/source", "state": "file", "uid": 0}

TASK [Creating the volume snapshot] ********************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:26
2019-03-07T09:12:20.287426 (delta: 0.433136)         elapsed: 18.508637 *******
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl apply -f snapshot.yml", "delta": "0:00:00.795915", "end": "2019-03-07 09:12:21.292827", "rc": 0, "start": "2019-03-07 09:12:20.496912", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshot.volumesnapshot.external-storage.k8s.io/y73rz4ab created", "stdout_lines": ["volumesnapshot.volumesnapshot.external-storage.k8s.io/y73rz4ab created"]}

TASK [Obtaining the storage class used from PVC] *******************************
task path: /percona/functional/k8s_snapshot/test.yml:119
2019-03-07T09:12:21.358748 (delta: 1.071264)         elapsed: 19.579959 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n snap-percona --no-headers -o custom-columns=:.spec.storageClassName", "delta": "0:00:00.627617", "end": "2019-03-07 09:12:22.301057", "rc": 0, "start": "2019-03-07 09:12:21.673440", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-sparse", "stdout_lines": ["openebs-cstor-sparse"]}

TASK [Obtaining the SPC from storage class] ************************************
task path: /percona/functional/k8s_snapshot/test.yml:123
2019-03-07T09:12:22.368362 (delta: 1.009564)         elapsed: 20.589573 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse --no-headers -o yaml | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/\"//g'", "delta": "0:00:00.604385", "end": "2019-03-07 09:12:23.235093", "rc": 0, "start": "2019-03-07 09:12:22.630708", "stderr": "", "stderr_lines": [], "stdout": " cstor-sparse-pool", "stdout_lines": [" cstor-sparse-pool"]}

TASK [Obtaining the pool deployments from cvr] *********************************
task path: /percona/functional/k8s_snapshot/test.yml:127
2019-03-07T09:12:23.290585 (delta: 0.922058)         elapsed: 21.511796 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-5a682fbd-40b8-11e9-af96-42010a800043 --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}'", "delta": "0:00:00.681390", "end": "2019-03-07 09:12:24.230307", "rc": 0, "start": "2019-03-07 09:12:23.548917", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-bno3\ncstor-sparse-pool-gw1f\ncstor-sparse-pool-r8jt", "stdout_lines": ["cstor-sparse-pool-bno3", "cstor-sparse-pool-gw1f", "cstor-sparse-pool-r8jt"]}

TASK [Obtaining the replicasets corresponding to pool deployements.] ***********
task path: /percona/functional/k8s_snapshot/test.yml:136
2019-03-07T09:12:24.287533 (delta: 0.996896)         elapsed: 22.508744 *******
changed: [127.0.0.1] => (item=cstor-sparse-pool-bno3) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-bno3\")].metadata.name}'", "delta": "0:00:00.618057", "end": "2019-03-07 09:12:25.160840", "item": "cstor-sparse-pool-bno3", "rc": 0, "start": "2019-03-07 09:12:24.542783", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-bno3-85df57fd65", "stdout_lines": ["cstor-sparse-pool-bno3-85df57fd65"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-gw1f) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-gw1f\")].metadata.name}'", "delta": "0:00:00.714807", "end": "2019-03-07 09:12:26.080962", "item": "cstor-sparse-pool-gw1f", "rc": 0, "start": "2019-03-07 09:12:25.366155", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-gw1f-86674796d", "stdout_lines": ["cstor-sparse-pool-gw1f-86674796d"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-r8jt) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-r8jt\")].metadata.name}'", "delta": "0:00:00.642848", "end": "2019-03-07 09:12:26.904999", "item": "cstor-sparse-pool-r8jt", "rc": 0, "start": "2019-03-07 09:12:26.262151", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-r8jt-5bcf7d886c", "stdout_lines": ["cstor-sparse-pool-r8jt-5bcf7d886c"]}
TASK [Obtaining the pool pods] *************************************************
task path: /percona/functional/k8s_snapshot/test.yml:144
2019-03-07T09:12:27.022988 (delta: 2.735342)         elapsed: 25.244199 *******
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-bno3-85df57fd65', '_ansible_item_result': True, u'delta': u'0:00:00.618057', 'stdout_lines': [u'cstor-sparse-pool-bno3-85df57fd65'], '_ansible_item_label': u'cstor-sparse-pool-bno3', u'end': u'2019-03-07 09:12:25.160840', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-bno3")].metadata.name}\'', 'item': u'cstor-sparse-pool-bno3', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-bno3")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-07 09:12:24.542783', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-bno3-85df57fd65\")].metadata.name}'", "delta": "0:00:00.570002", "end": "2019-03-07 09:12:27.848915", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-bno3\")].metadata.name}'", "delta": "0:00:00.618057", "end": "2019-03-07 09:12:25.160840", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-bno3\")].metadata.name}'", "_uses_shell": true, "argv":null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-bno3", "rc": 0, "start": "2019-03-07 09:12:24.542783", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-bno3-85df57fd65", "stdout_lines": ["cstor-sparse-pool-bno3-85df57fd65"]}, "rc": 0, "start": "2019-03-07 09:12:27.278913", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-bno3-85df57fd65-b5hz9", "stdout_lines": ["cstor-sparse-pool-bno3-85df57fd65-b5hz9"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-gw1f-86674796d', '_ansible_item_result': True, u'delta': u'0:00:00.714807', 'stdout_lines': [u'cstor-sparse-pool-gw1f-86674796d'], '_ansible_item_label': u'cstor-sparse-pool-gw1f', u'end': u'2019-03-07 09:12:26.080962', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-gw1f")].metadata.name}\'', 'item': u'cstor-sparse-pool-gw1f', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-gw1f")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-07 09:12:25.366155', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-gw1f-86674796d\")].metadata.name}'", "delta": "0:00:00.635274", "end": "2019-03-07 09:12:28.728861", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-gw1f\")].metadata.name}'", "delta": "0:00:00.714807", "end": "2019-03-07 09:12:26.080962", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-gw1f\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-gw1f", "rc": 0, "start": "2019-03-07 09:12:25.366155", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-gw1f-86674796d", "stdout_lines": ["cstor-sparse-pool-gw1f-86674796d"]}, "rc": 0, "start": "2019-03-07 09:12:28.093587", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-gw1f-86674796d-nxcmp", "stdout_lines":["cstor-sparse-pool-gw1f-86674796d-nxcmp"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-r8jt-5bcf7d886c', '_ansible_item_result': True, u'delta': u'0:00:00.642848', 'stdout_lines': [u'cstor-sparse-pool-r8jt-5bcf7d886c'], '_ansible_item_label': u'cstor-sparse-pool-r8jt', u'end': u'2019-03-07 09:12:26.904999', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-r8jt")].metadata.name}\'', 'item': u'cstor-sparse-pool-r8jt', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-r8jt")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-07 09:12:26.262151', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-r8jt-5bcf7d886c\")].metadata.name}'", "delta": "0:00:00.799257", "end": "2019-03-07 09:12:29.771332", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-r8jt\")].metadata.name}'", "delta": "0:00:00.642848", "end": "2019-03-07 09:12:26.904999", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-r8jt\")].metadata.name}'", "_uses_shell": true, "argv":null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-r8jt", "rc": 0, "start": "2019-03-07 09:12:26.262151", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-r8jt-5bcf7d886c", "stdout_lines": ["cstor-sparse-pool-r8jt-5bcf7d886c"]}, "rc": 0, "start": "2019-03-07 09:12:28.972075", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-r8jt-5bcf7d886c-bslq7", "stdout_lines": ["cstor-sparse-pool-r8jt-5bcf7d886c-bslq7"]}
TASK [Checking if the snapshot is created in all the pool pods.] ***************
task path: /percona/functional/k8s_snapshot/test.yml:152
2019-03-07T09:12:29.858160 (delta: 2.835068)         elapsed: 28.079371 *******
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-bno3-85df57fd65-b5hz9', '_ansible_item_result': True, u'delta': u'0:00:00.570002', 'stdout_lines': [u'cstor-sparse-pool-bno3-85df57fd65-b5hz9'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-bno3-85df57fd65', '_ansible_item_result': True, u'delta': u'0:00:00.618057', 'stdout_lines': [u'cstor-sparse-pool-bno3-85df57fd65'], '_ansible_item_label': u'cstor-sparse-pool-bno3', u'end': u'2019-03-07 09:12:25.160840', '_ansible_no_log': False, u'start': u'2019-03-07 09:12:24.542783', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-bno3")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-bno3', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-bno3")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-03-07 09:12:27.848915', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-bno3-85df57fd65")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-bno3-85df57fd65', '_ansible_item_result': True, u'delta': u'0:00:00.618057', 'stdout_lines': [u'cstor-sparse-pool-bno3-85df57fd65'], '_ansible_item_label': u'cstor-sparse-pool-bno3', u'end': u'2019-03-07 09:12:25.160840', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-bno3")].metadata.name}\'', u'start': u'2019-03-07 09:12:24.542783', 'item': u'cstor-sparse-pool-bno3', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-bno3")].metadata.name}\'', u'removes': None, u'argv': None, u'creates':None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-bno3-85df57fd65")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-07 09:12:27.278913', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-sparse-pool-bno3-85df57fd65-b5hz9 -n openebs -- zfs list -t snapshot", "delta": "0:00:00.787780", "end": "2019-03-07 09:12:30.910757", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-bno3-85df57fd65\")].metadata.name}'", "delta": "0:00:00.570002", "end": "2019-03-07 09:12:27.848915", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-bno3-85df57fd65\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-bno3\")].metadata.name}'", "delta": "0:00:00.618057", "end": "2019-03-07 09:12:25.160840", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-bno3\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-bno3", "rc": 0, "start": "2019-03-07 09:12:24.542783", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-bno3-85df57fd65", "stdout_lines": ["cstor-sparse-pool-bno3-85df57fd65"]}, "rc": 0, "start": "2019-03-07 09:12:27.278913", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-bno3-85df57fd65-b5hz9", "stdout_lines": ["cstor-sparse-pool-bno3-85df57fd65-b5hz9"]}, "rc": 0, "start": "2019-03-07 09:12:30.122977", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-bno3-85df57fd65-b5hz9 -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-bno3-85df57fd65-b5hz9 -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                        USED  AVAIL  REFER  MOUNTPOINT\ncstor-b8326987-409c-11e9-af96-42010a800043/pvc-06d8cf40-40ab-11e9-af96-42010a800043@pvc-06d8cf40-40ab-11e9-af96-42010a800043_m259dnj9_1551944285512655553  12.1M      -  23.2M  -\ncstor-b8326987-409c-11e9-af96-42010a800043/pvc-5a682fbd-40b8-11e9-af96-42010a800043@pvc-5a682fbd-40b8-11e9-af96-42010a800043_y73rz4ab_1551949941341856656   325K      -  17.9M  -\ncstor-b8326987-409c-11e9-af96-42010a800043/pvc-c0ba41c5-40b6-11e9-af96-42010a800043@pvc-c0ba41c5-40b6-11e9-af96-42010a800043_yd5nsitw_1551949230469149540  6.16M   -  16.8M  -", "stdout_lines": ["NAME                                                                                                                                                        USED  AVAIL  REFER  MOUNTPOINT", "cstor-b8326987-409c-11e9-af96-42010a800043/pvc-06d8cf40-40ab-11e9-af96-42010a800043@pvc-06d8cf40-40ab-11e9-af96-42010a800043_m259dnj9_1551944285512655553  12.1M      -  23.2M  -", "cstor-b8326987-409c-11e9-af96-42010a800043/pvc-5a682fbd-40b8-11e9-af96-42010a800043@pvc-5a682fbd-40b8-11e9-af96-42010a800043_y73rz4ab_1551949941341856656   325K      -  17.9M  -", "cstor-b8326987-409c-11e9-af96-42010a800043/pvc-c0ba41c5-40b6-11e9-af96-42010a800043@pvc-c0ba41c5-40b6-11e9-af96-42010a800043_yd5nsitw_1551949230469149540  6.16M      -  16.8M  -"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-gw1f-86674796d-nxcmp', '_ansible_item_result': True, u'delta': u'0:00:00.635274', 'stdout_lines': [u'cstor-sparse-pool-gw1f-86674796d-nxcmp'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-gw1f-86674796d', '_ansible_item_result': True, u'delta': u'0:00:00.714807', 'stdout_lines': [u'cstor-sparse-pool-gw1f-86674796d'], '_ansible_item_label': u'cstor-sparse-pool-gw1f', u'end': u'2019-03-07 09:12:26.080962', '_ansible_no_log': False, u'start': u'2019-03-07 09:12:25.366155', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-gw1f")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-gw1f', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-gw1f")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-03-07 09:12:28.728861', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-gw1f-86674796d")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-gw1f-86674796d', '_ansible_item_result': True, u'delta': u'0:00:00.714807', 'stdout_lines': [u'cstor-sparse-pool-gw1f-86674796d'], '_ansible_item_label': u'cstor-sparse-pool-gw1f', u'end': u'2019-03-07 09:12:26.080962', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-gw1f")].metadata.name}\'', u'start': u'2019-03-07 09:12:25.366155', 'item': u'cstor-sparse-pool-gw1f', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-gw1f")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-gw1f-86674796d")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-07 09:12:28.093587', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-sparse-pool-gw1f-86674796d-nxcmp -n openebs -- zfs list -t snapshot", "delta": "0:00:00.940824", "end": "2019-03-07 09:12:32.090304", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-gw1f-86674796d\")].metadata.name}'", "delta": "0:00:00.635274", "end": "2019-03-07 09:12:28.728861", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-gw1f-86674796d\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn":true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-gw1f\")].metadata.name}'", "delta": "0:00:00.714807", "end": "2019-03-07 09:12:26.080962", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-gw1f\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-gw1f", "rc": 0, "start": "2019-03-07 09:12:25.366155", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-gw1f-86674796d", "stdout_lines": ["cstor-sparse-pool-gw1f-86674796d"]}, "rc": 0, "start": "2019-03-07 09:12:28.093587", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-gw1f-86674796d-nxcmp", "stdout_lines": ["cstor-sparse-pool-gw1f-86674796d-nxcmp"]}, "rc": 0, "start": "2019-03-07 09:12:31.149480", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-gw1f-86674796d-nxcmp -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-gw1f-86674796d-nxcmp -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                       USED  AVAIL  REFER  MOUNTPOINT\ncstor-b85900d9-409c-11e9-af96-42010a800043/pvc-06d8cf40-40ab-11e9-af96-42010a800043@pvc-06d8cf40-40ab-11e9-af96-42010a800043_m259dnj9_1551944285512655553  12.1M      -  23.2M  -\ncstor-b85900d9-409c-11e9-af96-42010a800043/pvc-5a682fbd-40b8-11e9-af96-42010a800043@pvc-5a682fbd-40b8-11e9-af96-42010a800043_y73rz4ab_1551949941341856656   324K      -  17.9M  -\ncstor-b85900d9-409c-11e9-af96-42010a800043/pvc-c0ba41c5-40b6-11e9-af96-42010a800043@pvc-c0ba41c5-40b6-11e9-af96-42010a800043_yd5nsitw_1551949230469149540  6.17M      -  16.8M  -","stdout_lines": ["NAME                                                                                                                                                        USED  AVAIL  REFER  MOUNTPOINT", "cstor-b85900d9-409c-11e9-af96-42010a800043/pvc-06d8cf40-40ab-11e9-af96-42010a800043@pvc-06d8cf40-40ab-11e9-af96-42010a800043_m259dnj9_1551944285512655553  12.1M      -  23.2M  -", "cstor-b85900d9-409c-11e9-af96-42010a800043/pvc-5a682fbd-40b8-11e9-af96-42010a800043@pvc-5a682fbd-40b8-11e9-af96-42010a800043_y73rz4ab_1551949941341856656   324K      -  17.9M  -", "cstor-b85900d9-409c-11e9-af96-42010a800043/pvc-c0ba41c5-40b6-11e9-af96-42010a800043@pvc-c0ba41c5-40b6-11e9-af96-42010a800043_yd5nsitw_1551949230469149540  6.17M      -  16.8M  -"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-r8jt-5bcf7d886c-bslq7', '_ansible_item_result': True, u'delta': u'0:00:00.799257', 'stdout_lines': [u'cstor-sparse-pool-r8jt-5bcf7d886c-bslq7'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-r8jt-5bcf7d886c', '_ansible_item_result': True, u'delta': u'0:00:00.642848', 'stdout_lines': [u'cstor-sparse-pool-r8jt-5bcf7d886c'], '_ansible_item_label': u'cstor-sparse-pool-r8jt', u'end': u'2019-03-07 09:12:26.904999', '_ansible_no_log': False, u'start': u'2019-03-07 09:12:26.262151', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-r8jt")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-r8jt', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-r8jt")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-03-07 09:12:29.771332', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-r8jt-5bcf7d886c")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-r8jt-5bcf7d886c', '_ansible_item_result': True, u'delta': u'0:00:00.642848', 'stdout_lines': [u'cstor-sparse-pool-r8jt-5bcf7d886c'], '_ansible_item_label': u'cstor-sparse-pool-r8jt', u'end': u'2019-03-07 09:12:26.904999', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-r8jt")].metadata.name}\'', u'start': u'2019-03-07 09:12:26.262151', 'item': u'cstor-sparse-pool-r8jt', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-r8jt")].metadata.name}\'', u'removes': None, u'argv': None, u'creates':None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-r8jt-5bcf7d886c")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-07 09:12:28.972075', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-sparse-pool-r8jt-5bcf7d886c-bslq7 -n openebs -- zfs list -t snapshot", "delta": "0:00:01.033271", "end": "2019-03-07 09:12:33.359369", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-r8jt-5bcf7d886c\")].metadata.name}'", "delta": "0:00:00.799257", "end": "2019-03-07 09:12:29.771332", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-r8jt-5bcf7d886c\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-r8jt\")].metadata.name}'", "delta": "0:00:00.642848", "end": "2019-03-07 09:12:26.904999", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-r8jt\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-r8jt", "rc": 0, "start": "2019-03-07 09:12:26.262151", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-r8jt-5bcf7d886c", "stdout_lines": ["cstor-sparse-pool-r8jt-5bcf7d886c"]}, "rc": 0, "start": "2019-03-07 09:12:28.972075", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-r8jt-5bcf7d886c-bslq7", "stdout_lines": ["cstor-sparse-pool-r8jt-5bcf7d886c-bslq7"]}, "rc": 0, "start": "2019-03-07 09:12:32.326098", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-r8jt-5bcf7d886c-bslq7 -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-r8jt-5bcf7d886c-bslq7 -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                        USED  AVAIL  REFER  MOUNTPOINT\ncstor-b811e2eb-409c-11e9-af96-42010a800043/pvc-06d8cf40-40ab-11e9-af96-42010a800043@pvc-06d8cf40-40ab-11e9-af96-42010a800043_m259dnj9_1551944285512655553  12.1M      -  23.2M  -\ncstor-b811e2eb-409c-11e9-af96-42010a800043/pvc-5a682fbd-40b8-11e9-af96-42010a800043@pvc-5a682fbd-40b8-11e9-af96-42010a800043_y73rz4ab_1551949941341856656   329K      -  17.9M  -\ncstor-b811e2eb-409c-11e9-af96-42010a800043/pvc-c0ba41c5-40b6-11e9-af96-42010a800043@pvc-c0ba41c5-40b6-11e9-af96-42010a800043_yd5nsitw_1551949230469149540  6.16M   -  16.8M  -", "stdout_lines": ["NAME                                                                                                                                                        USED  AVAIL  REFER  MOUNTPOINT", "cstor-b811e2eb-409c-11e9-af96-42010a800043/pvc-06d8cf40-40ab-11e9-af96-42010a800043@pvc-06d8cf40-40ab-11e9-af96-42010a800043_m259dnj9_1551944285512655553  12.1M      -  23.2M  -", "cstor-b811e2eb-409c-11e9-af96-42010a800043/pvc-5a682fbd-40b8-11e9-af96-42010a800043@pvc-5a682fbd-40b8-11e9-af96-42010a800043_y73rz4ab_1551949941341856656   329K      -  17.9M  -", "cstor-b811e2eb-409c-11e9-af96-42010a800043/pvc-c0ba41c5-40b6-11e9-af96-42010a800043@pvc-c0ba41c5-40b6-11e9-af96-42010a800043_yd5nsitw_1551949230469149540  6.16M      -  16.8M  -"]}

TASK [Creating clone using snapshot.] ******************************************
task path: /percona/functional/k8s_snapshot/test.yml:164
2019-03-07T09:12:33.449426 (delta: 3.591205)         elapsed: 31.670637 *******
included: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml for 127.0.0.1

TASK [Generate unique string for use as clone claim.] **************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:5
2019-03-07T09:12:33.533906 (delta: 0.084422)         elapsed: 31.755117 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "cat /dev/urandom | tr -cd 'a-z0-9' | head -c 8", "delta": "0:00:00.506392", "end": "2019-03-07 09:12:34.272712", "rc": 0, "start": "2019-03-07 09:12:33.766320", "stderr": "", "stderr_lines": [], "stdout": "jn5nd026", "stdout_lines": ["jn5nd026"]}

TASK [Form the clone claim name.] **********************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:11
2019-03-07T09:12:34.372032 (delta: 0.83799)         elapsed: 32.593243 ********
ok: [127.0.0.1] => {"ansible_facts": {"clone_claim_name": "snap-mysql-claim-jn5nd026"}, "changed": false}

TASK [Update the clone creation template with the values provided.] ************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:15
2019-03-07T09:12:34.486913 (delta: 0.11482)         elapsed: 32.708124 ********
changed: [127.0.0.1] => {"changed": true, "checksum": "efc31b3f797148257ed0512990d622b9cd5f36af", "dest": "./snapshot-claim.yml", "gid": 0, "group": "root", "md5sum": "fd89a869313d5d3121093f089c2c26f2", "mode": "0644", "owner": "root", "size": 313, "src": "/root/.ansible/tmp/ansible-tmp-1551949954.57-82878917304318/source", "state": "file", "uid": 0}

TASK [Creating PVC from the snapshot] ******************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:20
2019-03-07T09:12:35.021733 (delta: 0.534735)         elapsed: 33.242944 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f snapshot-claim.yml", "delta": "0:00:00.749923", "end": "2019-03-07 09:12:35.970094", "rc": 0, "start": "2019-03-07 09:12:35.220171", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/snap-mysql-claim-jn5nd026 created", "stdout_lines": ["persistentvolumeclaim/snap-mysql-claim-jn5nd026 created"]}

TASK [Checking if the pvc is created successfully] *****************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:25
2019-03-07T09:12:36.062307 (delta: 1.040484)         elapsed: 34.283518 *******
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc -n snap-percona | grep snap-mysql-claim-jn5nd026", "delta": "0:00:01.169406", "end": "2019-03-07 09:12:37.629981", "rc": 0, "start": "2019-03-07 09:12:36.460575", "stderr": "", "stderr_lines": [], "stdout": "snap-mysql-claim-jn5nd026   Bound    pvc-25d83cde-40b9-11e9-af96-42010a800043   5G         RWO            openebs-snapshot-promoter   2s", "stdout_lines": ["snap-mysql-claim-jn5nd026   Bound    pvc-25d83cde-40b9-11e9-af96-42010a800043   5G         RWO            openebs-snapshot-promoter   2s"]}

TASK [Obtaining new PV name from the pvc.] *************************************
task path: /percona/functional/k8s_snapshot/test.yml:167
2019-03-07T09:12:37.718435 (delta: 1.655655)         elapsed: 35.939646 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc snap-mysql-claim-jn5nd026 -n snap-percona -o custom-columns=:spec.volumeName --no-headers", "delta": "0:00:00.747995", "end": "2019-03-07 09:12:38.685665", "rc": 0, "start": "2019-03-07 09:12:37.937670", "stderr": "", "stderr_lines": [], "stdout": "pvc-25d83cde-40b9-11e9-af96-42010a800043", "stdout_lines": ["pvc-25d83cde-40b9-11e9-af96-42010a800043"]}

TASK [List the corresponding storage replica pods..] ***************************
task path: /percona/functional/k8s_snapshot/test.yml:173
2019-03-07T09:12:38.755862 (delta: 1.037278)         elapsed: 36.977073 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n snap-percona -l openebs.io/replica=jiva-replica | grep pvc-25d83cde-40b9-11e9-af96-42010a800043 | awk '{print $1}'", "delta": "0:00:00.960037", "end": "2019-03-07 09:12:40.436986", "rc": 0, "start": "2019-03-07 09:12:39.476949", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [check if the sync is completed in all the above replicas.] ***************
task path: /percona/functional/k8s_snapshot/test.yml:179
2019-03-07T09:12:40.494832 (delta: 1.738914)         elapsed: 38.716043 *******

TASK [Update the percona deployment spec with the clone pvc.] ******************
task path: /percona/functional/k8s_snapshot/test.yml:190
2019-03-07T09:12:40.559894 (delta: 0.065)         elapsed: 38.781105 **********
changed: [127.0.0.1] => {"changed": true, "checksum": "2ed22e2e8fc95ab9fbef394add0864f11c3e959e", "dest": "./percona.yml", "gid": 0, "group": "root", "md5sum": "eb2188dd86175babfd783aa8cc91c38b", "mode": "0644", "owner": "root", "size": 862, "src": "/root/.ansible/tmp/ansible-tmp-1551949960.61-172313503200526/source", "state": "file", "uid": 0}

TASK [Deploy the application using snapped volume.] ****************************
task path: /percona/functional/k8s_snapshot/test.yml:195
2019-03-07T09:12:41.216063 (delta: 0.655688)         elapsed: 39.437274 *******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f percona.yml -n snap-percona", "delta": "0:00:00.878758", "end": "2019-03-07 09:12:42.458304", "rc": 0, "start": "2019-03-07 09:12:41.579546", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/percona-new created", "stdout_lines": ["deployment.apps/percona-new created"]}

TASK [Check if the new application pod is started.] ****************************
task path: /percona/functional/k8s_snapshot/test.yml:200
2019-03-07T09:12:42.558459 (delta: 1.342343)         elapsed: 40.77967 ********
FAILED - RETRYING: Check if the new application pod is started. (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n snap-percona -l name=percona-new", "delta": "0:00:00.652360", "end": "2019-03-07 09:13:44.394544", "rc": 0, "start": "2019-03-07 09:13:43.742184", "stderr": "", "stderr_lines": [], "stdout": "NAME                           READY   STATUS    RESTARTS   AGE\npercona-new-6ffd4bb5fd-qc9sw   1/1     Running   0          1m", "stdout_lines": ["NAME                           READY   STATUS    RESTARTS   AGE", "percona-new-6ffd4bb5fd-qc9sw   1/1     Running   0          1m"]}

TASK [Obtaining the application pod name.] *************************************
task path: /percona/functional/k8s_snapshot/test.yml:209
2019-03-07T09:13:44.471260 (delta: 61.912685)         elapsed: 102.692471 *****
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n snap-percona -l name=percona-new --no-headers -o custom-columns=:metadata.name", "delta": "0:00:00.882542", "end": "2019-03-07 09:13:45.706027", "rc": 0, "start": "2019-03-07 09:13:44.823485", "stderr": "", "stderr_lines": [], "stdout": "percona-new-6ffd4bb5fd-qc9sw", "stdout_lines": ["percona-new-6ffd4bb5fd-qc9sw"]}

TASK [Validate the data in the new application pod db.] ************************
task path: /percona/functional/k8s_snapshot/test.yml:215
2019-03-07T09:13:45.788833 (delta: 1.317201)         elapsed: 104.010044 ******
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it percona-new-6ffd4bb5fd-qc9sw -n snap-percona -- mysql -uroot -pk8sDem0 -e \"select * from platforms;\" cloud;", "delta": "0:00:00.958758", "end": "2019-03-07 09:13:46.962514", "rc": 0, "start": "2019-03-07 09:13:46.003756", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nmysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\naws", "stdout_lines": ["Data", "aws"]}

TASK [Attempt deleting volume which has clones.] *******************************
task path: /percona/functional/k8s_snapshot/test.yml:226
2019-03-07T09:13:47.029012 (delta: 1.240006)         elapsed: 105.250223 ******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pvc percona-mysql-claim -n snap-percona", "delta": "0:00:00.667128", "end": "2019-03-07 09:13:47.944757", "failed_when_result": false, "msg": "non-zero return code", "rc": 1, "start": "2019-03-07 09:13:47.277629", "stderr": "Error from server (PVC with cloned volumes can't be deleted): admission webhook \"admission-webhook.openebs.io\" denied the request: pvc \"percona-mysql-claim\" has '1' cloned volume(s)", "stderr_lines": ["Error from server (PVC with cloned volumes can't be deleted): admission webhook \"admission-webhook.openebs.io\" denied the request: pvc \"percona-mysql-claim\" has '1' cloned volume(s)"], "stdout": "", "stdout_lines": []}

TASK [Check if the PVC is not deleted.] ****************************************
task path: /percona/functional/k8s_snapshot/test.yml:233
2019-03-07T09:13:48.008062 (delta: 0.978996)         elapsed: 106.229273 ******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n snap-percona --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.580619", "end": "2019-03-07 09:13:48.780310", "failed_when_result":false, "rc": 0, "start": "2019-03-07 09:13:48.199691", "stderr": "", "stderr_lines": [], "stdout": "Bound", "stdout_lines": ["Bound"]}

TASK [set_fact] ****************************************************************
task path: /percona/functional/k8s_snapshot/test.yml:240
2019-03-07T09:13:48.860574 (delta: 0.852355)         elapsed: 107.081785 ******
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /percona/functional/k8s_snapshot/test.yml:249
2019-03-07T09:13:48.945758 (delta: 0.085115)         elapsed: 107.166969 ******
changed: [127.0.0.1] => {"changed": true, "checksum": "86e9a8e1c5b8b82c3da3ae4f88c14234a53818f7", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a3b5ff0c0471589cec3188a6311b1ab7", "mode": "0644", "owner": "root", "size": 431, "src": "/root/.ansible/tmp/ansible-tmp-1551950029.07-11982726497651/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
task path: /percona/functional/k8s_snapshot/test.yml:260
2019-03-07T09:13:50.686296 (delta: 1.740481)         elapsed: 108.907507 ******
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:00.805239", "end": "2019-03-07 09:13:51.693584", "failed_when_result": false, "rc": 0, "start": "2019-03-07 09:13:50.888345", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-k8s-snapshot-clone configured", "stdout_lines": ["litmusresult.litmus.io/create-k8s-snapshot-clone configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=41   changed=33   unreachable=0    failed=0

2019-03-07T09:13:51.766813 (delta: 1.080461)         elapsed: 109.988024 ******
```