### PR TITLE
Refactor openebs-deployment litmusbook to use cstor pool-exporter image

### DIFF
--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -138,6 +138,12 @@
             executable: /bin/bash
           when: lookup('env','OPENEBS_IO_VOLUME_MONITOR_IMAGE') | length > 0
 
+        - name: Updating openebs cstor pool exporter image
+          shell: "{{ kubeapply }} set env deployment maya-apiserver \"OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE={{ lookup('env','OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE') }}\" -n {{ namespace }}"
+          args:
+            executable: /bin/bash
+          when: lookup('env','OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE') | length > 0
+
         - name: Restarting all pods in openebs namespace
           shell: "kubectl delete po --all -n {{ namespace }}"
           args:

--- a/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/litmusbook/openebs_setup.yaml
@@ -50,6 +50,8 @@ spec:
             value:
           - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
             value:        
+          - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
+            value:  
           - name: IMAGE_PULL_POLICY
             value:
           - name: OPENEBS_INFRA_CHAOS


### PR DESCRIPTION
**What this PR does / why we need it**:

- Refactor openebs-deployment litmusbook to use cstor pool-exporter image

** Following is the logs of litmus-test-container**
```
TASK [Updating openebs cstor volume management image] **************************
task path: /operator/master/ansible/openebs_setup.yaml:129
2019-03-22T09:22:13.253225 (delta: 1.766535)         elapsed: 37.006856 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf set env deployment maya-apiserver \"OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE=openebs/cstor-volume-mgmt:0.8.2-RC1\" -n openebs", "delta": "0:00:01.356426", "end": "2019-03-22 09:22:14.986127", "rc": 0, "start": "2019-03-22 09:22:13.629701", "stderr": "", "stderr_lines": [], "stdout": "deployment.extensions/maya-apiserver env updated", "stdout_lines": ["deployment.extensions/maya-apiserver env updated"]}

TASK [Updating openebs cstor volume monitor image] *****************************
task path: /operator/master/ansible/openebs_setup.yaml:135
2019-03-22T09:22:15.081525 (delta: 1.828214)         elapsed: 38.835156 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf set env deployment maya-apiserver \"OPENEBS_IO_VOLUME_MONITOR_IMAGE=openebs/m-exporter:0.8.2-RC1\" -n openebs", "delta": "0:00:01.245626", "end": "2019-03-22 09:22:16.795063", "rc": 0, "start": "2019-03-22 09:22:15.549437", "stderr": "", "stderr_lines": [], "stdout": "deployment.extensions/maya-apiserver env updated", "stdout_lines": ["deployment.extensions/maya-apiserver env updated"]}

TASK [Updating openebs cstor pool exporter image] ******************************
task path: /operator/master/ansible/openebs_setup.yaml:141
2019-03-22T09:22:16.851532 (delta: 1.76991)         elapsed: 40.605163 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf set env deployment maya-apiserver \"OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE=openebs/m-exporter:0.8.2-RC1\" -n openebs", "delta": "0:00:01.353744", "end": "2019-03-22 09:22:18.411651", "rc": 0, "start": "2019-03-22 09:22:17.057907", "stderr": "", "stderr_lines": [], "stdout": "deployment.extensions/maya-apiserver env updated", "stdout_lines": ["deployment.extensions/maya-apiserver env updated"]}

```

