### PR TITLE
refactor[yaml]: Modified network delay utils to check the replica status

### DIFF
--- a/apps/percona/chaos/openebs_replica_network_delay/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_replica_network_delay/run_litmus_test.yml
@@ -34,7 +34,7 @@ spec:
             value: percona-mysql-claim
 
           - name: NETWORK_DELAY
-            value: "3000" # in milliseconds
+            value: "60000" # in milliseconds
 
           - name: CHAOS_DURATION
             value: "60" # in seconds

--- a/apps/percona/chaos/openebs_target_network_delay/run_litmus_test.yml
+++ b/apps/percona/chaos/openebs_target_network_delay/run_litmus_test.yml
@@ -34,7 +34,7 @@ spec:
             value: percona-mysql-claim
 
           - name: NETWORK_DELAY
-            value: "3000" # in milliseconds
+            value: "60000" # in milliseconds
 
           - name: CHAOS_DURATION
             value: "60" # in seconds

--- a/chaoslib/openebs/jiva_controller_network_delay.yaml
+++ b/chaoslib/openebs/jiva_controller_network_delay.yaml
@@ -49,6 +49,30 @@
     executable: /bin/bash
   register: node  
 
+- name: Get controller svc
+  shell: >
+    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc
+    -n {{ app_ns }} --no-headers -o custom-columns=:spec.clusterIP
+  args:
+    executable: /bin/bash
+  register: controller_svc
+  failed_when: controller_svc.stdout == ""
+
+- name: Install jq package inside a controller container
+  shell: >
+    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} -c {{ jiva_controller_name }} 
+    -- bash -c "apt-get update && apt-get install -y jq && apt-get install -y iproute2"
+  args:
+    executable: /bin/bash
+
+- name: Getting the ReplicaCount before injecting delay
+  shell: >
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
+  args:
+    executable: /bin/bash
+  register: rcount_before
+
 - name: Identify the pumba pod that co-exists with jiva controller
   shell: >
     kubectl get pods -l app=pumba -n {{ app_ns }} 
@@ -65,10 +89,17 @@
   args:
     executable: /bin/bash
 
-- name: Wait for 10s post fault injection 
-  wait_for:
-    timeout: 10
-
+- name: Verifying the Replica getting disconnected
+  shell: >
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
+  args:
+    executable: /bin/bash
+  register: resp
+  until: resp.stdout != rcount_before.stdout
+  retries: 10
+  delay: 15
+  
 - name: Delete the pumba daemonset 
   shell: kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n {{ app_ns }} 
   args:
@@ -84,3 +115,14 @@
   until: "'Running' not in result.stdout"
   delay: 20
   retries: 15
+
+- name: Verifying the replicas post network recovery
+  shell: >
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
+  args:
+    executable: /bin/bash
+  register: replica
+  until: replica.stdout == rcount_before.stdout
+  retries: 10
+  delay: 15

--- a/chaoslib/openebs/jiva_replica_network_delay.yaml
+++ b/chaoslib/openebs/jiva_replica_network_delay.yaml
@@ -27,6 +27,20 @@
     executable: /bin/bash
   register: pv
 
+- name: Identify the jiva controller pod belonging to the PV
+  shell: > 
+    kubectl get pods -l openebs.io/controller=jiva-controller
+    -n {{ app_ns }} --no-headers | grep {{ pv.stdout }} 
+    | awk '{print $1}'
+  args:
+    executable: /bin/bash
+  register: jiva_controller_pod
+
+- name: Record the jiva controller container name
+  set_fact:
+    # Depends on the naming convention in maya-apiserver (<pv-id>-rep)
+    jiva_controller_name: "{{ pv.stdout }}-ctrl-con"
+
 - name: Identify the jiva replica pod belonging to the PV
   shell: > 
     kubectl get pods -l openebs.io/replica=jiva-replica
@@ -49,6 +63,37 @@
     executable: /bin/bash
   register: node  
 
+- name: Get controller svc
+  shell: >
+    kubectl get svc -l openebs.io/controller-service=jiva-controller-svc
+    -n {{ app_ns }} --no-headers -o custom-columns=:spec.clusterIP
+  args:
+    executable: /bin/bash
+  register: controller_svc
+  failed_when: controller_svc.stdout == ""
+
+- name: Install jq package inside a controller container
+  shell: >
+    kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} -c {{ jiva_controller_name }} 
+    -- bash -c "apt-get update && apt-get install -y jq && apt-get install -y iproute2"
+  args:
+    executable: /bin/bash
+
+- name: Install jq package inside a replica container
+  shell: >
+    kubectl exec -it {{ jiva_replica_pod.stdout }} -n {{ app_ns }} -c {{ jiva_replica_name }}
+    -- bash -c "apt-get update && apt-get install -y jq && apt-get install -y iproute2"
+  args:
+    executable: /bin/bash
+
+- name: Getting the ReplicaCount before injecting delay
+  shell: >
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
+  args:
+    executable: /bin/bash
+  register: rcount_before
+
 - name: Identify the pumba pod that co-exists with jiva controller
   shell: >
     kubectl get pods -l app=pumba -n {{ app_ns }} 
@@ -65,9 +110,16 @@
   args:
     executable: /bin/bash
 
-- name: Wait for 10s post fault injection 
-  wait_for:
-    timeout: 10
+- name: Verifying the Replica getting disconnected
+  shell: >
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
+  args:
+    executable: /bin/bash
+  register: resp
+  until: resp.stdout != rcount_before.stdout
+  retries: 10
+  delay: 15
 
 - name: Delete the pumba daemonset 
   shell: kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n {{ app_ns }} 
@@ -84,3 +136,15 @@
   until: "'Running' not in result.stdout"
   delay: 20
   retries: 15
+
+- name: Verifying the replicas post network recovery
+  shell: >
+   kubectl exec -it {{ jiva_controller_pod.stdout }} -n {{ app_ns }} 
+   -c {{ jiva_controller_name }} curl http://"{{controller_svc.stdout}}":9501/v1/volumes | jq -r '.data[].replicaCount'
+  args:
+    executable: /bin/bash
+  register: replica
+  until: replica.stdout == rcount_before.stdout
+  retries: 10
+  delay: 15
+


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Modified network delay until for controller and replica.
- The included tasks are check the replica getting disconnected after inducing delay in controller in controller network delay util. The same task added in the replica network delay util also.

ctrl.log
```
ansible-playbook 2.7.8
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./percona/chaos/openebs_target_network_delay/test.yml

PLAY [localhost] ***************************************************************
2019-03-07T19:01:37.174182 (delta: 0.118807)         elapsed: 0.118807 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:2
2019-03-07T19:01:37.203483 (delta: 0.029164)         elapsed: 0.148108 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:12
2019-03-07T19:01:58.574448 (delta: 21.3709)         elapsed: 21.519073 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:16
2019-03-07T19:01:58.774454 (delta: 0.199922)         elapsed: 21.719079 ******* 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /common/utils/create_testname.yml:3
2019-03-07T19:01:59.084799 (delta: 0.310259)         elapsed: 22.029424 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /common/utils/create_testname.yml:7
2019-03-07T19:01:59.248307 (delta: 0.163416)         elapsed: 22.192932 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:2
2019-03-07T19:01:59.385156 (delta: 0.135735)         elapsed: 22.329781 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:04.088518", "end": "2019-03-07 19:02:04.410677", "rc": 0, "start": "2019-03-07 19:02:00.322159", "stderr": "", "stderr_lines": [], "stdout": "openebs-jiva-default", "stdout_lines": ["openebs-jiva-default"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:10
2019-03-07T19:02:04.674774 (delta: 5.289533)         elapsed: 27.619399 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default --no-headers -o custom-columns=:provisioner", "delta": "0:00:04.222229", "end": "2019-03-07 19:02:09.928976", "rc": 0, "start": "2019-03-07 19:02:05.706747", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:18
2019-03-07T19:02:10.244511 (delta: 5.569451)         elapsed: 33.189136 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-jiva-default"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:22
2019-03-07T19:02:10.488348 (delta: 0.241914)         elapsed: 33.432973 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:27
2019-03-07T19:02:10.715705 (delta: 0.227258)         elapsed: 33.66033 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:03.306457", "end": "2019-03-07 19:02:14.949367", "rc": 0, "start": "2019-03-07 19:02:11.642910", "stderr": "", "stderr_lines": [], "stdout": "pvc-bb880fa7-410a-11e9-bed3-42010a800042", "stdout_lines": ["pvc-bb880fa7-410a-11e9-bed3-42010a800042"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:35
2019-03-07T19:02:15.126626 (delta: 4.410333)         elapsed: 38.071251 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-bb880fa7-410a-11e9-bed3-42010a800042 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:03.857941", "end": "2019-03-07 19:02:19.577522", "rc": 0, "start": "2019-03-07 19:02:15.719581", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [Record the storage engine name] ******************************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:43
2019-03-07T19:02:19.736888 (delta: 4.610181)         elapsed: 42.681513 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /percona/chaos/openebs_target_network_delay/test_prerequisites.yml:48
2019-03-07T19:02:20.023663 (delta: 0.286699)         elapsed: 42.968288 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "137781b9db9e90483410f27628fcbde087b091e6", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "596bdd1088ab2ad5ab78689e89933c03", "mode": "0644", "owner": "root", "size": 63, "src": "/root/.ansible/tmp/ansible-tmp-1551985340.13-158036764193016/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:20
2019-03-07T19:02:22.149804 (delta: 2.121178)         elapsed: 45.094429 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/jiva_controller_network_delay.yaml"}, "ansible_included_var_files": ["/percona/chaos/openebs_target_network_delay/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:23
2019-03-07T19:02:22.283884 (delta: 0.133997)         elapsed: 45.228509 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/jiva_controller_network_delay.yaml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:29
2019-03-07T19:02:22.463740 (delta: 0.17871)         elapsed: 45.408365 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-03-07T19:02:22.646752 (delta: 0.182926)         elapsed: 45.591377 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "1b151cfb79090c2878c77de63896d80850f3d583", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "93647d9182948b262e3f5738149a4c3a", "mode": "0644", "owner": "root", "size": 466, "src": "/root/.ansible/tmp/ansible-tmp-1551985342.83-17577510446001/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-03-07T19:02:23.856263 (delta: 1.209426)         elapsed: 46.800888 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:02.940649", "end": "2019-03-07 19:02:27.289190", "rc": 0, "start": "2019-03-07 19:02:24.348541", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_controller_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_controller_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-03-07T19:02:27.594022 (delta: 3.737607)         elapsed: 50.538647 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:03.192033", "end": "2019-03-07 19:02:31.332362", "failed_when_result": false, "rc": 0, "start": "2019-03-07 19:02:28.140329", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-delay configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-03-07T19:02:31.593569 (delta: 3.999278)         elapsed: 54.538194 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-03-07T19:02:31.841978 (delta: 0.24742)         elapsed: 54.786603 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-03-07T19:02:32.163095 (delta: 0.320871)         elapsed: 55.10772 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /percona/chaos/openebs_target_network_delay/test.yml:36
2019-03-07T19:02:32.309248 (delta: 0.146072)         elapsed: 55.253873 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : app-percona-ns", 
        "Label        : name=percona", 
        "PVC          : percona-mysql-claim", 
        "StorageClass : openebs-jiva-default"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /percona/chaos/openebs_target_network_delay/test.yml:47
2019-03-07T19:02:32.534037 (delta: 0.224702)         elapsed: 55.478662 ******* 
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /common/utils/status_app_pod.yml:2
2019-03-07T19:02:32.702187 (delta: 0.168069)         elapsed: 55.646812 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:03.101285", "end": "2019-03-07 19:02:36.379775", "rc": 0, "start": "2019-03-07 19:02:33.278490", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-03-07T18:58:07Z]]", "stdout_lines": ["map[running:map[startedAt:2019-03-07T18:58:07Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /common/utils/status_app_pod.yml:13
2019-03-07T19:02:36.503405 (delta: 3.795698)         elapsed: 59.44803 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:02.182315", "end": "2019-03-07 19:02:39.042480", "rc": 0, "start": "2019-03-07 19:02:36.860165", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:56
2019-03-07T19:02:39.118268 (delta: 2.614787)         elapsed: 62.062893 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:02.140497", "end": "2019-03-07 19:02:41.575082", "rc": 0, "start": "2019-03-07 19:02:39.434585", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-hmlts", "stdout_lines": ["percona-cb697f8b4-hmlts"]}

TASK [Create some test data in the mysql database] *****************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:64
2019-03-07T19:02:41.664254 (delta: 2.545889)         elapsed: 64.608879 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:78
2019-03-07T19:02:41.835652 (delta: 0.171308)         elapsed: 64.780277 ******* 
included: /chaoslib/openebs/jiva_controller_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:1
2019-03-07T19:02:42.013108 (delta: 0.17718)         elapsed: 64.957733 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n app-percona-ns", "delta": "0:00:02.315934", "end": "2019-03-07 19:02:44.545208", "rc": 0, "start": "2019-03-07 19:02:42.229274", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:9
2019-03-07T19:02:44.646005 (delta: 2.632743)         elapsed: 67.59063 ******** 
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n app-percona-ns | sort | uniq", "delta": "0:00:02.014963", "end": "2019-03-07 19:03:09.986277", "rc": 0, "start": "2019-03-07 19:03:07.971314", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:21
2019-03-07T19:03:10.100412 (delta: 25.454328)         elapsed: 93.045037 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n app-percona-ns --no-headers", "delta": "0:00:02.127505", "end": "2019-03-07 19:03:12.587887", "rc": 0, "start": "2019-03-07 19:03:10.460382", "stderr": "", "stderr_lines": [], "stdout": "pvc-bb880fa7-410a-11e9-bed3-42010a800042", "stdout_lines": ["pvc-bb880fa7-410a-11e9-bed3-42010a800042"]}

TASK [Identify the jiva controller pod belonging to the PV] ********************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:30
2019-03-07T19:03:12.775657 (delta: 2.675161)         elapsed: 95.720282 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/controller=jiva-controller -n app-percona-ns --no-headers | grep pvc-bb880fa7-410a-11e9-bed3-42010a800042 | awk '{print $1}'", "delta": "0:00:02.457848", "end": "2019-03-07 19:03:15.746086", "rc": 0, "start": "2019-03-07 19:03:13.288238", "stderr": "", "stderr_lines": [], "stdout": "pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2", "stdout_lines": ["pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2"]}

TASK [Record the jiva controller container name] *******************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:39
2019-03-07T19:03:15.918460 (delta: 3.142698)         elapsed: 98.863085 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_controller_name": "pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-con"}, "changed": false}

TASK [Get the node on which the jiva controller is scheduled] ******************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:44
2019-03-07T19:03:16.156640 (delta: 0.238105)         elapsed: 99.101265 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2 -n app-percona-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:02.044891", "end": "2019-03-07 19:03:19.112449", "rc": 0, "start": "2019-03-07 19:03:17.067558", "stderr": "", "stderr_lines": [], "stdout": "gke-e2e-cluster-2-default-pool-4ba8b47d-3xs4", "stdout_lines": ["gke-e2e-cluster-2-default-pool-4ba8b47d-3xs4"]}

TASK [Get controller svc] ******************************************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:52
2019-03-07T19:03:19.208353 (delta: 3.051631)         elapsed: 102.152978 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -l openebs.io/controller-service=jiva-controller-svc -n app-percona-ns --no-headers -o custom-columns=:spec.clusterIP", "delta": "0:00:02.502231", "end": "2019-03-07 19:03:22.065285", "failed_when_result": false, "rc": 0, "start": "2019-03-07 19:03:19.563054", "stderr": "", "stderr_lines": [], "stdout": "10.63.245.237", "stdout_lines": ["10.63.245.237"]}

TASK [Install jq package inside a controller container] ************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:61
2019-03-07T19:03:22.213857 (delta: 3.005301)         elapsed: 105.158482 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2 -n app-percona-ns -c pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-con -- bash -c \"apt-get update && apt-get install -y jq && apt-get install -y iproute2\"", "delta": "0:00:37.940443", "end": "2019-03-07 19:04:00.459277", "rc": 0, "start": "2019-03-07 19:03:22.518834", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\ndebconf: delaying package configuration, since apt-utils is not installed\ndebconf: delaying package configuration, since apt-utils is not installed", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "debconf: delaying package configuration, since apt-utils is not installed", "debconf: delaying package configuration, since apt-utils is not installed"], "stdout": "Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nGet:5 http://security.ubuntu.com/ubuntu xenial-security/universe Sources [126 kB]\nGet:6 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [795 kB]\nGet:7 http://archive.ubuntu.com/ubuntu xenial/universe Sources [9802 kB]\nGet:8 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]\nGet:9 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [544 kB]\nGet:10 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6116 B]\nGet:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]\nGet:14 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]\nGet:15 http://archive.ubuntu.com/ubuntu xenial-updates/universe Sources [315 kB]\nGet:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1189 kB]\nGet:17 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]\nGet:18 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [951 kB]\nGet:19 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.1 kB]\nGet:20 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]\nGet:21 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8532 B]\nFetched 25.9 MB in 11s (2260 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libonig2\nThe following NEW packages will be installed:\n  jq libonig2\n0 upgraded, 2 newly installed, 0 to remove and 32 not upgraded.\nNeed to get 231 kB of archives.\nAfter this operation, 797 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]\nFetched 231 kB in 0s (297 kB/s)\nSelecting previously unselected package libonig2:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5285 files and directories currently installed.)\r\nPreparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...\r\nUnpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSelecting previously unselected package jq.\r\nPreparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...\r\nUnpacking jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nSetting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSetting up jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libatm1 libmnl0 libxtables11\nSuggested packages:\n  iproute2-doc\nThe following NEW packages will be installed:\n  iproute2 libatm1 libmnl0 libxtables11\n0 upgraded, 4 newly installed, 0 to remove and 32 not upgraded.\nNeed to get 585 kB of archives.\nAfter this operation, 1808 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.4 [521 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]\nFetched 585 kB in 0s (639 kB/s)\nSelecting previously unselected package libatm1:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5297 files and directories currently installed.)\r\nPreparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...\r\nUnpacking libatm1:amd64 (1:2.5.1-1.5) ...\r\nSelecting previously unselected package libmnl0:amd64.\r\nPreparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...\r\nUnpacking libmnl0:amd64 (1.0.3-5) ...\r\nSelecting previously unselected package iproute2.\r\nPreparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.4_amd64.deb ...\r\nUnpacking iproute2 (4.3.0-1ubuntu3.16.04.4) ...\r\nSelecting previously unselected package libxtables11:amd64.\r\nPreparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...\r\nUnpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nSetting up libatm1:amd64 (1:2.5.1-1.5) ...\r\nSetting up libmnl0:amd64 (1.0.3-5) ...\r\nSetting up iproute2 (4.3.0-1ubuntu3.16.04.4) ...\r\nSetting up libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...", "stdout_lines": ["Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Get:5 http://security.ubuntu.com/ubuntu xenial-security/universe Sources [126 kB]", "Get:6 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [795 kB]", "Get:7 http://archive.ubuntu.com/ubuntu xenial/universe Sources [9802 kB]", "Get:8 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]", "Get:9 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [544 kB]", "Get:10 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6116 B]", "Get:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]", "Get:14 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]", "Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/universe Sources [315 kB]", "Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1189 kB]", "Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]", "Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [951 kB]", "Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.1 kB]", "Get:20 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]", "Get:21 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8532 B]", "Fetched 25.9 MB in 11s (2260 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libonig2", "The following NEW packages will be installed:", "  jq libonig2", "0 upgraded, 2 newly installed, 0 to remove and 32 not upgraded.", "Need to get 231 kB of archives.", "After this operation, 797 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]", "Fetched 231 kB in 0s (297 kB/s)", "Selecting previously unselected package libonig2:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5285 files and directories currently installed.)", "Preparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...", "Unpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Selecting previously unselected package jq.", "Preparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...", "Unpacking jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Setting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Setting up jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libatm1 libmnl0 libxtables11", "Suggested packages:", "  iproute2-doc", "The following NEW packages will be installed:", "  iproute2 libatm1 libmnl0 libxtables11", "0 upgraded, 4 newly installed, 0 to remove and 32 not upgraded.", "Need to get 585 kB of archives.", "After this operation, 1808 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.4 [521 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]", "Fetched 585 kB in 0s (639 kB/s)", "Selecting previously unselected package libatm1:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5297 files and directories currently installed.)", "Preparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...", "Unpacking libatm1:amd64 (1:2.5.1-1.5) ...", "Selecting previously unselected package libmnl0:amd64.", "Preparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...", "Unpacking libmnl0:amd64 (1.0.3-5) ...", "Selecting previously unselected package iproute2.", "Preparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.4_amd64.deb ...", "Unpacking iproute2 (4.3.0-1ubuntu3.16.04.4) ...", "Selecting previously unselected package libxtables11:amd64.", "Preparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...", "Unpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Setting up libatm1:amd64 (1:2.5.1-1.5) ...", "Setting up libmnl0:amd64 (1.0.3-5) ...", "Setting up iproute2 (4.3.0-1ubuntu3.16.04.4) ...", "Setting up libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ..."]}

TASK [Getting the ReplicaCount before injecting delay] *************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:68
2019-03-07T19:04:00.648274 (delta: 38.434344)         elapsed: 143.592899 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2 -n app-percona-ns -c pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-con curl http://\"10.63.245.237\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:04.617462", "end": "2019-03-07 19:04:05.761320", "rc": 0, "start": "2019-03-07 19:04:01.143858", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   769  100   769    0     0  90887      0 --:--:-- --:--:-- --:--:--  150k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100   769  100   769    0     0  90887      0 --:--:-- --:--:-- --:--:--  150k"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Identify the pumba pod that co-exists with jiva controller] **************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:76
2019-03-07T19:04:05.964142 (delta: 5.315785)         elapsed: 148.908767 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n app-percona-ns -o jsonpath='{.items[?(@.spec.nodeName==''\"gke-e2e-cluster-2-default-pool-4ba8b47d-3xs4\"'')].metadata.name}'", "delta": "0:00:03.189036", "end": "2019-03-07 19:04:10.146010", "rc": 0, "start": "2019-03-07 19:04:06.956974", "stderr": "", "stderr_lines": [], "stdout": "pumba-svn9j", "stdout_lines": ["pumba-svn9j"]}

TASK [Inject egress delay of 60000ms on jiva controller for 60s] ***************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:84
2019-03-07T19:04:10.251213 (delta: 4.286958)         elapsed: 153.195838 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-svn9j -n app-percona-ns -- pumba netem --interface eth0 --duration 60s delay --time 60000 re2:k8s_pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-co", "delta": "0:01:03.981131", "end": "2019-03-07 19:05:14.554494", "rc": 0, "start": "2019-03-07 19:04:10.573363", "stderr": "time=\"2019-03-07T19:04:13Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2019-03-07T19:04:14Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 24686df1ebee0355c7257fbf5ccac763ce47fa90feb1434bf5f5100e6a45e934 for 1m0s\" \ntime=\"2019-03-07T19:04:14Z\" level=info msg=\"Start netem for container 24686df1ebee0355c7257fbf5ccac763ce47fa90feb1434bf5f5100e6a45e934 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" \ntime=\"2019-03-07T19:05:14Z\" level=info msg=\"Stopping netem on container 24686df1ebee0355c7257fbf5ccac763ce47fa90feb1434bf5f5100e6a45e934\" \ntime=\"2019-03-07T19:05:14Z\" level=info msg=\"Stop netem for container 24686df1ebee0355c7257fbf5ccac763ce47fa90feb1434bf5f5100e6a45e934 on 'eth0'\" ", "stderr_lines": ["time=\"2019-03-07T19:04:13Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2019-03-07T19:04:14Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 24686df1ebee0355c7257fbf5ccac763ce47fa90feb1434bf5f5100e6a45e934 for 1m0s\" ", "time=\"2019-03-07T19:04:14Z\" level=info msg=\"Start netem for container 24686df1ebee0355c7257fbf5ccac763ce47fa90feb1434bf5f5100e6a45e934 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" ", "time=\"2019-03-07T19:05:14Z\" level=info msg=\"Stopping netem on container 24686df1ebee0355c7257fbf5ccac763ce47fa90feb1434bf5f5100e6a45e934\" ", "time=\"2019-03-07T19:05:14Z\" level=info msg=\"Stop netem for container 24686df1ebee0355c7257fbf5ccac763ce47fa90feb1434bf5f5100e6a45e934 on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Verifying the Replica getting disconnected] ******************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:92
2019-03-07T19:05:14.659303 (delta: 64.408009)         elapsed: 217.603928 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2 -n app-percona-ns -c pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-con curl http://\"10.63.245.237\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:04.435458", "end": "2019-03-07 19:05:19.776085", "rc": 0, "start": "2019-03-07 19:05:15.340627", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   520  100   520    0     0   259k      0 --:--:-- --:--:-- --:--:--  507k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100   520  100   520    0     0   259k      0 --:--:-- --:--:-- --:--:--  507k"], "stdout": "0", "stdout_lines": ["0"]}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:103
2019-03-07T19:05:20.257678 (delta: 5.598294)         elapsed: 223.202303 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n app-percona-ns", "delta": "0:00:02.802372", "end": "2019-03-07 19:05:24.090015", "rc": 0, "start": "2019-03-07 19:05:21.287643", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:109
2019-03-07T19:05:24.279576 (delta: 4.021808)         elapsed: 227.224201 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n app-percona-ns", "delta": "0:00:03.606591", "end": "2019-03-07 19:05:28.734602", "rc": 0, "start": "2019-03-07 19:05:25.128011", "stderr": "", "stderr_lines": [], "stdout": "pumba-gs57r   0/1   Terminating   0     2m\npumba-kgc6n   0/1   Terminating   0     2m", "stdout_lines": ["pumba-gs57r   0/1   Terminating   0     2m", "pumba-kgc6n   0/1   Terminating   0     2m"]}

TASK [Verifying the replicas post network recovery] ****************************
task path: /chaoslib/openebs/jiva_controller_network_delay.yaml:119
2019-03-07T19:05:28.943607 (delta: 4.66395)         elapsed: 231.888232 ******* 
FAILED - RETRYING: Verifying the replicas post network recovery (10 retries left).
FAILED - RETRYING: Verifying the replicas post network recovery (9 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl exec -it pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2 -n app-percona-ns -c pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-con curl http://\"10.63.245.237\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:02.897017", "end": "2019-03-07 19:06:09.166437", "rc": 0, "start": "2019-03-07 19:06:06.269420", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   769  100   769    0     0   434k      0 --:--:-- --:--:-- --:--:--  750k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100   769  100   769    0     0   434k      0 --:--:-- --:--:-- --:--:--  750k"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:86
2019-03-07T19:06:09.234694 (delta: 40.290989)         elapsed: 272.179319 ***** 
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /common/utils/status_app_pod.yml:2
2019-03-07T19:06:09.365165 (delta: 0.130368)         elapsed: 272.30979 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:02.489252", "end": "2019-03-07 19:06:12.342905", "rc": 0, "start": "2019-03-07 19:06:09.853653", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-03-07T18:58:07Z]]", "stdout_lines": ["map[running:map[startedAt:2019-03-07T18:58:07Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /common/utils/status_app_pod.yml:13
2019-03-07T19:06:12.430176 (delta: 3.064912)         elapsed: 275.374801 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:02.600046", "end": "2019-03-07 19:06:15.358046", "rc": 0, "start": "2019-03-07 19:06:12.758000", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:95
2019-03-07T19:06:15.484737 (delta: 3.054474)         elapsed: 278.429362 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:98
2019-03-07T19:06:15.576629 (delta: 0.091255)         elapsed: 278.521254 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:110
2019-03-07T19:06:15.650106 (delta: 0.073395)         elapsed: 278.594731 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_target_network_delay/test.yml:121
2019-03-07T19:06:15.836066 (delta: 0.185877)         elapsed: 278.780691 ****** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-03-07T19:06:16.049227 (delta: 0.213069)         elapsed: 278.993852 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-03-07T19:06:16.155618 (delta: 0.10631)         elapsed: 279.100243 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-03-07T19:06:16.227122 (delta: 0.070953)         elapsed: 279.171747 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-03-07T19:06:16.344006 (delta: 0.116776)         elapsed: 279.288631 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "9be24fd65ce65f9c713f64935b74ffbff67aa54a", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "540b5997a2d61c1b7972ad544385a4d3", "mode": "0644", "owner": "root", "size": 464, "src": "/root/.ansible/tmp/ansible-tmp-1551985576.46-65104298832010/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-03-07T19:06:21.853063 (delta: 5.508895)         elapsed: 284.797688 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.995345", "end": "2019-03-07 19:06:24.935855", "rc": 0, "start": "2019-03-07 19:06:22.940510", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-target-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_controller_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-target-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_controller_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-03-07T19:06:25.033292 (delta: 3.180151)         elapsed: 287.977917 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:03.009644", "end": "2019-03-07 19:06:28.410181", "failed_when_result": false, "rc": 0, "start": "2019-03-07 19:06:25.400537", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-target-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-target-network-delay configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=45   changed=30   unreachable=0    failed=0   

2019-03-07T19:06:28.483389 (delta: 3.449966)         elapsed: 291.428014 ****** 
=============================================================================== 
```

replica log

```
ansible-playbook 2.7.8
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /percona/chaos/openebs_replica_network_delay/test_prerequisites.yml
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./percona/chaos/openebs_replica_network_delay/test.yml

PLAY [localhost] ***************************************************************
2019-03-07T20:00:28.017294 (delta: 0.098418)         elapsed: 0.098418 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:2
2019-03-07T20:00:28.041458 (delta: 0.023934)         elapsed: 0.122582 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:11
2019-03-07T20:00:43.475437 (delta: 15.433939)         elapsed: 15.556561 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Identify the storage class used by the PVC] ******************************
task path: /percona/chaos/openebs_replica_network_delay/test_prerequisites.yml:2
2019-03-07T20:00:43.551799 (delta: 0.076294)         elapsed: 15.632923 *******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.storageClassName", "delta": "0:00:02.086619", "end": "2019-03-07 20:00:46.156366", "rc": 0, "start": "2019-03-07 20:00:44.069747", "stderr": "", "stderr_lines": [], "stdout": "openebs-jiva-default", "stdout_lines": ["openebs-jiva-default"]}

TASK [Identify the storage provisioner used by the SC] *************************
task path: /percona/chaos/openebs_replica_network_delay/test_prerequisites.yml:10
2019-03-07T20:00:46.249398 (delta: 2.697534)         elapsed: 18.330522 *******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-jiva-default --no-headers -o custom-columns=:provisioner", "delta": "0:00:01.863062", "end": "2019-03-07 20:00:48.334721", "rc": 0, "start": "2019-03-07 20:00:46.471659", "stderr": "", "stderr_lines": [], "stdout": "openebs.io/provisioner-iscsi", "stdout_lines": ["openebs.io/provisioner-iscsi"]}

TASK [Record the storage class name] *******************************************
task path: /percona/chaos/openebs_replica_network_delay/test_prerequisites.yml:18
2019-03-07T20:00:48.401803 (delta: 2.152342)         elapsed: 20.482927 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"sc": "openebs-jiva-default"}, "changed": false}

TASK [Record the storage provisioner name] *************************************
task path: /percona/chaos/openebs_replica_network_delay/test_prerequisites.yml:22
2019-03-07T20:00:48.492718 (delta: 0.09061)         elapsed: 20.573842 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"stg_prov": "openebs.io/provisioner-iscsi"}, "changed": false}

TASK [Derive PV name from PVC to query storage engine type (openebs)] **********
task path: /percona/chaos/openebs_replica_network_delay/test_prerequisites.yml:27
2019-03-07T20:00:48.598034 (delta: 0.10525)         elapsed: 20.679158 ********changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -n app-percona-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:02.119995", "end": "2019-03-07 20:00:51.003748", "rc": 0, "start": "2019-03-07 20:00:48.883753", "stderr": "", "stderr_lines": [], "stdout": "pvc-bb880fa7-410a-11e9-bed3-42010a800042", "stdout_lines": ["pvc-bb880fa7-410a-11e9-bed3-42010a800042"]}

TASK [Check for presence & value of cas type annotation] ***********************
task path: /percona/chaos/openebs_replica_network_delay/test_prerequisites.yml:35
2019-03-07T20:00:51.088395 (delta: 2.490289)         elapsed: 23.169519 *******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pv pvc-bb880fa7-410a-11e9-bed3-42010a800042 --no-headers -o jsonpath=\"{.metadata.annotations.openebs\\\\.io/cas-type}\"", "delta": "0:00:01.856381", "end": "2019-03-07 20:00:53.184890", "rc": 0, "start": "2019-03-07 20:00:51.328509", "stderr": "", "stderr_lines": [], "stdout": "jiva", "stdout_lines": ["jiva"]}

TASK [Record the storage engine name] ******************************************
task path: /percona/chaos/openebs_replica_network_delay/test_prerequisites.yml:43
2019-03-07T20:00:53.231659 (delta: 2.143134)         elapsed: 25.312783 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"stg_engine": "jiva"}, "changed": false}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /percona/chaos/openebs_replica_network_delay/test_prerequisites.yml:48
2019-03-07T20:00:53.298249 (delta: 0.066522)         elapsed: 25.379373 *******changed: [127.0.0.1] => {"changed": true, "checksum": "cc41594b9e756bd386a5f8aefa6f4406bb8500fb", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "c4e8e343052a60e26ff990195e2675d5", "mode": "0644", "owner": "root", "size": 60, "src": "/root/.ansible/tmp/ansible-tmp-1551988853.34-55455075231506/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:18
2019-03-07T20:00:54.420039 (delta: 1.121686)         elapsed: 26.501163 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "openebs/jiva_replica_network_delay.yaml"}, "ansible_included_var_files": ["/percona/chaos/openebs_replica_network_delay/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:21
2019-03-07T20:00:54.525562 (delta: 0.105447)         elapsed: 26.606686 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/chaoslib/openebs/jiva_replica_network_delay.yaml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:27
2019-03-07T20:00:54.678980 (delta: 0.153174)         elapsed: 26.760104 ******* 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /common/utils/create_testname.yml:3
2019-03-07T20:00:54.788869 (delta: 0.109817)         elapsed: 26.869993 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /common/utils/create_testname.yml:7
2019-03-07T20:00:54.861043 (delta: 0.071794)         elapsed: 26.942167 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:29
2019-03-07T20:00:54.950647 (delta: 0.089384)         elapsed: 27.031771 ******* 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-03-07T20:00:55.071515 (delta: 0.120768)         elapsed: 27.152639 *******changed: [127.0.0.1] => {"changed": true, "checksum": "443a1dcd12c02b289a1b7a96be0b3ba148072b96", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4a2eb222bfccd1a2105b7468f0c61247", "mode": "0644", "owner": "root", "size": 464, "src": "/root/.ansible/tmp/ansible-tmp-1551988855.15-161802517704698/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-03-07T20:00:55.710577 (delta: 0.638991)         elapsed: 27.791701 *******changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.659065", "end": "2019-03-07 20:00:57.630526", "rc": 0, "start": "2019-03-07 20:00:55.971461", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-replica-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-replica-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-03-07T20:00:57.694589 (delta: 1.983184)         elapsed: 29.775713 *******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.168393", "end": "2019-03-07 20:01:00.096823", "failed_when_result": false, "rc": 0, "start": "2019-03-07 20:00:57.928430", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-replica-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-replica-network-delay configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-03-07T20:01:00.215799 (delta: 2.521159)         elapsed: 32.296923 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-03-07T20:01:00.313528 (delta: 0.097303)         elapsed: 32.394652 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-03-07T20:01:00.378613 (delta: 0.06502)         elapsed: 32.459737 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:36
2019-03-07T20:01:00.438043 (delta: 0.059348)         elapsed: 32.519167 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : app-percona-ns", 
        "Label        : name=percona", 
        "PVC          : percona-mysql-claim", 
        "StorageClass : openebs-jiva-default"
    ]
}

TASK [Verify that the AUT (Application Under Test) is running] *****************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:47
2019-03-07T20:01:00.571116 (delta: 0.132999)         elapsed: 32.65224 ******** 
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /common/utils/status_app_pod.yml:2
2019-03-07T20:01:00.724577 (delta: 0.153365)         elapsed: 32.805701 *******changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.926071", "end": "2019-03-07 20:01:02.925386", "rc": 0, "start": "2019-03-07 20:01:00.999315", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-03-07T18:58:07Z]]", "stdout_lines": ["map[running:map[startedAt:2019-03-07T18:58:07Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /common/utils/status_app_pod.yml:13
2019-03-07T20:01:03.053390 (delta: 2.328749)         elapsed: 35.134514 *******changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.861136", "end": "2019-03-07 20:01:05.353869", "rc": 0, "start": "2019-03-07 20:01:03.492733", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get application pod name] ************************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:56
2019-03-07T20:01:05.418177 (delta: 2.364509)         elapsed: 37.499301 *******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:01.723563", "end": "2019-03-07 20:01:07.490095", "rc": 0, "start": "2019-03-07 20:01:05.766532", "stderr": "", "stderr_lines": [], "stdout": "percona-cb697f8b4-hmlts", "stdout_lines": ["percona-cb697f8b4-hmlts"]}

TASK [Create some test data in the mysql database] *****************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:64
2019-03-07T20:01:07.561023 (delta: 2.142772)         elapsed: 39.642147 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include] *****************************************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:78
2019-03-07T20:01:07.799552 (delta: 0.238327)         elapsed: 39.880676 ******* 
included: /chaoslib/openebs/jiva_replica_network_delay.yaml for 127.0.0.1

TASK [Setup pumba chaos infrastructure] ****************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:1
2019-03-07T20:01:08.094515 (delta: 0.294766)         elapsed: 40.175639 *******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f /chaoslib/pumba/pumba_kube.yaml -n app-percona-ns", "delta": "0:00:01.963100", "end": "2019-03-07 20:01:10.376656", "rc": 0, "start": "2019-03-07 20:01:08.413556", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions/pumba created", "stdout_lines": ["daemonset.extensions/pumba created"]}

TASK [Confirm that the pumba ds is running on all nodes] ***********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:9
2019-03-07T20:01:10.450043 (delta: 2.354826)         elapsed: 42.531167 ******* 
FAILED - RETRYING: Confirm that the pumba ds is running on all nodes (15 retries left).[0changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -l app=pumba --no-headers -o custom-columns=:status.phase -n app-percona-ns | sort | uniq", "delta": "0:00:01.844831", "end": "2019-03-07 20:01:35.607589", "rc": 0, "start": "2019-03-07 20:01:33.762758", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV from application PVC] ******************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:21
2019-03-07T20:01:35.739478 (delta: 25.289252)         elapsed: 67.820602 ******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc percona-mysql-claim -o custom-columns=:spec.volumeName -n app-percona-ns --no-headers", "delta": "0:00:01.983114", "end": "2019-03-07 20:01:37.999803", "rc": 0, "start": "2019-03-07 20:01:36.016689", "stderr": "", "stderr_lines": [], "stdout": "pvc-bb880fa7-410a-11e9-bed3-42010a800042", "stdout_lines": ["pvc-bb880fa7-410a-11e9-bed3-42010a800042"]}

TASK [Identify the jiva controller pod belonging to the PV] ********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:30
2019-03-07T20:01:38.053752 (delta: 2.314205)         elapsed: 70.134876 *******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/controller=jiva-controller -n app-percona-ns --no-headers | grep pvc-bb880fa7-410a-11e9-bed3-42010a800042 | awk '{print $1}'", "delta": "0:00:02.038185", "end": "2019-03-07 20:01:40.393985", "rc": 0, "start": "2019-03-07 20:01:38.355800", "stderr": "", "stderr_lines": [], "stdout": "pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2", "stdout_lines": ["pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2"]}

TASK [Record the jiva controller container name] *******************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:39
2019-03-07T20:01:40.463877 (delta: 2.410033)         elapsed: 72.545001 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_controller_name": "pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-con"}, "changed": false}

TASK [Identify the jiva replica pod belonging to the PV] ***********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:44
2019-03-07T20:01:40.566321 (delta: 0.102247)         elapsed: 72.647445 *******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l openebs.io/replica=jiva-replica -n app-percona-ns --no-headers | grep pvc-bb880fa7-410a-11e9-bed3-42010a800042 | awk 'FNR == 1 {print}'| awk {'print $1'}", "delta": "0:00:01.931706", "end": "2019-03-07 20:01:42.803178", "rc": 0, "start": "2019-03-07 20:01:40.871472", "stderr": "", "stderr_lines": [], "stdout": "pvc-bb880fa7-410a-11e9-bed3-42010a800042-rep-7f4556b9cc-5lxkg", "stdout_lines": ["pvc-bb880fa7-410a-11e9-bed3-42010a800042-rep-7f4556b9cc-5lxkg"]}

TASK [Record the jiva replica container name] **********************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:53
2019-03-07T20:01:42.878000 (delta: 2.311509)         elapsed: 74.959124 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"jiva_replica_name": "pvc-bb880fa7-410a-11e9-bed3-42010a800042-rep-con"}, "changed": false}

TASK [Get the node on which the jiva replica is scheduled] *********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:58
2019-03-07T20:01:43.035060 (delta: 0.156969)         elapsed: 75.116184 *******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod pvc-bb880fa7-410a-11e9-bed3-42010a800042-rep-7f4556b9cc-5lxkg -n app-percona-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:01.944930", "end": "2019-03-07 20:01:45.387574", "rc": 0, "start": "2019-03-07 20:01:43.442644", "stderr": "", "stderr_lines": [], "stdout": "gke-e2e-cluster-2-default-pool-4ba8b47d-t1hl", "stdout_lines": ["gke-e2e-cluster-2-default-pool-4ba8b47d-t1hl"]}

TASK [Get controller svc] ******************************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:66
2019-03-07T20:01:45.442793 (delta: 2.407538)         elapsed: 77.523917 *******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get svc -l openebs.io/controller-service=jiva-controller-svc -n app-percona-ns --no-headers -o custom-columns=:spec.clusterIP", "delta": "0:00:01.655674", "end": "2019-03-07 20:01:47.395529", "failed_when_result": false, "rc": 0, "start": "2019-03-07 20:01:45.739855", "stderr": "", "stderr_lines": [], "stdout": "10.63.245.237", "stdout_lines": ["10.63.245.237"]}

TASK [Install jq package inside a controller container] ************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:75
2019-03-07T20:01:47.459016 (delta: 2.016083)         elapsed: 79.54014 ********changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2 -n app-percona-ns -c pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-con -- bash -c \"apt-get update && apt-get install -y jq && apt-get install -y iproute2\"", "delta": "0:00:18.414532", "end": "2019-03-07 20:02:06.262304", "rc": 0, "start": "2019-03-07 20:01:47.847772", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nHit:2 http://archive.ubuntu.com/ubuntu xenial InRelease\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nFetched 325 kB in 1s (186 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\njq is already the newest version (1.5+dfsg-1ubuntu0.1).\n0 upgraded, 0 newly installed, 0 to remove and 32 not upgraded.\nReading package lists...\nBuilding dependency tree...\nReading state information...\niproute2 is already the newest version (4.3.0-1ubuntu3.16.04.4).\n0 upgraded, 0 newly installed, 0 to remove and 32 not upgraded.", "stdout_lines": ["Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Fetched 325 kB in 1s (186 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "jq is already the newest version (1.5+dfsg-1ubuntu0.1).", "0 upgraded, 0 newly installed, 0 to remove and 32 not upgraded.", "Reading package lists...", "Building dependency tree...", "Reading state information...", "iproute2 is already the newest version (4.3.0-1ubuntu3.16.04.4).", "0 upgraded, 0 newly installed, 0 to remove and 32 not upgraded."]}

TASK [Install jq package inside a replica container] ***************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:82
2019-03-07T20:02:06.333299 (delta: 18.874205)         elapsed: 98.414423 ******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-bb880fa7-410a-11e9-bed3-42010a800042-rep-7f4556b9cc-5lxkg -n app-percona-ns -c pvc-bb880fa7-410a-11e9-bed3-42010a800042-rep-con -- bash -c \"apt-get update && apt-get install -y jq && apt-get install -y iproute2\"", "delta": "0:00:29.105787", "end": "2019-03-07 20:02:35.690648", "rc": 0, "start": "2019-03-07 20:02:06.584861", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\ndebconf: delaying package configuration, since apt-utils is not installed\ndebconf: delaying package configuration, since apt-utils is not installed", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "debconf: delaying package configuration, since apt-utils is not installed", "debconf: delaying package configuration, since apt-utils is not installed"], "stdout": "Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]\nGet:5 http://security.ubuntu.com/ubuntu xenial-security/universe Sources [126 kB]\nGet:6 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [795 kB]\nGet:7 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]\nGet:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [544 kB]\nGet:9 http://archive.ubuntu.com/ubuntu xenial/universe Sources [9802 kB]\nGet:10 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6116 B]\nGet:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]\nGet:12 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]\nGet:13 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]\nGet:14 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]\nGet:15 http://archive.ubuntu.com/ubuntu xenial-updates/universe Sources [315 kB]\nGet:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1189 kB]\nGet:17 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]\nGet:18 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [951 kB]\nGet:19 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.1 kB]\nGet:20 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]\nGet:21 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8532 B]\nFetched 25.9 MB in 8s (2954 kB/s)\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libonig2\nThe following NEW packages will be installed:\n  jq libonig2\n0 upgraded, 2 newly installed, 0 to remove and 32 not upgraded.\nNeed to get 231 kB of archives.\nAfter this operation, 797 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]\nFetched 231 kB in 0s (294 kB/s)\nSelecting previously unselected package libonig2:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5285 files and directories currently installed.)\r\nPreparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...\r\nUnpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSelecting previously unselected package jq.\r\nPreparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...\r\nUnpacking jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nSetting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...\r\nSetting up jq (1.5+dfsg-1ubuntu0.1) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nReading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  libatm1 libmnl0 libxtables11\nSuggested packages:\n  iproute2-doc\nThe following NEW packages will be installed:\n  iproute2 libatm1 libmnl0 libxtables11\n0 upgraded, 4 newly installed, 0 to remove and 32 not upgraded.\nNeed to get 585 kB of archives.\nAfter this operation, 1808 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]\nGet:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]\nGet:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.4 [521 kB]\nGet:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]\nFetched 585 kB in 0s (652 kB/s)\nSelecting previously unselected package libatm1:amd64.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 5297 files and directories currently installed.)\r\nPreparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...\r\nUnpacking libatm1:amd64 (1:2.5.1-1.5) ...\r\nSelecting previously unselected package libmnl0:amd64.\r\nPreparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...\r\nUnpacking libmnl0:amd64 (1.0.3-5) ...\r\nSelecting previously unselected package iproute2.\r\nPreparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.4_amd64.deb ...\r\nUnpacking iproute2 (4.3.0-1ubuntu3.16.04.4) ...\r\nSelecting previously unselected package libxtables11:amd64.\r\nPreparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...\r\nUnpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...\r\nSetting up libatm1:amd64 (1:2.5.1-1.5) ...\r\nSetting up libmnl0:amd64 (1.0.3-5) ...\r\nSetting up iproute2 (4.3.0-1ubuntu3.16.04.4) ...\r\nSetting up libxtables11:amd64 (1.6.0-2ubuntu3) ...\r\nProcessing triggers for libc-bin (2.23-0ubuntu10) ...", "stdout_lines": ["Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]", "Get:5 http://security.ubuntu.com/ubuntu xenial-security/universe Sources [126 kB]", "Get:6 http://security.ubuntu.com/ubuntu xenial-security/main amd64 Packages [795 kB]", "Get:7 http://security.ubuntu.com/ubuntu xenial-security/restricted amd64 Packages [12.7 kB]", "Get:8 http://security.ubuntu.com/ubuntu xenial-security/universe amd64 Packages [544 kB]", "Get:9 http://archive.ubuntu.com/ubuntu xenial/universe Sources [9802 kB]", "Get:10 http://security.ubuntu.com/ubuntu xenial-security/multiverse amd64 Packages [6116 B]", "Get:11 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]", "Get:12 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]", "Get:13 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]", "Get:14 http://archive.ubuntu.com/ubuntu xenial/multiverse amd64 Packages [176 kB]", "Get:15 http://archive.ubuntu.com/ubuntu xenial-updates/universe Sources [315 kB]", "Get:16 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [1189 kB]", "Get:17 http://archive.ubuntu.com/ubuntu xenial-updates/restricted amd64 Packages [13.1 kB]", "Get:18 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 Packages [951 kB]", "Get:19 http://archive.ubuntu.com/ubuntu xenial-updates/multiverse amd64 Packages [19.1 kB]", "Get:20 http://archive.ubuntu.com/ubuntu xenial-backports/main amd64 Packages [7942 B]", "Get:21 http://archive.ubuntu.com/ubuntu xenial-backports/universe amd64 Packages [8532 B]", "Fetched 25.9 MB in 8s (2954 kB/s)", "Reading package lists...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libonig2", "The following NEW packages will be installed:", "  jq libonig2", "0 upgraded, 2 newly installed, 0 to remove and 32 not upgraded.", "Need to get 231 kB of archives.", "After this operation, 797 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 libonig2 amd64 5.9.6-1ubuntu0.1 [86.7 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial-updates/universe amd64 jq amd64 1.5+dfsg-1ubuntu0.1 [144 kB]", "Fetched 231 kB in 0s (294 kB/s)", "Selecting previously unselected package libonig2:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5285 files and directories currently installed.)", "Preparing to unpack .../libonig2_5.9.6-1ubuntu0.1_amd64.deb ...", "Unpacking libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Selecting previously unselected package jq.", "Preparing to unpack .../jq_1.5+dfsg-1ubuntu0.1_amd64.deb ...", "Unpacking jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Setting up libonig2:amd64 (5.9.6-1ubuntu0.1) ...", "Setting up jq (1.5+dfsg-1ubuntu0.1) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  libatm1 libmnl0 libxtables11", "Suggested packages:", "  iproute2-doc", "The following NEW packages will be installed:", "  iproute2 libatm1 libmnl0 libxtables11", "0 upgraded, 4 newly installed, 0 to remove and 32 not upgraded.", "Need to get 585 kB of archives.", "After this operation, 1808 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 libatm1 amd64 1:2.5.1-1.5 [24.2 kB]", "Get:2 http://archive.ubuntu.com/ubuntu xenial/main amd64 libmnl0 amd64 1.0.3-5 [12.0 kB]", "Get:3 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 iproute2 amd64 4.3.0-1ubuntu3.16.04.4 [521 kB]", "Get:4 http://archive.ubuntu.com/ubuntu xenial/main amd64 libxtables11 amd64 1.6.0-2ubuntu3 [27.2 kB]", "Fetched 585 kB in 0s (652 kB/s)", "Selecting previously unselected package libatm1:amd64.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 5297 files and directories currently installed.)", "Preparing to unpack .../libatm1_1%3a2.5.1-1.5_amd64.deb ...", "Unpacking libatm1:amd64 (1:2.5.1-1.5) ...", "Selecting previously unselected package libmnl0:amd64.", "Preparing to unpack .../libmnl0_1.0.3-5_amd64.deb ...", "Unpacking libmnl0:amd64 (1.0.3-5) ...", "Selecting previously unselected package iproute2.", "Preparing to unpack .../iproute2_4.3.0-1ubuntu3.16.04.4_amd64.deb ...", "Unpacking iproute2 (4.3.0-1ubuntu3.16.04.4) ...", "Selecting previously unselected package libxtables11:amd64.", "Preparing to unpack .../libxtables11_1.6.0-2ubuntu3_amd64.deb ...", "Unpacking libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ...", "Setting up libatm1:amd64 (1:2.5.1-1.5) ...", "Setting up libmnl0:amd64 (1.0.3-5) ...", "Setting up iproute2 (4.3.0-1ubuntu3.16.04.4) ...", "Setting up libxtables11:amd64 (1.6.0-2ubuntu3) ...", "Processing triggers for libc-bin (2.23-0ubuntu10) ..."]}

TASK [Getting the ReplicaCount before injecting delay] *************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:89
2019-03-07T20:02:35.788867 (delta: 29.455225)         elapsed: 127.869991 *****changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2 -n app-percona-ns -c pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-con curl http://\"10.63.245.237\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:02.136096", "end": "2019-03-07 20:02:38.257556", "rc": 0, "start": "2019-03-07 20:02:36.121460", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   769  100   769    0     0   409k      0 --:--:-- --:--:-- --:--:--  750k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100   769  100   769    0     0   409k      0 --:--:-- --:--:-- --:--:--  750k"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Identify the pumba pod that co-exists with jiva controller] **************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:97
2019-03-07T20:02:38.331831 (delta: 2.542893)         elapsed: 130.412955 ******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -l app=pumba -n app-percona-ns -o jsonpath='{.items[?(@.spec.nodeName==''\"gke-e2e-cluster-2-default-pool-4ba8b47d-t1hl\"'')].metadata.name}'", "delta": "0:00:01.898841", "end": "2019-03-07 20:02:40.486899", "rc": 0, "start": "2019-03-07 20:02:38.588058", "stderr": "", "stderr_lines": [], "stdout": "pumba-jzv2m", "stdout_lines": ["pumba-jzv2m"]}

TASK [Inject egress delay of 60000ms on jiva controller for 60s] ***************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:105
2019-03-07T20:02:40.605873 (delta: 2.273973)         elapsed: 132.686997 ******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec pumba-jzv2m -n app-percona-ns -- pumba netem --interface eth0 --duration 60s delay --time 60000 re2:k8s_pvc-bb880fa7-410a-11e9-bed3-42010a800042-rep-con", "delta": "0:01:03.368549", "end": "2019-03-07 20:03:44.484312", "rc": 0, "start": "2019-03-07 20:02:41.115763", "stderr": "time=\"2019-03-07T20:02:43Z\" level=info msg=\"netem: delay for containers\" \ntime=\"2019-03-07T20:02:44Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 19ae0b7b34a96a413d512aaa6b29db1533e2ec6541226aa4007785bd67461b22 for 1m0s\" \ntime=\"2019-03-07T20:02:44Z\" level=info msg=\"Start netem for container 19ae0b7b34a96a413d512aaa6b29db1533e2ec6541226aa4007785bd67461b22 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" \ntime=\"2019-03-07T20:03:44Z\" level=info msg=\"Stopping netem on container 19ae0b7b34a96a413d512aaa6b29db1533e2ec6541226aa4007785bd67461b22\" \ntime=\"2019-03-07T20:03:44Z\" level=info msg=\"Stop netem for container 19ae0b7b34a96a413d512aaa6b29db1533e2ec6541226aa4007785bd67461b22 on 'eth0'\" ", "stderr_lines": ["time=\"2019-03-07T20:02:43Z\" level=info msg=\"netem: delay for containers\" ", "time=\"2019-03-07T20:02:44Z\" level=info msg=\"Running netem command '[delay 60000ms 10ms 20.00]' on container 19ae0b7b34a96a413d512aaa6b29db1533e2ec6541226aa4007785bd67461b22 for 1m0s\" ", "time=\"2019-03-07T20:02:44Z\" level=info msg=\"Start netem for container 19ae0b7b34a96a413d512aaa6b29db1533e2ec6541226aa4007785bd67461b22 on 'eth0' with command '[delay 60000ms 10ms 20.00]'\" ", "time=\"2019-03-07T20:03:44Z\" level=info msg=\"Stopping netem on container 19ae0b7b34a96a413d512aaa6b29db1533e2ec6541226aa4007785bd67461b22\" ", "time=\"2019-03-07T20:03:44Z\" level=info msg=\"Stop netem for container 19ae0b7b34a96a413d512aaa6b29db1533e2ec6541226aa4007785bd67461b22 on 'eth0'\" "], "stdout": "", "stdout_lines": []}

TASK [Verifying the Replica getting disconnected] ******************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:113
2019-03-07T20:03:44.547511 (delta: 63.941575)         elapsed: 196.628635 *****changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2 -n app-percona-ns -c pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-con curl http://\"10.63.245.237\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:01.966107", "end": "2019-03-07 20:03:46.829443", "rc": 0, "start": "2019-03-07 20:03:44.863336", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   769  100   769    0     0   135k      0 --:--:-- --:--:-- --:--:--  187k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100   769  100   769    0     0   135k      0 --:--:-- --:--:-- --:--:--  187k"], "stdout": "2", "stdout_lines": ["2"]}

TASK [Delete the pumba daemonset] **********************************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:124
2019-03-07T20:03:46.907855 (delta: 2.360257)         elapsed: 198.988979 ******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f /chaoslib/pumba/pumba_kube.yaml -n app-percona-ns", "delta": "0:00:01.969321", "end": "2019-03-07 20:03:49.150703", "rc": 0, "start": "2019-03-07 20:03:47.181382", "stderr": "", "stderr_lines": [], "stdout": "daemonset.extensions \"pumba\" deleted", "stdout_lines": ["daemonset.extensions \"pumba\" deleted"]}

TASK [Confirm that the pumba ds is deleted successfully] ***********************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:130
2019-03-07T20:03:49.218100 (delta: 2.310142)         elapsed: 201.299224 ******changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -l app=pumba --no-headers -n app-percona-ns", "delta": "0:00:01.926369", "end": "2019-03-07 20:03:51.452372", "rc": 0, "start": "2019-03-07 20:03:49.526003", "stderr": "", "stderr_lines": [], "stdout": "pumba-9r9bv   0/1   Terminating   0     2m\npumba-jzv2m   0/1   Terminating   0     2m", "stdout_lines": ["pumba-9r9bv   0/1   Terminating   0     2m", "pumba-jzv2m   0/1   Terminating   0     2m"]}

TASK [Verifying the replicas post network recovery] ****************************
task path: /chaoslib/openebs/jiva_replica_network_delay.yaml:140
2019-03-07T20:03:51.552556 (delta: 2.334368)         elapsed: 203.63368 ******* 
FAILED - RETRYING: Verifying the replicas post network recovery (10 retries left).[0changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl exec -it pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-676799f46-fz8j2 -n app-percona-ns -c pvc-bb880fa7-410a-11e9-bed3-42010a800042-ctrl-con curl http://\"10.63.245.237\":9501/v1/volumes | jq -r '.data[].replicaCount'", "delta": "0:00:01.833293", "end": "2019-03-07 20:04:11.058310", "rc": 0, "start": "2019-03-07 20:04:09.225017", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   769  100   769    0     0   259k      0 --:--:-- --:--:-- --:--:--  375k", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100   769  100   769    0     0   259k      0 --:--:-- --:--:-- --:--:--  375k"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Verify AUT liveness post fault-injection] ********************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:85
2019-03-07T20:04:11.117381 (delta: 19.564756)         elapsed: 223.198505 ***** 
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /common/utils/status_app_pod.yml:2
2019-03-07T20:04:11.191315 (delta: 0.07387)         elapsed: 223.272439 *******changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.869541", "end": "2019-03-07 20:04:13.234463", "rc": 0, "start": "2019-03-07 20:04:11.364922", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-03-07T18:58:07Z]]", "stdout_lines": ["map[running:map[startedAt:2019-03-07T18:58:07Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /common/utils/status_app_pod.yml:13
2019-03-07T20:04:13.301724 (delta: 2.110231)         elapsed: 225.382848 ******changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:01.982049", "end": "2019-03-07 20:04:15.649592", "rc": 0, "start": "2019-03-07 20:04:13.667543", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:94
2019-03-07T20:04:15.733229 (delta: 2.431278)         elapsed: 227.814353 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:97
2019-03-07T20:04:15.800546 (delta: 0.067169)         elapsed: 227.88167 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:109
2019-03-07T20:04:15.863509 (delta: 0.062541)         elapsed: 227.944633 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /percona/chaos/openebs_replica_network_delay/test.yml:120
2019-03-07T20:04:15.978879 (delta: 0.115304)         elapsed: 228.060003 ****** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-03-07T20:04:16.119292 (delta: 0.140331)         elapsed: 228.200416 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-03-07T20:04:16.203428 (delta: 0.084067)         elapsed: 228.284552 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-03-07T20:04:16.270912 (delta: 0.066268)         elapsed: 228.352036 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-03-07T20:04:16.353358 (delta: 0.082381)         elapsed: 228.434482 ******changed: [127.0.0.1] => {"changed": true, "checksum": "47915e31a46564f7297b4020a66371f050b5979d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0ecc5235fdbbc77eca4a60ab61ea7117", "mode": "0644", "owner": "root", "size": 462, "src": "/root/.ansible/tmp/ansible-tmp-1551989056.42-128643770727390/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-03-07T20:04:20.458386 (delta: 4.10467)         elapsed: 232.53951 ********changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.562660", "end": "2019-03-07 20:04:22.361951", "rc": 0, "start": "2019-03-07 20:04:20.799291", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebs-replica-network-delay \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: openebs/jiva_replica_network_delay \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebs-replica-network-delay ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: openebs/jiva_replica_network_delay ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-03-07T20:04:22.405519 (delta: 1.946978)         elapsed: 234.486643 ******changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.030671", "end": "2019-03-07 20:04:24.989492", "failed_when_result": false, "rc": 0, "start": "2019-03-07 20:04:22.958821", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebs-replica-network-delay configured", "stdout_lines": ["litmusresult.litmus.io/openebs-replica-network-delay configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP ********************************************************************127.0.0.1                  : ok=48  [0changed=32   unreachable=0    failed=0   

2019-03-07T20:04:25.034591 (delta: 2.629013)         elapsed: 237.115715 ****** 
=============================================================================== 
```