### PR TITLE
feat(litmus):Implementing snapshot creation litmus book.

### DIFF
--- a/experiments/functional/snapshot-creation/run_litmus_test.yml
+++ b/experiments/functional/snapshot-creation/run_litmus_test.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-snapshot-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: snapshot-litmus
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+            # Application pvc
+          - name: APP_PVC
+            value: openebs-busybox
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: app-busybox-ns 
+            
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/snapshot-creation/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+

--- a/experiments/functional/snapshot-creation/test.yml
+++ b/experiments/functional/snapshot-creation/test.yml
@@ -1,0 +1,106 @@
+---
+#Description: Creation of volume snapshot.
+#Author: Giri
+#
+########################################################################################
+#Steps:                                                                                #
+#1) Creating LitmusResult CR for updating test result.                                 #
+#2) Checking if the application is running in k8s cluster.                             #
+#3) Create snapshot using corresponding funclib utility.                               #
+#4) Verify snapshot creation in all the pool pods.                     
+#5) Update the LitmusResult CR.                                                       #
+########################################################################################
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+        ## Generating the testname for deployment
+        - include_tasks: /common/utils/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/common/utils/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Derive PV name from PVC
+          shell: >
+            kubectl get pvc {{ pvc_name }} -n {{ app_ns }}
+            --no-headers -o custom-columns=:spec.volumeName
+          args:
+            executable: /bin/bash
+          register: pv
+
+## Include an utility from litmus funclib to create snapshot.This creates snapshot and validates successful creation.
+       
+        - name: Creating snapshot.
+          include_tasks: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml
+
+        - name: Obtaining the storage class used from PVC
+          shell: kubectl get pvc {{ pvc_name }} -n {{ app_ns }} --no-headers -o custom-columns=:.spec.storageClassName
+          args:
+            executable: /bin/bash
+          register: app_sc
+
+        - name: Obtaining the SPC from storage class
+          shell: kubectl get sc {{ app_sc.stdout }} --no-headers  -o yaml | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/"//g'
+          args:
+            executable: /bin/bash
+          register: spc
+
+        - name: Obtaining the pool deployments from cvr
+          shell: >
+            kubectl get cvr -n {{ operator_ns }}
+            -l openebs.io/persistent-volume={{ pv.stdout }} --no-headers
+            -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\.openebs\.io\/name}{"\n"}{end}'
+          args:
+            executable: /bin/bash
+          register: pool_deployment
+
+        - name: Obtaining the replicasets corresponding to pool deployements.
+          shell: >
+            kubectl get rs --selector=app=cstor-pool -n {{ operator_ns }} --no-headers
+            -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item}}")].metadata.name}'
+          args:
+            executable: /bin/bash
+          register: rs_list
+          with_items:
+            - "{{ pool_deployment.stdout_lines }}"
+
+        - name: Obtaining the pool pods
+          shell: >
+            kubectl get pod --selector=app=cstor-pool -n {{ operator_ns }} --no-headers 
+            -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name=="{{item.stdout}}")].metadata.name}'
+          args:
+            executable: /bin/bash
+          register: pool_pods
+          with_items:
+            - "{{ rs_list.results }}"
+
+        - name: Checking if the snapshot is created in all the pool pods.
+          shell: kubectl exec -ti {{ item.stdout }} -n {{ operator_ns }} -- zfs list -t snapshot
+          args:
+            executable: /bin/bash
+          register: snap_list
+          failed_when: "snapshot_name not in snap_list.stdout"
+          with_items:
+            - "{{ pool_pods.results }}"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+

--- a/experiments/functional/snapshot-creation/test_vars.yml
+++ b/experiments/functional/snapshot-creation/test_vars.yml
@@ -1,0 +1,9 @@
+---
+test_name: create-snapshot
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+pvc_name: "{{ lookup('env','APP_PVC') }}"
+
+operator_ns: openebs
+

--- a/tools/ansible-runner/Dockerfile
+++ b/tools/ansible-runner/Dockerfile
@@ -34,3 +34,4 @@ COPY ./executor/ansible/plugins/callback/actionable.py /usr/local/lib/python2.7/
 COPY ./executor/ansible/plugins/callback/timestamp.py /usr/local/lib/python2.7/dist-packages/ansible/plugins/callback/
 COPY ./hack/litmus-result.j2 ./
 COPY ./common/utils ./common/utils/
+COPY experiments ./experiments


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Added a directory named experiment in which we can add functional and chaos litmusbooks.
- Implemented litmusbook which is capable of creating snapshot using pvc name as input.

```
PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/snapshot-creation/test.yml

PLAY [localhost] ***************************************************************
2019-03-20T10:02:22.227388 (delta: 0.061742)         elapsed: 0.061742 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/snapshot-creation/test.yml:14
2019-03-20T10:02:22.241479 (delta: 0.014039)         elapsed: 0.075833 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/snapshot-creation/test.yml:24
2019-03-20T10:02:31.867195 (delta: 9.625688)         elapsed: 9.701549 ******** 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /common/utils/create_testname.yml:3
2019-03-20T10:02:31.940099 (delta: 0.072855)         elapsed: 9.774453 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /common/utils/create_testname.yml:7
2019-03-20T10:02:32.004325 (delta: 0.06417)         elapsed: 9.838679 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/snapshot-creation/test.yml:27
2019-03-20T10:02:32.086098 (delta: 0.081723)         elapsed: 9.920452 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-03-20T10:02:32.261057 (delta: 0.174887)         elapsed: 10.095411 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "ae5e1fb24fe9758d6506364e5431f1b080beaace", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4c6f3ac54283a0ab817f286982e9560f", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1553076152.33-118092441042279/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-03-20T10:02:33.347050 (delta: 1.085902)         elapsed: 11.181404 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.951814", "end": "2019-03-20 10:02:34.777997", "rc": 0, "start": "2019-03-20 10:02:33.826183", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-snapshot \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-snapshot ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-03-20T10:02:34.833802 (delta: 1.486668)         elapsed: 12.668156 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.768195", "end": "2019-03-20 10:02:36.871576", "failed_when_result": false, "rc": 0, "start": "2019-03-20 10:02:35.103381", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-snapshot created", "stdout_lines": ["litmusresult.litmus.io/create-snapshot created"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-03-20T10:02:36.954723 (delta: 2.120844)         elapsed: 14.789077 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-03-20T10:02:37.032023 (delta: 0.077244)         elapsed: 14.866377 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-03-20T10:02:37.132736 (delta: 0.10058)         elapsed: 14.96709 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Derive PV name from PVC] *************************************************
task path: /experiments/functional/snapshot-creation/test.yml:31
2019-03-20T10:02:37.235013 (delta: 0.102135)         elapsed: 15.069367 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.253189", "end": "2019-03-20 10:02:38.894704", "rc": 0, "start": "2019-03-20 10:02:37.641515", "stderr": "", "stderr_lines": [], "stdout": "pvc-d9fff0d3-4ad6-11e9-9501-005056985c20", "stdout_lines": ["pvc-d9fff0d3-4ad6-11e9-9501-005056985c20"]}

TASK [Creating snapshot.] ******************************************************
task path: /experiments/functional/snapshot-creation/test.yml:41
2019-03-20T10:02:39.002271 (delta: 1.767155)         elapsed: 16.836625 ******* 
included: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml for 127.0.0.1

TASK [Generate unique string for use as snapname] ******************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:4
2019-03-20T10:02:39.164980 (delta: 0.162605)         elapsed: 16.999334 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat /dev/urandom | tr -cd 'a-z0-9' | head -c 8", "delta": "0:00:01.046611", "end": "2019-03-20 10:02:40.500258", "rc": 0, "start": "2019-03-20 10:02:39.453647", "stderr": "", "stderr_lines": [], "stdout": "kp8tgz2p", "stdout_lines": ["kp8tgz2p"]}

TASK [Form the snap name being rebuilt.] ***************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:10
2019-03-20T10:02:40.571726 (delta: 1.406688)         elapsed: 18.40608 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"snapshot_name": "kp8tgz2p"}, "changed": false}

TASK [Display details] *********************************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:14
2019-03-20T10:02:40.703202 (delta: 0.131398)         elapsed: 18.537556 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "app_ns: app-busybox-ns", 
        "pvc_name: openebs-busybox", 
        "snapshot_name: kp8tgz2p"
    ]
}

TASK [Update the snapshot template with the values provided.] ******************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:21
2019-03-20T10:02:40.880600 (delta: 0.177296)         elapsed: 18.714954 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "a9b96830c28cb0481c9fb641fbf06d30c0b3055e", "dest": "./snapshot.yml", "gid": 0, "group": "root", "md5sum": "ddf6f728bffef5081b869614eb331d8b", "mode": "0644", "owner": "root", "size": 182, "src": "/root/.ansible/tmp/ansible-tmp-1553076160.98-280071571517001/source", "state": "file", "uid": 0}

TASK [Creating the volume snapshot] ********************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:26
2019-03-20T10:02:41.464830 (delta: 0.584126)         elapsed: 19.299184 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl apply -f snapshot.yml", "delta": "0:00:02.545824", "end": "2019-03-20 10:02:44.322750", "rc": 0, "start": "2019-03-20 10:02:41.776926", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshot.volumesnapshot.external-storage.k8s.io/kp8tgz2p created", "stdout_lines": ["volumesnapshot.volumesnapshot.external-storage.k8s.io/kp8tgz2p created"]}

TASK [Obtaining the storage class used from PVC] *******************************
task path: /experiments/functional/snapshot-creation/test.yml:44
2019-03-20T10:02:44.456000 (delta: 2.991071)         elapsed: 22.290354 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:.spec.storageClassName", "delta": "0:00:01.153820", "end": "2019-03-20 10:02:46.027295", "rc": 0, "start": "2019-03-20 10:02:44.873475", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-sparse", "stdout_lines": ["openebs-cstor-sparse"]}

TASK [Obtaining the SPC from storage class] ************************************
task path: /experiments/functional/snapshot-creation/test.yml:50
2019-03-20T10:02:46.157574 (delta: 1.701472)         elapsed: 23.991928 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse --no-headers -o yaml | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/\"//g'", "delta": "0:00:01.327192", "end": "2019-03-20 10:02:47.754101", "rc": 0, "start": "2019-03-20 10:02:46.426909", "stderr": "", "stderr_lines": [], "stdout": " cstor-sparse-pool", "stdout_lines": [" cstor-sparse-pool"]}

TASK [Obtaining the pool deployments from cvr] *********************************
task path: /experiments/functional/snapshot-creation/test.yml:56
2019-03-20T10:02:47.860988 (delta: 1.703307)         elapsed: 25.695342 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-d9fff0d3-4ad6-11e9-9501-005056985c20 --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}'", "delta": "0:00:02.419756", "end": "2019-03-20 10:02:50.677710", "rc": 0, "start": "2019-03-20 10:02:48.257954", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy\ncstor-sparse-pool-h5ir\ncstor-sparse-pool-rej4", "stdout_lines": ["cstor-sparse-pool-6wsy", "cstor-sparse-pool-h5ir", "cstor-sparse-pool-rej4"]}

TASK [Obtaining the replicasets corresponding to pool deployements.] ***********
task path: /experiments/functional/snapshot-creation/test.yml:65
2019-03-20T10:02:50.731135 (delta: 2.870042)         elapsed: 28.565489 ******* 
changed: [127.0.0.1] => (item=cstor-sparse-pool-6wsy) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy\")].metadata.name}'", "delta": "0:00:01.102053", "end": "2019-03-20 10:02:52.033528", "item": "cstor-sparse-pool-6wsy", "rc": 0, "start": "2019-03-20 10:02:50.931475", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy-77b7899f94", "stdout_lines": ["cstor-sparse-pool-6wsy-77b7899f94"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-h5ir) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir\")].metadata.name}'", "delta": "0:00:01.355130", "end": "2019-03-20 10:02:53.669334", "item": "cstor-sparse-pool-h5ir", "rc": 0, "start": "2019-03-20 10:02:52.314204", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-h5ir-78cc8b7b88", "stdout_lines": ["cstor-sparse-pool-h5ir-78cc8b7b88"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-rej4) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4\")].metadata.name}'", "delta": "0:00:01.435623", "end": "2019-03-20 10:02:55.440120", "item": "cstor-sparse-pool-rej4", "rc": 0, "start": "2019-03-20 10:02:54.004497", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-rej4-589f59db9", "stdout_lines": ["cstor-sparse-pool-rej4-589f59db9"]}

TASK [Obtaining the pool pods] *************************************************
task path: /experiments/functional/snapshot-creation/test.yml:75
2019-03-20T10:02:55.539648 (delta: 4.808458)         elapsed: 33.374002 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-6wsy-77b7899f94', '_ansible_item_result': True, u'delta': u'0:00:01.102053', 'stdout_lines': [u'cstor-sparse-pool-6wsy-77b7899f94'], '_ansible_item_label': u'cstor-sparse-pool-6wsy', u'end': u'2019-03-20 10:02:52.033528', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', 'item': u'cstor-sparse-pool-6wsy', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-20 10:02:50.931475', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy-77b7899f94\")].metadata.name}'", "delta": "0:00:01.309582", "end": "2019-03-20 10:02:57.239063", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy\")].metadata.name}'", "delta": "0:00:01.102053", "end": "2019-03-20 10:02:52.033528", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-6wsy", "rc": 0, "start": "2019-03-20 10:02:50.931475", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy-77b7899f94", "stdout_lines": ["cstor-sparse-pool-6wsy-77b7899f94"]}, "rc": 0, "start": "2019-03-20 10:02:55.929481", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy-77b7899f94-hn27k", "stdout_lines": ["cstor-sparse-pool-6wsy-77b7899f94-hn27k"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-h5ir-78cc8b7b88', '_ansible_item_result': True, u'delta': u'0:00:01.355130', 'stdout_lines': [u'cstor-sparse-pool-h5ir-78cc8b7b88'], '_ansible_item_label': u'cstor-sparse-pool-h5ir', u'end': u'2019-03-20 10:02:53.669334', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', 'item': u'cstor-sparse-pool-h5ir', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-20 10:02:52.314204', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir-78cc8b7b88\")].metadata.name}'", "delta": "0:00:01.068401", "end": "2019-03-20 10:02:58.501844", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir\")].metadata.name}'", "delta": "0:00:01.355130", "end": "2019-03-20 10:02:53.669334", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-h5ir", "rc": 0, "start": "2019-03-20 10:02:52.314204", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-h5ir-78cc8b7b88", "stdout_lines": ["cstor-sparse-pool-h5ir-78cc8b7b88"]}, "rc": 0, "start": "2019-03-20 10:02:57.433443", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-h5ir-78cc8b7b88-x6zth", "stdout_lines": ["cstor-sparse-pool-h5ir-78cc8b7b88-x6zth"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-rej4-589f59db9', '_ansible_item_result': True, u'delta': u'0:00:01.435623', 'stdout_lines': [u'cstor-sparse-pool-rej4-589f59db9'], '_ansible_item_label': u'cstor-sparse-pool-rej4', u'end': u'2019-03-20 10:02:55.440120', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', 'item': u'cstor-sparse-pool-rej4', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-20 10:02:54.004497', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4-589f59db9\")].metadata.name}'", "delta": "0:00:01.253809", "end": "2019-03-20 10:02:59.917914", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4\")].metadata.name}'", "delta": "0:00:01.435623", "end": "2019-03-20 10:02:55.440120", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-rej4", "rc": 0, "start": "2019-03-20 10:02:54.004497", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-rej4-589f59db9", "stdout_lines": ["cstor-sparse-pool-rej4-589f59db9"]}, "rc": 0, "start": "2019-03-20 10:02:58.664105", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-rej4-589f59db9-tz2tz", "stdout_lines": ["cstor-sparse-pool-rej4-589f59db9-tz2tz"]}

TASK [Checking if the snapshot is created in all the pool pods.] ***************
task path: /experiments/functional/snapshot-creation/test.yml:85
2019-03-20T10:02:59.977599 (delta: 4.437847)         elapsed: 37.811953 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-6wsy-77b7899f94-hn27k', '_ansible_item_result': True, u'delta': u'0:00:01.309582', 'stdout_lines': [u'cstor-sparse-pool-6wsy-77b7899f94-hn27k'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-6wsy-77b7899f94', '_ansible_item_result': True, u'delta': u'0:00:01.102053', 'stdout_lines': [u'cstor-sparse-pool-6wsy-77b7899f94'], '_ansible_item_label': u'cstor-sparse-pool-6wsy', u'end': u'2019-03-20 10:02:52.033528', '_ansible_no_log': False, u'start': u'2019-03-20 10:02:50.931475', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-6wsy', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-03-20 10:02:57.239063', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy-77b7899f94")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-6wsy-77b7899f94', '_ansible_item_result': True, u'delta': u'0:00:01.102053', 'stdout_lines': [u'cstor-sparse-pool-6wsy-77b7899f94'], '_ansible_item_label': u'cstor-sparse-pool-6wsy', u'end': u'2019-03-20 10:02:52.033528', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', u'start': u'2019-03-20 10:02:50.931475', 'item': u'cstor-sparse-pool-6wsy', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy-77b7899f94")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-20 10:02:55.929481', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-sparse-pool-6wsy-77b7899f94-hn27k -n openebs -- zfs list -t snapshot", "delta": "0:00:01.375417", "end": "2019-03-20 10:03:01.549043", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy-77b7899f94\")].metadata.name}'", "delta": "0:00:01.309582", "end": "2019-03-20 10:02:57.239063", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy-77b7899f94\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy\")].metadata.name}'", "delta": "0:00:01.102053", "end": "2019-03-20 10:02:52.033528", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-6wsy", "rc": 0, "start": "2019-03-20 10:02:50.931475", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy-77b7899f94", "stdout_lines": ["cstor-sparse-pool-6wsy-77b7899f94"]}, "rc": 0, "start": "2019-03-20 10:02:55.929481", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy-77b7899f94-hn27k", "stdout_lines": ["cstor-sparse-pool-6wsy-77b7899f94-hn27k"]}, "rc": 0, "start": "2019-03-20 10:03:00.173626", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-6wsy-77b7899f94-hn27k -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-6wsy-77b7899f94-hn27k -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                        USED  AVAIL  REFER  MOUNTPOINT\ncstor-c16d516b-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941     0B      -   434M  -", "stdout_lines": ["NAME                                                                                                                                                        USED  AVAIL  REFER  MOUNTPOINT", "cstor-c16d516b-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941     0B      -   434M  -"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-h5ir-78cc8b7b88-x6zth', '_ansible_item_result': True, u'delta': u'0:00:01.068401', 'stdout_lines': [u'cstor-sparse-pool-h5ir-78cc8b7b88-x6zth'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-h5ir-78cc8b7b88', '_ansible_item_result': True, u'delta': u'0:00:01.355130', 'stdout_lines': [u'cstor-sparse-pool-h5ir-78cc8b7b88'], '_ansible_item_label': u'cstor-sparse-pool-h5ir', u'end': u'2019-03-20 10:02:53.669334', '_ansible_no_log': False, u'start': u'2019-03-20 10:02:52.314204', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-h5ir', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-03-20 10:02:58.501844', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir-78cc8b7b88")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-h5ir-78cc8b7b88', '_ansible_item_result': True, u'delta': u'0:00:01.355130', 'stdout_lines': [u'cstor-sparse-pool-h5ir-78cc8b7b88'], '_ansible_item_label': u'cstor-sparse-pool-h5ir', u'end': u'2019-03-20 10:02:53.669334', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', u'start': u'2019-03-20 10:02:52.314204', 'item': u'cstor-sparse-pool-h5ir', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir-78cc8b7b88")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-20 10:02:57.433443', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-sparse-pool-h5ir-78cc8b7b88-x6zth -n openebs -- zfs list -t snapshot", "delta": "0:00:02.491975", "end": "2019-03-20 10:03:04.216908", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir-78cc8b7b88\")].metadata.name}'", "delta": "0:00:01.068401", "end": "2019-03-20 10:02:58.501844", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir-78cc8b7b88\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir\")].metadata.name}'", "delta": "0:00:01.355130", "end": "2019-03-20 10:02:53.669334", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-h5ir", "rc": 0, "start": "2019-03-20 10:02:52.314204", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-h5ir-78cc8b7b88", "stdout_lines": ["cstor-sparse-pool-h5ir-78cc8b7b88"]}, "rc": 0, "start": "2019-03-20 10:02:57.433443", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-h5ir-78cc8b7b88-x6zth", "stdout_lines": ["cstor-sparse-pool-h5ir-78cc8b7b88-x6zth"]}, "rc": 0, "start": "2019-03-20 10:03:01.724933", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-h5ir-78cc8b7b88-x6zth -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-h5ir-78cc8b7b88-x6zth -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                        USED  AVAIL  REFER  MOUNTPOINT\ncstor-c195da7d-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941     0B      -   434M  -", "stdout_lines": ["NAME                                                                                                                                                        USED  AVAIL  REFER  MOUNTPOINT", "cstor-c195da7d-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941     0B      -   434M  -"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-rej4-589f59db9-tz2tz', '_ansible_item_result': True, u'delta': u'0:00:01.253809', 'stdout_lines': [u'cstor-sparse-pool-rej4-589f59db9-tz2tz'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-rej4-589f59db9', '_ansible_item_result': True, u'delta': u'0:00:01.435623', 'stdout_lines': [u'cstor-sparse-pool-rej4-589f59db9'], '_ansible_item_label': u'cstor-sparse-pool-rej4', u'end': u'2019-03-20 10:02:55.440120', '_ansible_no_log': False, u'start': u'2019-03-20 10:02:54.004497', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-rej4', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-03-20 10:02:59.917914', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4-589f59db9")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-rej4-589f59db9', '_ansible_item_result': True, u'delta': u'0:00:01.435623', 'stdout_lines': [u'cstor-sparse-pool-rej4-589f59db9'], '_ansible_item_label': u'cstor-sparse-pool-rej4', u'end': u'2019-03-20 10:02:55.440120', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', u'start': u'2019-03-20 10:02:54.004497', 'item': u'cstor-sparse-pool-rej4', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4-589f59db9")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-20 10:02:58.664105', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-sparse-pool-rej4-589f59db9-tz2tz -n openebs -- zfs list -t snapshot", "delta": "0:00:01.505147", "end": "2019-03-20 10:03:06.054882", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4-589f59db9\")].metadata.name}'", "delta": "0:00:01.253809", "end": "2019-03-20 10:02:59.917914", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4-589f59db9\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4\")].metadata.name}'", "delta": "0:00:01.435623", "end": "2019-03-20 10:02:55.440120", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-rej4", "rc": 0, "start": "2019-03-20 10:02:54.004497", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-rej4-589f59db9", "stdout_lines": ["cstor-sparse-pool-rej4-589f59db9"]}, "rc": 0, "start": "2019-03-20 10:02:58.664105", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-rej4-589f59db9-tz2tz", "stdout_lines": ["cstor-sparse-pool-rej4-589f59db9-tz2tz"]}, "rc": 0, "start": "2019-03-20 10:03:04.549735", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-rej4-589f59db9-tz2tz -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-rej4-589f59db9-tz2tz -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                        USED  AVAIL  REFER  MOUNTPOINT\ncstor-c1aa54cc-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941     0B      -   434M  -", "stdout_lines": ["NAME                                                                                                                                                        USED  AVAIL  REFER  MOUNTPOINT", "cstor-c1aa54cc-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941     0B      -   434M  -"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/snapshot-creation/test.yml:94
2019-03-20T10:03:06.202657 (delta: 6.224988)         elapsed: 44.037011 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/snapshot-creation/test.yml:103
2019-03-20T10:03:06.368153 (delta: 0.165391)         elapsed: 44.202507 ******* 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-03-20T10:03:06.545977 (delta: 0.17772)         elapsed: 44.380331 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-03-20T10:03:06.606036 (delta: 0.059995)         elapsed: 44.44039 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-03-20T10:03:06.670046 (delta: 0.063923)         elapsed: 44.5044 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-03-20T10:03:06.756372 (delta: 0.086232)         elapsed: 44.590726 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "0729a880f30ed49523377585f88c84785297782d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "75581027b99e9de1e903ec50005f5822", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1553076186.87-265231293128378/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-03-20T10:03:09.580845 (delta: 2.824388)         elapsed: 47.415199 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.962921", "end": "2019-03-20 10:03:10.825300", "rc": 0, "start": "2019-03-20 10:03:09.862379", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-snapshot \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-snapshot ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-03-20T10:03:10.879743 (delta: 1.29879)         elapsed: 48.714097 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.490530", "end": "2019-03-20 10:03:13.663872", "failed_when_result": false, "rc": 0, "start": "2019-03-20 10:03:11.173342", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-snapshot configured", "stdout_lines": ["litmusresult.litmus.io/create-snapshot configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=24   changed=16   unreachable=0    failed=0   

2019-03-20T10:03:13.741618 (delta: 2.861819)         elapsed: 51.575972 ******* 
=============================================================================== 
```