### PR TITLE
Including clone and parent volume deletion litmusbooks

### DIFF
--- a/experiments/functional/clone-creation/run_litmus_test.yml
+++ b/experiments/functional/clone-creation/run_litmus_test.yml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: gprasath/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
 
         env:

--- a/experiments/functional/clone-creation/run_litmus_test.yml
+++ b/experiments/functional/clone-creation/run_litmus_test.yml
@@ -1,0 +1,45 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-clone-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: litmus-clone
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: gprasath/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+            
+            # Application pvc
+          - name: APP_PVC
+            value: openebs-busybox
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: app-busybox-ns 
+
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-snapshot-promoter
+
+            # Name of clone volume
+          - name: CLONE_VOL_CLAIM
+            value: clone-busybox
+
+          - name: SNAPSHOT
+            value: snapshot-busybox
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/clone-creation/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/clone-creation/test.yml
+++ b/experiments/functional/clone-creation/test.yml
@@ -1,0 +1,60 @@
+---
+#Description: Creation of volume snapshot and clone.
+#
+########################################################################################
+#Steps:                                                                                #
+#1) Creating LitmusResult CR for updating test result.                                 #
+#2) Checking if the snapshot-promoter storage class is created.                        #
+#3) Use funclib util to create snapshot by passing environmental variables.            #
+#4) Check if the cloned pvc is created successfully.                                   #
+########################################################################################
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /common/utils/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/common/utils/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Check whether the snapshot specific storage class is created.
+          shell: kubectl get sc {{ lookup('env','PROVIDER_STORAGE_CLASS') }}
+          args:
+            executable: /bin/bash
+          register: result
+
+        - name: Check if the snapshot is created.
+          shell: kubectl get volumesnapshot -n {{ app_ns }}
+          args:
+            executable: /bin/bash
+          register: snap_result
+          failed_when: "snapshot_name not in snap_result.stdout"
+
+       ## Include an utility from litmus funclib to create clone using volume snapshot.
+       ## Passing app_ns, snapshot_name,storage class and clone name as environmental variable.
+
+        - name: Creating clone using snapshot.
+          include_tasks: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+

--- a/experiments/functional/clone-creation/test_vars.yml
+++ b/experiments/functional/clone-creation/test_vars.yml
@@ -1,0 +1,14 @@
+---
+test_name: create-clone
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+pvc_name: "{{ lookup('env','APP_PVC') }}"
+
+clone_claim_name: "{{ lookup('env','CLONE_VOL_CLAIM') }}"
+
+storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+operator_ns: openebs
+
+snapshot_name: "{{ lookup('env','SNAPSHOT') }}"

--- a/experiments/functional/restrict-parent-volume-deletion/run_litmus_test.yml
+++ b/experiments/functional/restrict-parent-volume-deletion/run_litmus_test.yml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: gprasath/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
 
         env:

--- a/experiments/functional/restrict-parent-volume-deletion/run_litmus_test.yml
+++ b/experiments/functional/restrict-parent-volume-deletion/run_litmus_test.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-delete-parent-volume
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: litmus-delete-parent-volume
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: gprasath/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+            
+            # Application pvc
+          - name: APP_PVC
+            value: openebs-busybox
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: app-busybox-ns 
+
+          - name: SNAPSHOT
+            value: snapshot-busybox
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/restrict-parent-volume-deletion/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/restrict-parent-volume-deletion/test.yml
+++ b/experiments/functional/restrict-parent-volume-deletion/test.yml
@@ -1,0 +1,54 @@
+---
+#Description: Creation of volume snapshot and clone.
+#
+########################################################################################
+#Steps:                                                                                #
+#1) Creating LitmusResult CR for updating test result.                                 #
+#2) Try to delete the volume which has clone and snapshot created.                     #
+#3) Update the result to the LitmusResult CR.                                          #
+########################################################################################
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname for deployment
+        - include_tasks: /common/utils/create_testname.yml
+
+        ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/common/utils/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Attempt deleting the volume which has descendants
+          shell: kubectl delete pvc {{ pvc_name }} -n {{ app_ns }}
+          args:
+            executable: /bin/bash
+          register: pvc_result
+          failed_when: pvc_result.rc == 0
+
+        - name: Check if the PVC is not deleted.
+          shell: kubectl get pvc {{ pvc_name }} -n {{ app_ns }} --no-headers -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: pvc_state
+          failed_when: "'Bound' not in pvc_state.stdout"
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+           ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
+

--- a/experiments/functional/restrict-parent-volume-deletion/test_vars.yml
+++ b/experiments/functional/restrict-parent-volume-deletion/test_vars.yml
@@ -1,0 +1,8 @@
+---
+test_name: delete-parent-volume
+
+app_ns: "{{ lookup('env','APP_NAMESPACE') }}"
+
+pvc_name: "{{ lookup('env','APP_PVC') }}"
+
+snapshot_name: "{{ lookup('env','SNAPSHOT') }}"

--- a/funclib/kubectl/k8s_snapshot_clone/create_clone.yml
+++ b/funclib/kubectl/k8s_snapshot_clone/create_clone.yml
@@ -2,15 +2,22 @@
 ## This utility creates clone volume using the snapshot.
 # This utility creates snapshot using K8s external storage API.
 #
-- name: Generate unique string for use as clone claim.
-  shell: cat /dev/urandom | tr -cd 'a-z0-9' | head -c 8
-  args:
-    executable: /bin/bash
-  register: clone_name
+#- name: Generate unique string for use as clone claim.
+#  shell: cat /dev/urandom | tr -cd 'a-z0-9' | head -c 8
+#  args:
+#    executable: /bin/bash
+#  register: clone_name
 
-- name: Form the clone claim name.
-  set_fact:
-    clone_claim_name: "{{ clone_claim }}-{{ clone_name.stdout }}"
+#- name: Form the clone claim name.
+#  set_fact:
+#    clone_claim_name: "{{ clone_claim }}-{{ clone_name.stdout }}"
+#
+#
+#    The arguments necessary for this template are
+#        - app_ns  - application namespace
+#        - clone_claim_name - name for clone volume
+#        - snapshot_name - Name of snapshot
+#        - storage_class  - storageclass to create clone
 
 - name: Update the clone creation template with the values provided.
   template:


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:

- Implemented two litmusbooks to create clone and check if the parent volume can be deleted successfully.
- Passing snapshot name, namespace as env in clone creation litmusbook.
- Passing parent volume name, namespace as env in parent volume deletion playbook.

```
PLAY [localhost] ***************************************************************
2019-03-22T07:15:20.777129 (delta: 0.062306)         elapsed: 0.062306 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/clone-creation/test.yml:12
2019-03-22T07:15:20.791387 (delta: 0.014201)         elapsed: 0.076564 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/clone-creation/test.yml:22
2019-03-22T07:15:29.727142 (delta: 8.935735)         elapsed: 9.012319 ******** 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /common/utils/create_testname.yml:3
2019-03-22T07:15:29.796424 (delta: 0.06924)         elapsed: 9.081601 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /common/utils/create_testname.yml:7
2019-03-22T07:15:29.856422 (delta: 0.059946)         elapsed: 9.141599 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/clone-creation/test.yml:25
2019-03-22T07:15:29.917726 (delta: 0.061238)         elapsed: 9.202903 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-03-22T07:15:30.024582 (delta: 0.106799)         elapsed: 9.309759 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "70453a66cf60a43485f19f3f23b997c13d550c61", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "57ca86cfc5956f934372292255d089c8", "mode": "0644", "owner": "root", "size": 413, "src": "/root/.ansible/tmp/ansible-tmp-1553238930.08-70247773012126/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-03-22T07:15:30.771811 (delta: 0.747177)         elapsed: 10.056988 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.212053", "end": "2019-03-22 07:15:32.357933", "rc": 0, "start": "2019-03-22 07:15:31.145880", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-clone \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-clone ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-03-22T07:15:32.416427 (delta: 1.644565)         elapsed: 11.701604 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.924721", "end": "2019-03-22 07:15:34.619706", "failed_when_result": false, "rc": 0, "start": "2019-03-22 07:15:32.694985", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-clone configured", "stdout_lines": ["litmusresult.litmus.io/create-clone configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-03-22T07:15:34.739155 (delta: 2.322677)         elapsed: 14.024332 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-03-22T07:15:34.863601 (delta: 0.124349)         elapsed: 14.148778 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-03-22T07:15:34.967519 (delta: 0.103818)         elapsed: 14.252696 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the snapshot specific storage class is created.] ***********
task path: /experiments/functional/clone-creation/test.yml:29
2019-03-22T07:15:35.076207 (delta: 0.108591)         elapsed: 14.361384 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-snapshot-promoter", "delta": "0:00:01.282818", "end": "2019-03-22 07:15:36.773343", "rc": 0, "start": "2019-03-22 07:15:35.490525", "stderr": "", "stderr_lines": [], "stdout": "NAME                        PROVISIONER                                                AGE\nopenebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   2d", "stdout_lines": ["NAME                        PROVISIONER                                                AGE", "openebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   2d"]}

TASK [Check if the snapshot is created.] ***************************************
task path: /experiments/functional/clone-creation/test.yml:35
2019-03-22T07:15:36.878638 (delta: 1.8023)         elapsed: 16.163815 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get volumesnapshot -n app-busybox-ns", "delta": "0:00:01.090074", "end": "2019-03-22 07:15:38.216817", "failed_when_result": false, "rc": 0, "start": "2019-03-22 07:15:37.126743", "stderr": "", "stderr_lines": [], "stdout": "NAME               CREATED AT\nkp8tgz2p           1d\nq9r2xgj0           1d\nsnapshot-busybox   23h", "stdout_lines": ["NAME               CREATED AT", "kp8tgz2p           1d", "q9r2xgj0           1d", "snapshot-busybox   23h"]}

TASK [Creating clone using snapshot.] ******************************************
task path: /experiments/functional/clone-creation/test.yml:45
2019-03-22T07:15:38.330945 (delta: 1.452215)         elapsed: 17.616122 ******* 
included: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml for 127.0.0.1

TASK [Update the clone creation template with the values provided.] ************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:22
2019-03-22T07:15:38.494784 (delta: 0.163745)         elapsed: 17.779961 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "d1b21bb2cbfc61b1f58e139cf40392af235f31c5", "dest": "./snapshot-claim.yml", "gid": 0, "group": "root", "md5sum": "bdc3d5962ef5669c9574699b52bd28fe", "mode": "0644", "owner": "root", "size": 311, "src": "/root/.ansible/tmp/ansible-tmp-1553238938.56-95137845290644/source", "state": "file", "uid": 0}

TASK [Creating PVC from the snapshot] ******************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:27
2019-03-22T07:15:39.147474 (delta: 0.652639)         elapsed: 18.432651 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f snapshot-claim.yml", "delta": "0:00:01.553020", "end": "2019-03-22 07:15:40.880708", "rc": 0, "start": "2019-03-22 07:15:39.327688", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/clone-busybox created", "stdout_lines": ["persistentvolumeclaim/clone-busybox created"]}

TASK [Checking if the pvc is created successfully] *****************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:32
2019-03-22T07:15:40.986991 (delta: 1.839464)         elapsed: 20.272168 ******* 
FAILED - RETRYING: Checking if the pvc is created successfully (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pvc -n app-busybox-ns | grep clone-busybox", "delta": "0:00:01.248230", "end": "2019-03-22 07:16:44.140507", "rc": 0, "start": "2019-03-22 07:16:42.892277", "stderr": "", "stderr_lines": [], "stdout": "clone-busybox     Bound    pvc-4cb6cdf5-4c72-11e9-a8b4-005056985c20   5G         RWO            openebs-snapshot-promoter   1m", "stdout_lines": ["clone-busybox     Bound    pvc-4cb6cdf5-4c72-11e9-a8b4-005056985c20   5G         RWO            openebs-snapshot-promoter   1m"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/clone-creation/test.yml:48
2019-03-22T07:16:44.213719 (delta: 63.226634)         elapsed: 83.498896 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/clone-creation/test.yml:57
2019-03-22T07:16:44.344727 (delta: 0.130946)         elapsed: 83.629904 ******* 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-03-22T07:16:44.535930 (delta: 0.191125)         elapsed: 83.821107 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-03-22T07:16:44.643750 (delta: 0.107721)         elapsed: 83.928927 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-03-22T07:16:44.752006 (delta: 0.108164)         elapsed: 84.037183 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-03-22T07:16:44.857468 (delta: 0.105367)         elapsed: 84.142645 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "b3147baa483b131761e151aca8513426f1d56159", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "1ba3007a49c610ead878cad791ce59cf", "mode": "0644", "owner": "root", "size": 411, "src": "/root/.ansible/tmp/ansible-tmp-1553239004.97-50724832267465/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-03-22T07:16:47.348252 (delta: 2.490692)         elapsed: 86.633429 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.179559", "end": "2019-03-22 07:16:48.850451", "rc": 0, "start": "2019-03-22 07:16:47.670892", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-clone \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-clone ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-03-22T07:16:48.921409 (delta: 1.573076)         elapsed: 88.206586 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.267611", "end": "2019-03-22 07:16:50.432099", "failed_when_result": false, "rc": 0, "start": "2019-03-22 07:16:49.164488", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-clone configured", "stdout_lines": ["litmusresult.litmus.io/create-clone configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=17   changed=11   unreachable=0    failed=0   

2019-03-22T07:16:50.487039 (delta: 1.565552)         elapsed: 89.772216 ******* 
```