### PR TITLE
Passing snapshot name as env in snapshot creation litmusbook

### DIFF
--- a/experiments/functional/snapshot-creation/run_litmus_test.yml
+++ b/experiments/functional/snapshot-creation/run_litmus_test.yml
@@ -30,7 +30,11 @@ spec:
             # Application namespace
           - name: APP_NAMESPACE
             value: app-busybox-ns 
-            
+           
+            # Name of snapshot
+          - name: snapshot
+            value: snapshot-busybox
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/snapshot-creation/test.yml -i /etc/ansible/hosts -vv; exit 0"]
 

--- a/experiments/functional/snapshot-creation/test_vars.yml
+++ b/experiments/functional/snapshot-creation/test_vars.yml
@@ -7,3 +7,4 @@ pvc_name: "{{ lookup('env','APP_PVC') }}"
 
 operator_ns: openebs
 
+snapshot_name: "{{ lookup('env','snapshot') }}"

--- a/funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml
+++ b/funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml
@@ -1,15 +1,15 @@
 ---
 # This utility creates snapshot using K8s external storage API.
 #
-- name: Generate unique string for use as snapname
-  shell: cat /dev/urandom | tr -cd 'a-z0-9' | head -c 8
-  args:
-    executable: /bin/bash
-  register: snap_name
+#- name: Generate unique string for use as snapname
+#  shell: cat /dev/urandom | tr -cd 'a-z0-9' | head -c 8
+#  args:
+#    executable: /bin/bash
+#  register: snap_name
 
-- name: Form the snap name being rebuilt.
-  set_fact:
-    snapshot_name: "{{snap_name.stdout }}"
+#- name: Form the snap name being rebuilt.
+#  set_fact:
+#    snapshot_name: "{{snap_name.stdout }}"
 
 - name: Display details
   debug:


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- Rather than generating random name for snapshot, passing it as an environmental variable.

```

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/snapshot-creation/test.yml

PLAY [localhost] ***************************************************************
2019-03-21T08:08:07.475116 (delta: 0.061173)         elapsed: 0.061173 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/snapshot-creation/test.yml:14
2019-03-21T08:08:07.490201 (delta: 0.015033)         elapsed: 0.076258 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/snapshot-creation/test.yml:24
2019-03-21T08:08:16.327093 (delta: 8.83686)         elapsed: 8.91315 ********** 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /common/utils/create_testname.yml:3
2019-03-21T08:08:16.423995 (delta: 0.096847)         elapsed: 9.010052 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /common/utils/create_testname.yml:7
2019-03-21T08:08:16.510858 (delta: 0.086793)         elapsed: 9.096915 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/snapshot-creation/test.yml:27
2019-03-21T08:08:16.617811 (delta: 0.106877)         elapsed: 9.203868 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-03-21T08:08:16.824757 (delta: 0.206839)         elapsed: 9.410814 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "ae5e1fb24fe9758d6506364e5431f1b080beaace", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "4c6f3ac54283a0ab817f286982e9560f", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1553155696.88-26868757291481/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-03-21T08:08:17.663730 (delta: 0.838909)         elapsed: 10.249787 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.981805", "end": "2019-03-21 08:08:19.009699", "rc": 0, "start": "2019-03-21 08:08:18.027894", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-snapshot \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-snapshot ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-03-21T08:08:19.067314 (delta: 1.403522)         elapsed: 11.653371 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.794569", "end": "2019-03-21 08:08:21.199430", "failed_when_result": false, "rc": 0, "start": "2019-03-21 08:08:19.404861", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-snapshot configured", "stdout_lines": ["litmusresult.litmus.io/create-snapshot configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-03-21T08:08:21.302574 (delta: 2.235204)         elapsed: 13.888631 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-03-21T08:08:21.404713 (delta: 0.10204)         elapsed: 13.99077 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-03-21T08:08:21.535813 (delta: 0.130997)         elapsed: 14.12187 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Derive PV name from PVC] *************************************************
task path: /experiments/functional/snapshot-creation/test.yml:31
2019-03-21T08:08:21.645376 (delta: 0.109458)         elapsed: 14.231433 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.280489", "end": "2019-03-21 08:08:23.303757", "rc": 0, "start": "2019-03-21 08:08:22.023268", "stderr": "", "stderr_lines": [], "stdout": "pvc-d9fff0d3-4ad6-11e9-9501-005056985c20", "stdout_lines": ["pvc-d9fff0d3-4ad6-11e9-9501-005056985c20"]}

TASK [Creating snapshot.] ******************************************************
task path: /experiments/functional/snapshot-creation/test.yml:41
2019-03-21T08:08:23.406246 (delta: 1.760754)         elapsed: 15.992303 ******* 
included: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml for 127.0.0.1

TASK [Display details] *********************************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:14
2019-03-21T08:08:23.592143 (delta: 0.185767)         elapsed: 16.1782 ********* 
ok: [127.0.0.1] => {
    "msg": [
        "app_ns: app-busybox-ns", 
        "pvc_name: openebs-busybox", 
        "snapshot_name: snapshot-busybox"
    ]
}

TASK [Update the snapshot template with the values provided.] ******************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:21
2019-03-21T08:08:23.777419 (delta: 0.185176)         elapsed: 16.363476 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "cda7cffd8a1a31b4ca484f3ccab133ddda6deb33", "dest": "./snapshot.yml", "gid": 0, "group": "root", "md5sum": "c3be2cd40b743ee00a4ec5ee718a294a", "mode": "0644", "owner": "root", "size": 190, "src": "/root/.ansible/tmp/ansible-tmp-1553155703.88-228884635625474/source", "state": "file", "uid": 0}

TASK [Creating the volume snapshot] ********************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:26
2019-03-21T08:08:24.297487 (delta: 0.519969)         elapsed: 16.883544 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl apply -f snapshot.yml", "delta": "0:00:01.424138", "end": "2019-03-21 08:08:25.931197", "rc": 0, "start": "2019-03-21 08:08:24.507059", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshot.volumesnapshot.external-storage.k8s.io/snapshot-busybox created", "stdout_lines": ["volumesnapshot.volumesnapshot.external-storage.k8s.io/snapshot-busybox created"]}

TASK [Obtaining the storage class used from PVC] *******************************
task path: /experiments/functional/snapshot-creation/test.yml:44
2019-03-21T08:08:25.998695 (delta: 1.701151)         elapsed: 18.584752 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:.spec.storageClassName", "delta": "0:00:02.146553", "end": "2019-03-21 08:08:28.463485", "rc": 0, "start": "2019-03-21 08:08:26.316932", "stderr": "", "stderr_lines": [], "stdout": "openebs-cstor-sparse", "stdout_lines": ["openebs-cstor-sparse"]}

TASK [Obtaining the SPC from storage class] ************************************
task path: /experiments/functional/snapshot-creation/test.yml:50
2019-03-21T08:08:28.573322 (delta: 2.574568)         elapsed: 21.159379 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse --no-headers -o yaml | awk '/StoragePoolClaim/{getline; print}' | cut -d ':' -f2 | sed 's/\"//g'", "delta": "0:00:01.161912", "end": "2019-03-21 08:08:30.087901", "rc": 0, "start": "2019-03-21 08:08:28.925989", "stderr": "", "stderr_lines": [], "stdout": " cstor-sparse-pool", "stdout_lines": [" cstor-sparse-pool"]}

TASK [Obtaining the pool deployments from cvr] *********************************
task path: /experiments/functional/snapshot-creation/test.yml:56
2019-03-21T08:08:30.150387 (delta: 1.576921)         elapsed: 22.736444 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-d9fff0d3-4ad6-11e9-9501-005056985c20 --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}'", "delta": "0:00:01.124099", "end": "2019-03-21 08:08:31.547593", "rc": 0, "start": "2019-03-21 08:08:30.423494", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy\ncstor-sparse-pool-h5ir\ncstor-sparse-pool-rej4", "stdout_lines": ["cstor-sparse-pool-6wsy", "cstor-sparse-pool-h5ir", "cstor-sparse-pool-rej4"]}

TASK [Obtaining the replicasets corresponding to pool deployements.] ***********
task path: /experiments/functional/snapshot-creation/test.yml:65
2019-03-21T08:08:31.633066 (delta: 1.482609)         elapsed: 24.219123 ******* 
changed: [127.0.0.1] => (item=cstor-sparse-pool-6wsy) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy\")].metadata.name}'", "delta": "0:00:01.278276", "end": "2019-03-21 08:08:33.309861", "item": "cstor-sparse-pool-6wsy", "rc": 0, "start": "2019-03-21 08:08:32.031585", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy-77b7899f94", "stdout_lines": ["cstor-sparse-pool-6wsy-77b7899f94"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-h5ir) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir\")].metadata.name}'", "delta": "0:00:01.291673", "end": "2019-03-21 08:08:34.942246", "item": "cstor-sparse-pool-h5ir", "rc": 0, "start": "2019-03-21 08:08:33.650573", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-h5ir-78cc8b7b88", "stdout_lines": ["cstor-sparse-pool-h5ir-78cc8b7b88"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-rej4) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4\")].metadata.name}'", "delta": "0:00:01.303994", "end": "2019-03-21 08:08:36.572220", "item": "cstor-sparse-pool-rej4", "rc": 0, "start": "2019-03-21 08:08:35.268226", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-rej4-589f59db9", "stdout_lines": ["cstor-sparse-pool-rej4-589f59db9"]}

TASK [Obtaining the pool pods] *************************************************
task path: /experiments/functional/snapshot-creation/test.yml:75
2019-03-21T08:08:36.667794 (delta: 5.034641)         elapsed: 29.253851 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-6wsy-77b7899f94', '_ansible_item_result': True, u'delta': u'0:00:01.278276', 'stdout_lines': [u'cstor-sparse-pool-6wsy-77b7899f94'], '_ansible_item_label': u'cstor-sparse-pool-6wsy', u'end': u'2019-03-21 08:08:33.309861', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', 'item': u'cstor-sparse-pool-6wsy', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-21 08:08:32.031585', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy-77b7899f94\")].metadata.name}'", "delta": "0:00:01.345249", "end": "2019-03-21 08:08:38.281202", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy\")].metadata.name}'", "delta": "0:00:01.278276", "end": "2019-03-21 08:08:33.309861", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-6wsy", "rc": 0, "start": "2019-03-21 08:08:32.031585", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy-77b7899f94", "stdout_lines": ["cstor-sparse-pool-6wsy-77b7899f94"]}, "rc": 0, "start": "2019-03-21 08:08:36.935953", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy-77b7899f94-hn27k", "stdout_lines": ["cstor-sparse-pool-6wsy-77b7899f94-hn27k"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-h5ir-78cc8b7b88', '_ansible_item_result': True, u'delta': u'0:00:01.291673', 'stdout_lines': [u'cstor-sparse-pool-h5ir-78cc8b7b88'], '_ansible_item_label': u'cstor-sparse-pool-h5ir', u'end': u'2019-03-21 08:08:34.942246', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', 'item': u'cstor-sparse-pool-h5ir', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-21 08:08:33.650573', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir-78cc8b7b88\")].metadata.name}'", "delta": "0:00:01.233563", "end": "2019-03-21 08:08:39.870257", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir\")].metadata.name}'", "delta": "0:00:01.291673", "end": "2019-03-21 08:08:34.942246", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-h5ir", "rc": 0, "start": "2019-03-21 08:08:33.650573", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-h5ir-78cc8b7b88", "stdout_lines": ["cstor-sparse-pool-h5ir-78cc8b7b88"]}, "rc": 0, "start": "2019-03-21 08:08:38.636694", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-h5ir-78cc8b7b88-x6zth", "stdout_lines": ["cstor-sparse-pool-h5ir-78cc8b7b88-x6zth"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-rej4-589f59db9', '_ansible_item_result': True, u'delta': u'0:00:01.303994', 'stdout_lines': [u'cstor-sparse-pool-rej4-589f59db9'], '_ansible_item_label': u'cstor-sparse-pool-rej4', u'end': u'2019-03-21 08:08:36.572220', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', 'item': u'cstor-sparse-pool-rej4', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-21 08:08:35.268226', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4-589f59db9\")].metadata.name}'", "delta": "0:00:01.298562", "end": "2019-03-21 08:08:41.481733", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4\")].metadata.name}'", "delta": "0:00:01.303994", "end": "2019-03-21 08:08:36.572220", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-rej4", "rc": 0, "start": "2019-03-21 08:08:35.268226", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-rej4-589f59db9", "stdout_lines": ["cstor-sparse-pool-rej4-589f59db9"]}, "rc": 0, "start": "2019-03-21 08:08:40.183171", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-rej4-589f59db9-tz2tz", "stdout_lines": ["cstor-sparse-pool-rej4-589f59db9-tz2tz"]}

TASK [Checking if the snapshot is created in all the pool pods.] ***************
task path: /experiments/functional/snapshot-creation/test.yml:85
2019-03-21T08:08:41.602021 (delta: 4.934142)         elapsed: 34.188078 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-6wsy-77b7899f94-hn27k', '_ansible_item_result': True, u'delta': u'0:00:01.345249', 'stdout_lines': [u'cstor-sparse-pool-6wsy-77b7899f94-hn27k'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-6wsy-77b7899f94', '_ansible_item_result': True, u'delta': u'0:00:01.278276', 'stdout_lines': [u'cstor-sparse-pool-6wsy-77b7899f94'], '_ansible_item_label': u'cstor-sparse-pool-6wsy', u'end': u'2019-03-21 08:08:33.309861', '_ansible_no_log': False, u'start': u'2019-03-21 08:08:32.031585', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-6wsy', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-03-21 08:08:38.281202', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy-77b7899f94")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-6wsy-77b7899f94', '_ansible_item_result': True, u'delta': u'0:00:01.278276', 'stdout_lines': [u'cstor-sparse-pool-6wsy-77b7899f94'], '_ansible_item_label': u'cstor-sparse-pool-6wsy', u'end': u'2019-03-21 08:08:33.309861', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', u'start': u'2019-03-21 08:08:32.031585', 'item': u'cstor-sparse-pool-6wsy', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-6wsy-77b7899f94")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-21 08:08:36.935953', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-sparse-pool-6wsy-77b7899f94-hn27k -n openebs -- zfs list -t snapshot", "delta": "0:00:01.554957", "end": "2019-03-21 08:08:43.457744", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy-77b7899f94\")].metadata.name}'", "delta": "0:00:01.345249", "end": "2019-03-21 08:08:38.281202", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy-77b7899f94\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy\")].metadata.name}'", "delta": "0:00:01.278276", "end": "2019-03-21 08:08:33.309861", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-6wsy\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-6wsy", "rc": 0, "start": "2019-03-21 08:08:32.031585", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy-77b7899f94", "stdout_lines": ["cstor-sparse-pool-6wsy-77b7899f94"]}, "rc": 0, "start": "2019-03-21 08:08:36.935953", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-6wsy-77b7899f94-hn27k", "stdout_lines": ["cstor-sparse-pool-6wsy-77b7899f94-hn27k"]}, "rc": 0, "start": "2019-03-21 08:08:41.902787", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-6wsy-77b7899f94-hn27k -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-6wsy-77b7899f94-hn27k -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT\ncstor-c16d516b-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941          6.50K      -   434M  -\ncstor-c16d516b-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_q9r2xgj0_1553149929555408967          6.50K      -   434M  -\ncstor-c16d516b-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_snapshot-busybox_1553155706014720524     0B      -   434M  -", "stdout_lines": ["NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT", "cstor-c16d516b-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941          6.50K      -   434M  -", "cstor-c16d516b-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_q9r2xgj0_1553149929555408967          6.50K      -   434M  -", "cstor-c16d516b-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_snapshot-busybox_1553155706014720524     0B      -   434M  -"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-h5ir-78cc8b7b88-x6zth', '_ansible_item_result': True, u'delta': u'0:00:01.233563', 'stdout_lines': [u'cstor-sparse-pool-h5ir-78cc8b7b88-x6zth'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-h5ir-78cc8b7b88', '_ansible_item_result': True, u'delta': u'0:00:01.291673', 'stdout_lines': [u'cstor-sparse-pool-h5ir-78cc8b7b88'], '_ansible_item_label': u'cstor-sparse-pool-h5ir', u'end': u'2019-03-21 08:08:34.942246', '_ansible_no_log': False, u'start': u'2019-03-21 08:08:33.650573', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-h5ir', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-03-21 08:08:39.870257', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir-78cc8b7b88")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-h5ir-78cc8b7b88', '_ansible_item_result': True, u'delta': u'0:00:01.291673', 'stdout_lines': [u'cstor-sparse-pool-h5ir-78cc8b7b88'], '_ansible_item_label': u'cstor-sparse-pool-h5ir', u'end': u'2019-03-21 08:08:34.942246', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', u'start': u'2019-03-21 08:08:33.650573', 'item': u'cstor-sparse-pool-h5ir', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-h5ir-78cc8b7b88")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-21 08:08:38.636694', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-sparse-pool-h5ir-78cc8b7b88-x6zth -n openebs -- zfs list -t snapshot", "delta": "0:00:01.424347", "end": "2019-03-21 08:08:45.222536", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir-78cc8b7b88\")].metadata.name}'", "delta": "0:00:01.233563", "end": "2019-03-21 08:08:39.870257", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir-78cc8b7b88\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir\")].metadata.name}'", "delta": "0:00:01.291673", "end": "2019-03-21 08:08:34.942246", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-h5ir\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-h5ir", "rc": 0, "start": "2019-03-21 08:08:33.650573", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-h5ir-78cc8b7b88", "stdout_lines": ["cstor-sparse-pool-h5ir-78cc8b7b88"]}, "rc": 0, "start": "2019-03-21 08:08:38.636694", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-h5ir-78cc8b7b88-x6zth", "stdout_lines": ["cstor-sparse-pool-h5ir-78cc8b7b88-x6zth"]}, "rc": 0, "start": "2019-03-21 08:08:43.798189", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-h5ir-78cc8b7b88-x6zth -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-h5ir-78cc8b7b88-x6zth -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT\ncstor-c195da7d-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941          6.50K      -   434M  -\ncstor-c195da7d-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_q9r2xgj0_1553149929555408967          6.50K      -   434M  -\ncstor-c195da7d-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_snapshot-busybox_1553155706014720524     0B      -   434M  -", "stdout_lines": ["NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT", "cstor-c195da7d-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941          6.50K      -   434M  -", "cstor-c195da7d-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_q9r2xgj0_1553149929555408967          6.50K      -   434M  -", "cstor-c195da7d-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_snapshot-busybox_1553155706014720524     0B      -   434M  -"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-rej4-589f59db9-tz2tz', '_ansible_item_result': True, u'delta': u'0:00:01.298562', 'stdout_lines': [u'cstor-sparse-pool-rej4-589f59db9-tz2tz'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-rej4-589f59db9', '_ansible_item_result': True, u'delta': u'0:00:01.303994', 'stdout_lines': [u'cstor-sparse-pool-rej4-589f59db9'], '_ansible_item_label': u'cstor-sparse-pool-rej4', u'end': u'2019-03-21 08:08:36.572220', '_ansible_no_log': False, u'start': u'2019-03-21 08:08:35.268226', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-rej4', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-03-21 08:08:41.481733', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4-589f59db9")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-rej4-589f59db9', '_ansible_item_result': True, u'delta': u'0:00:01.303994', 'stdout_lines': [u'cstor-sparse-pool-rej4-589f59db9'], '_ansible_item_label': u'cstor-sparse-pool-rej4', u'end': u'2019-03-21 08:08:36.572220', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', u'start': u'2019-03-21 08:08:35.268226', 'item': u'cstor-sparse-pool-rej4', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': u'/bin/bash', u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-rej4-589f59db9")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-03-21 08:08:40.183171', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl exec -ti cstor-sparse-pool-rej4-589f59db9-tz2tz -n openebs -- zfs list -t snapshot", "delta": "0:00:01.685899", "end": "2019-03-21 08:08:47.236198", "failed_when_result": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4-589f59db9\")].metadata.name}'", "delta": "0:00:01.298562", "end": "2019-03-21 08:08:41.481733", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4-589f59db9\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4\")].metadata.name}'", "delta": "0:00:01.303994", "end": "2019-03-21 08:08:36.572220", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-rej4\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": "/bin/bash", "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-rej4", "rc": 0, "start": "2019-03-21 08:08:35.268226", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-rej4-589f59db9", "stdout_lines": ["cstor-sparse-pool-rej4-589f59db9"]}, "rc": 0, "start": "2019-03-21 08:08:40.183171", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-rej4-589f59db9-tz2tz", "stdout_lines": ["cstor-sparse-pool-rej4-589f59db9-tz2tz"]}, "rc": 0, "start": "2019-03-21 08:08:45.550299", "stderr": "Defaulting container name to cstor-pool.\nUse 'kubectl describe pod/cstor-sparse-pool-rej4-589f59db9-tz2tz -n openebs' to see all of the containers in this pod.\nUnable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Defaulting container name to cstor-pool.", "Use 'kubectl describe pod/cstor-sparse-pool-rej4-589f59db9-tz2tz -n openebs' to see all of the containers in this pod.", "Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT\ncstor-c1aa54cc-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941          6.50K      -   434M  -\ncstor-c1aa54cc-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_q9r2xgj0_1553149929555408967          6.50K      -   434M  -\ncstor-c1aa54cc-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_snapshot-busybox_1553155706014720524     0B      -   434M  -", "stdout_lines": ["NAME                                                                                                                                                                USED  AVAIL  REFER  MOUNTPOINT", "cstor-c1aa54cc-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_kp8tgz2p_1553076163440508941          6.50K      -   434M  -", "cstor-c1aa54cc-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_q9r2xgj0_1553149929555408967          6.50K      -   434M  -", "cstor-c1aa54cc-4ad4-11e9-9501-005056985c20/pvc-d9fff0d3-4ad6-11e9-9501-005056985c20@pvc-d9fff0d3-4ad6-11e9-9501-005056985c20_snapshot-busybox_1553155706014720524     0B      -   434M  -"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/snapshot-creation/test.yml:94
2019-03-21T08:08:47.431444 (delta: 5.829249)         elapsed: 40.017501 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/snapshot-creation/test.yml:103
2019-03-21T08:08:47.619953 (delta: 0.188371)         elapsed: 40.20601 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-03-21T08:08:47.719430 (delta: 0.099349)         elapsed: 40.305487 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-03-21T08:08:47.791599 (delta: 0.072107)         elapsed: 40.377656 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-03-21T08:08:47.841434 (delta: 0.049755)         elapsed: 40.427491 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-03-21T08:08:47.890658 (delta: 0.049165)         elapsed: 40.476715 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "0729a880f30ed49523377585f88c84785297782d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "75581027b99e9de1e903ec50005f5822", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1553155727.96-182262119884870/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-03-21T08:08:50.514530 (delta: 2.623815)         elapsed: 43.100587 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.278323", "end": "2019-03-21 08:08:52.039793", "rc": 0, "start": "2019-03-21 08:08:50.761470", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-snapshot \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-snapshot ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-03-21T08:08:52.100124 (delta: 1.585532)         elapsed: 44.686181 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.504562", "end": "2019-03-21 08:08:53.865498", "failed_when_result": false, "rc": 0, "start": "2019-03-21 08:08:52.360936", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-snapshot configured", "stdout_lines": ["litmusresult.litmus.io/create-snapshot configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=22   changed=15   unreachable=0    failed=0   

2019-03-21T08:08:53.922359 (delta: 1.822176)         elapsed: 46.508416 ******* 
=============================================================================== 
```