### PR TITLE
 refactor(yaml):Obtaining volume capacity as env in clone creation util.

### DIFF
--- a/experiments/functional/clone-creation/run_litmus_test.yml
+++ b/experiments/functional/clone-creation/run_litmus_test.yml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: gprasath/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
 
         env:
@@ -29,7 +29,7 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: app-busybox-snap
+            value: app-busybox-ns
 
           - name: PROVIDER_STORAGE_CLASS
             value: openebs-snapshot-promoter
@@ -42,7 +42,7 @@ spec:
             value: snapshot-busybox
 
           - name: CAPACITY
-            value: 7G
+            value: 5G
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/clone-creation/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/clone-creation/run_litmus_test.yml
+++ b/experiments/functional/clone-creation/run_litmus_test.yml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: openebs/ansible-runner:ci
+        image: gprasath/ansible-runner:ci
         imagePullPolicy: Always
 
         env:
@@ -29,7 +29,7 @@ spec:
 
             # Application namespace
           - name: APP_NAMESPACE
-            value: app-busybox-ns 
+            value: app-busybox-snap
 
           - name: PROVIDER_STORAGE_CLASS
             value: openebs-snapshot-promoter
@@ -40,6 +40,9 @@ spec:
 
           - name: SNAPSHOT
             value: snapshot-busybox
+
+          - name: CAPACITY
+            value: 7G
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./experiments/functional/clone-creation/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/clone-creation/test.yml
+++ b/experiments/functional/clone-creation/test.yml
@@ -44,6 +44,9 @@
 
         - name: Creating clone using snapshot.
           include_tasks: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml
+          vars:
+            capacity: "{{ volume_capacity }}"
+
 
         - set_fact:
             flag: "Pass"

--- a/experiments/functional/clone-creation/test_vars.yml
+++ b/experiments/functional/clone-creation/test_vars.yml
@@ -12,3 +12,5 @@ storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
 operator_ns: openebs
 
 snapshot_name: "{{ lookup('env','SNAPSHOT') }}"
+
+volume_capacity: "{{ lookup('env','CAPACITY') }}"

--- a/funclib/kubectl/k8s_snapshot_clone/snapshot-claim.j2
+++ b/funclib/kubectl/k8s_snapshot_clone/snapshot-claim.j2
@@ -10,5 +10,5 @@ spec:
   accessModes: [ "ReadWriteOnce" ]
   resources:
     requests:
-      storage: 5G
+      storage: {{ capacity }}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Updated clone creation util with a variable for volume capacity.
- Included variable for the same in test_vars.
- Updating the variable while executing clone creation.
- Included this variable in the job file.

- Litmusbook can validate the functionality of admission-server by providing more capacity.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #553 

**Special notes for your reviewer**:

Here is the stdout snippet:

```
[root@master-1552853078 clone-creation]# kubectl logs -f litmus-clone-qr487-nfwtf -n litmus
ansible-playbook 2.7.6
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/clone-creation/test.yml

PLAY [localhost] ***************************************************************
2019-04-01T06:53:02.554918 (delta: 0.062843)         elapsed: 0.062843 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/clone-creation/test.yml:12
2019-04-01T06:53:02.573185 (delta: 0.018213)         elapsed: 0.08111 ********* 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/clone-creation/test.yml:22
2019-04-01T06:53:12.062707 (delta: 9.489502)         elapsed: 9.570632 ******** 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /common/utils/create_testname.yml:3
2019-04-01T06:53:12.217472 (delta: 0.154689)         elapsed: 9.725397 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /common/utils/create_testname.yml:7
2019-04-01T06:53:12.364724 (delta: 0.147165)         elapsed: 9.872649 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/clone-creation/test.yml:25
2019-04-01T06:53:12.492648 (delta: 0.127805)         elapsed: 10.000573 ******* 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-04-01T06:53:12.695735 (delta: 0.202999)         elapsed: 10.20366 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "70453a66cf60a43485f19f3f23b997c13d550c61", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "57ca86cfc5956f934372292255d089c8", "mode": "0644", "owner": "root", "size": 413, "src": "/root/.ansible/tmp/ansible-tmp-1554101592.76-255305786802747/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-04-01T06:53:13.655537 (delta: 0.959742)         elapsed: 11.163462 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.170540", "end": "2019-04-01 06:53:15.310207", "rc": 0, "start": "2019-04-01 06:53:14.139667", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-clone \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-clone ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-04-01T06:53:15.361154 (delta: 1.705562)         elapsed: 12.869079 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.923925", "end": "2019-04-01 06:53:18.525396", "failed_when_result": false, "rc": 0, "start": "2019-04-01 06:53:15.601471", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-clone configured", "stdout_lines": ["litmusresult.litmus.io/create-clone configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-04-01T06:53:18.647577 (delta: 3.286367)         elapsed: 16.155502 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-04-01T06:53:18.764941 (delta: 0.117262)         elapsed: 16.272866 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-04-01T06:53:18.867626 (delta: 0.102586)         elapsed: 16.375551 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check whether the snapshot specific storage class is created.] ***********
task path: /experiments/functional/clone-creation/test.yml:29
2019-04-01T06:53:18.984558 (delta: 0.116831)         elapsed: 16.492483 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-snapshot-promoter", "delta": "0:00:01.278440", "end": "2019-04-01 06:53:20.628001", "rc": 0, "start": "2019-04-01 06:53:19.349561", "stderr": "", "stderr_lines": [], "stdout": "NAME                        PROVISIONER                                                AGE\nopenebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   12d", "stdout_lines": ["NAME                        PROVISIONER                                                AGE", "openebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   12d"]}

TASK [Check if the snapshot is created.] ***************************************
task path: /experiments/functional/clone-creation/test.yml:35
2019-04-01T06:53:20.741425 (delta: 1.756759)         elapsed: 18.24935 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get volumesnapshot -n app-busybox-snap", "delta": "0:00:02.171423", "end": "2019-04-01 06:53:23.281105", "failed_when_result": false, "rc": 0, "start": "2019-04-01 06:53:21.109682", "stderr": "", "stderr_lines": [], "stdout": "NAME               CREATED AT\nsnapshot-busybox   23m", "stdout_lines": ["NAME               CREATED AT", "snapshot-busybox   23m"]}

TASK [Creating clone using snapshot.] ******************************************
task path: /experiments/functional/clone-creation/test.yml:45
2019-04-01T06:53:23.403154 (delta: 2.661626)         elapsed: 20.911079 ******* 
included: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml for 127.0.0.1

TASK [Update the clone creation template with the values provided.] ************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:22
2019-04-01T06:53:23.576489 (delta: 0.173236)         elapsed: 21.084414 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "33573a722f69b0ee6435749c2502df5db7fd02d2", "dest": "./snapshot-claim.yml", "gid": 0, "group": "root", "md5sum": "0b0d4be37fa28d8ad7c734215b4bdb3e", "mode": "0644", "owner": "root", "size": 313, "src": "/root/.ansible/tmp/ansible-tmp-1554101603.65-271244707332522/source", "state": "file", "uid": 0}

TASK [Creating PVC from the snapshot] ******************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:27
2019-04-01T06:53:24.064091 (delta: 0.487541)         elapsed: 21.572016 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f snapshot-claim.yml", "delta": "0:00:01.470744", "end": "2019-04-01 06:53:25.890110", "rc": 0, "start": "2019-04-01 06:53:24.419366", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/clone-busybox created", "stdout_lines": ["persistentvolumeclaim/clone-busybox created"]}

TASK [Checking if the pvc is created successfully] *****************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:32
2019-04-01T06:53:25.993214 (delta: 1.929006)         elapsed: 23.501139 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc -n app-busybox-snap | grep clone-busybox", "delta": "0:00:01.270410", "end": "2019-04-01 06:53:27.734608", "rc": 0, "start": "2019-04-01 06:53:26.464198", "stderr": "", "stderr_lines": [], "stdout": "clone-busybox          Bound    pvc-d922598f-544a-11e9-b6b1-005056985c20   7G         RWO            openebs-snapshot-promoter   2s", "stdout_lines": ["clone-busybox          Bound    pvc-d922598f-544a-11e9-b6b1-005056985c20   7G         RWO            openebs-snapshot-promoter   2s"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/clone-creation/test.yml:51
2019-04-01T06:53:27.820825 (delta: 1.827471)         elapsed: 25.32875 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/clone-creation/test.yml:60
2019-04-01T06:53:27.978919 (delta: 0.157988)         elapsed: 25.486844 ******* 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-04-01T06:53:28.161195 (delta: 0.18217)         elapsed: 25.66912 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-04-01T06:53:28.269932 (delta: 0.108601)         elapsed: 25.777857 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-04-01T06:53:28.394720 (delta: 0.124689)         elapsed: 25.902645 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-04-01T06:53:28.504031 (delta: 0.109209)         elapsed: 26.011956 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "b3147baa483b131761e151aca8513426f1d56159", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "1ba3007a49c610ead878cad791ce59cf", "mode": "0644", "owner": "root", "size": 411, "src": "/root/.ansible/tmp/ansible-tmp-1554101608.64-174717270761231/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-04-01T06:53:31.503866 (delta: 2.999731)         elapsed: 29.011791 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.987368", "end": "2019-04-01 06:53:32.703192", "rc": 0, "start": "2019-04-01 06:53:31.715824", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: create-clone \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: create-clone ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-04-01T06:53:32.753940 (delta: 1.25)         elapsed: 30.261865 *********** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.408877", "end": "2019-04-01 06:53:34.365870", "failed_when_result": false, "rc": 0, "start": "2019-04-01 06:53:32.956993", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/create-clone configured", "stdout_lines": ["litmusresult.litmus.io/create-clone configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=17   changed=11   unreachable=0    failed=0   

2019-04-01T06:53:34.441201 (delta: 1.687203)         elapsed: 31.949126 ******* 
=============================================================================== 
```
