### PR TITLE
Add a litmusbook for busybox-liveness

### DIFF
--- a/apps/busybox/liveness/run_litmus_test.yml
+++ b/apps/busybox/liveness/run_litmus_test.yml
@@ -1,0 +1,61 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: busybox-liveness-
+  namespace: litmus
+spec:
+  activeDeadlineSeconds: 5400
+  template:
+    metadata:
+      name: busybox-liveness
+      namespace: litmus
+      labels:
+        liveness: busybox-liveness
+
+        # label used for mass-liveness check upon infra-chaos
+        infra-aid: liveness
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+ 
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+        env: 
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./busybox/liveness/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+      - name: busybox-liveness  
+        image: ranjnshashank855/busybox-liveness-client
+        imagePullPolicy: Always
+
+        env:
+
+           
+          - name: LIVENESS_TIMEOUT_SECONDS
+            value: "10"
+
+          # number of retries when livenss-fails 
+          - name: LIVENESS_RETRY_COUNT
+            value: "5"
+
+            # Namespace in which busybox is running
+          - name: NAMESPACE
+            value: app-busybox-ns 
+
+          - name: POD_NAME
+            value: busybox-0 
+
+        command: ["/bin/bash"]
+        args: ["-c", "./liveness.sh; exit 0"]

--- a/apps/busybox/liveness/test.yml
+++ b/apps/busybox/liveness/test.yml
@@ -1,0 +1,65 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - vars.yml
+
+  tasks:
+    - block:
+        - block:
+
+            - name: Record test instance/run ID
+              set_fact:
+                run_id: "{{ lookup('env','RUN_ID') }}"
+
+            - name: Construct testname appended with runID
+              set_fact:
+                test_name: "{{ test_name }}-{{ run_id }}"
+
+          when: lookup('env','RUN_ID')
+        
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
+        - name: Checking whether liveness container is running
+          shell: >
+            kubectl get pod {{ test_pod }} -n litmus 
+            -o jsonpath='{.status.containerStatuses[?(@.name=="busybox-liveness")].state}'
+          register: container_status
+          until: "'running' in container_status.stdout"
+          delay: 60
+          retries: 10
+
+        - name: Verifying whether liveness check is started successfully  
+          shell: kubectl logs {{ test_pod }} -n litmus -c busybox-liveness 
+          register: output
+          until: "liveness_log in output.stdout"
+          delay: 60 
+          retries: 20
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+        
+        ## if flag=fail, task exits immediately; if flag=pass, runs indefinitely until liveness check ends.
+        - name: Run until liveness container is terminated
+          shell: |
+            cmd="kubectl get pod {{ test_pod }} -n litmus -o jsonpath='{.status.containerStatuses[?(@.name==\"busybox-liveness\")].state}'"
+            while true; do state=$(eval $cmd); rc=$?; if [[ $rc -eq 0 && ! $state =~ 'terminated' ]]; then sleep 1; else exit; fi; done
+          args:
+            executable: /bin/bash
+          register: output
+          when: flag == "Pass"

--- a/apps/busybox/liveness/vars.yml
+++ b/apps/busybox/liveness/vars.yml
@@ -1,0 +1,3 @@
+test_name: busybox-liveness
+test_pod: "{{ lookup('env','MY_POD_NAME') }}"
+liveness_log: "liveness-running"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a litmusbook for busybox liveness.
- LitmusBook takes **LIVENESS_TIMEOUT**, **POD_NAME**, **LIVENESS_RETRY_COUNT** as environment variable.
- It performs **CRUD** operation on busybox using **dd-command** and for each successful iteration of CRUD-operation it sets liveness status as running. 

**Special notes for your reviewer**:
- The liveness client for busybox is part of PR in `openebs/test-tools`(link: https://github.com/openebs/test-tools/pull/82)

**Following is the log of the liveness-container**:
```
10240+0 records in
10240+0 records out
41943040 bytes (40.0MB) copied, 0.431196 seconds, 92.8MB/s
liveness-running
Unable to use a TTY - input is not a terminal or the right kind of file
10240+0 records in
10240+0 records out
41943040 bytes (40.0MB) copied, 0.395782 seconds, 101.1MB/s
liveness-running
Unable to use a TTY - input is not a terminal or the right kind of file
10240+0 records in
10240+0 records out
41943040 bytes (40.0MB) copied, 0.394063 seconds, 101.5MB/s
liveness-running
Unable to use a TTY - input is not a terminal or the right kind of file
10240+0 records in
10240+0 records out
41943040 bytes (40.0MB) copied, 0.545244 seconds, 73.4MB/s
liveness-running
```
