### PR TITLE
feat(yaml):Include litmusbook for helm based openebs deployment.

### DIFF
--- a/providers/openebs/installers/openebs_helm/run_litmus_test.yml
+++ b/providers/openebs/installers/openebs_helm/run_litmus_test.yml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: ansibletest
-        image: gprasath/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
 
         env:

--- a/providers/openebs/installers/openebs_helm/run_litmus_test.yml
+++ b/providers/openebs/installers/openebs_helm/run_litmus_test.yml
@@ -1,0 +1,32 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-openebs-helm-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: openebs-helm
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: gprasath/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            #value: log_plays, actionable, default
+            value: default
+
+          - name: NAMESPACE
+            value: openebs
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./providers/openebs/installers/openebs_helm/test.yml -i /etc/ansible/hosts -v; exit 0"]
+

--- a/providers/openebs/installers/openebs_helm/test.yml
+++ b/providers/openebs/installers/openebs_helm/test.yml
@@ -1,0 +1,121 @@
+---
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+
+    - block:
+
+        - name: Install helm client
+          shell: curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
+          args:
+            executable: /bin/bash
+          register: output
+          until: "'installed' in output.stdout"
+          delay: 30
+          retries: 5
+
+        - name: Setting up tiller.
+          shell: helm init
+          args:
+            executable: /bin/bash
+          register: tiller_out
+          until: "'Happy Helming' in tiller_out.stdout"
+          delay: 30
+          retries: 15
+
+        - name: Checking if the tiller pod is created.
+          shell: helm version
+          args:
+            executable: /bin/bash
+          register: tiller_version
+          until: "'Server: &version.Version' in tiller_version.stdout"
+          delay: 30
+          retries: 30
+       
+        - block:
+
+            - name: Checking if the tiller service account already exists.
+              shell: kubectl get sa -n kube-system | grep tiller
+              args:
+                executable: /bin/bash
+              register: sa
+              until: "'tiller' in sa.stdout"
+              delay: 20
+              retries: 2
+  
+          rescue:
+
+            - name: Creating the service account
+              shell: kubectl -n kube-system create sa tiller
+              args:
+                executable: /bin/bash
+              register: tiller
+              until: "'\"tiller\" created' in tiller.stdout"
+              delay: 30
+              retries: 5
+
+        - block:
+
+            - name: Checking if the tiller cluster role binding already exists.
+              shell: kubectl get clusterrolebinding | grep tiller
+              args:
+                executable: /bin/bash
+              register: cr
+              until: "'tiller' in cr.stdout"
+              delay: 10
+              retries: 2
+
+          rescue:
+
+            - name: Creating the cluster rolebinding.
+              shell: kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+              args:
+                executable: /bin/bash
+              register: crb
+              until: "'\"tiller\" created' in crb.stdout"
+              delay: 60
+              retries: 5
+
+        - name: Installing openebs using stable charts.
+          shell: >
+            helm install stable/openebs --namespace {{ namespace }}
+          args:
+            executable: /bin/bash
+          register: openebs_out
+          until: "'The OpenEBS has been installed' in openebs_out.stdout"
+          delay: 30
+          retries: 20
+
+        - name: Checking if the openebs-provisioner is up.
+          shell: kubectl get pods -n "{{ namespace }}" -l component=provisioner -o custom-columns=:status.phase --no-headers
+          args:
+            executable: /bin/bash
+          register: deployment
+          until: "'Running' in deployment.stdout"
+          delay: 30
+          retries: 10
+
+        - name: Checking if the openebs-apiserver is up.
+          shell: kubectl get pods -n "{{ namespace }}" -l component=apiserver -o custom-columns=:status.phase --no-headers
+          args:
+            executable: /bin/bash
+          register: api_server
+          until: "'Running' in api_server.stdout"
+          delay: 30
+          retries: 10
+
+        - name: Checking of the snapshot-operator is up.
+          shell: kubectl get pods -n {{ namespace }} -l component=snapshot-operator -o custom-columns=:status.phase --no-headers
+          args:
+            executable: /bin/bash
+          register: operator
+          until: "'Running' in operator.stdout"
+          delay: 30
+          retries: 10
+
+          
+

--- a/providers/openebs/installers/openebs_helm/test.yml
+++ b/providers/openebs/installers/openebs_helm/test.yml
@@ -9,6 +9,13 @@
 
     - block:
 
+        - include_tasks: /common/utils/create_testname.yml
+
+          ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'SOT'
+
         - name: Install helm client
           shell: curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
           args:
@@ -108,7 +115,7 @@
           delay: 30
           retries: 10
 
-        - name: Checking of the snapshot-operator is up.
+        - name: Checking if the snapshot-operator is up.
           shell: kubectl get pods -n {{ namespace }} -l component=snapshot-operator -o custom-columns=:status.phase --no-headers
           args:
             executable: /bin/bash
@@ -116,6 +123,20 @@
           until: "'Running' in operator.stdout"
           delay: 30
           retries: 10
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - name: Setting fail flag
+          set_fact:
+            flag: "Fail"
+
+      always:
+        ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: /common/utils/update_litmus_result_resource.yml
+          vars:
+            status: 'EOT'
 
           
 

--- a/providers/openebs/installers/openebs_helm/test_vars.yml
+++ b/providers/openebs/installers/openebs_helm/test_vars.yml
@@ -2,5 +2,4 @@
 
 namespace: "{{ lookup('env','NAMESPACE') }}"
 
-update_deploy_file: update.json
-
+test_name: "deploy-openebs-helm"

--- a/providers/openebs/installers/openebs_helm/test_vars.yml
+++ b/providers/openebs/installers/openebs_helm/test_vars.yml
@@ -1,0 +1,6 @@
+---
+
+namespace: "{{ lookup('env','NAMESPACE') }}"
+
+update_deploy_file: update.json
+


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- This litmusbook will deploy openebs using stable helm chart.
- It deploys helm client and tiller in the cluster before attempting to install openebs.
- Checks if the openebs components are running after installation.

**Special notes for your reviewer**:
Here is the test output snippets:

```
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAY [localhost] ***************************************************************
2019-04-03T06:57:31.324988 (delta: 0.064232)         elapsed: 0.064232 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-04-03T06:57:31.343618 (delta: 0.018576)         elapsed: 0.082862 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-04-03T06:57:40.392616 (delta: 9.048978)         elapsed: 9.13186 ********* 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-04-03T06:57:40.483579 (delta: 0.090918)         elapsed: 9.222823 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-04-03T06:57:40.549575 (delta: 0.065945)         elapsed: 9.288819 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-04-03T06:57:40.659029 (delta: 0.109403)         elapsed: 9.398273 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-04-03T06:57:40.862758 (delta: 0.203639)         elapsed: 9.602002 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "b535fae3eed5bd3b3e83fc41ef17480ece72d447", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a943beae22fe87a5a3ede9b9b133f104", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1554274660.98-206581712938718/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-04-03T06:57:41.889466 (delta: 1.026584)         elapsed: 10.62871 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.155665", "end": "2019-04-03 06:57:43.591557", "rc": 0, "start": "2019-04-03 06:57:42.435892", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: deploy-openebs-helm \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: deploy-openebs-helm ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-04-03T06:57:43.647671 (delta: 1.758144)         elapsed: 12.386915 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.987531", "end": "2019-04-03 06:57:45.904379", "failed_when_result": false, "rc": 0, "start": "2019-04-03 06:57:43.916848", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/deploy-openebs-helm created", "stdout_lines": ["litmusresult.litmus.io/deploy-openebs-helm created"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-04-03T06:57:46.023663 (delta: 2.375902)         elapsed: 14.762907 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-04-03T06:57:46.127520 (delta: 0.103749)         elapsed: 14.866764 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-04-03T06:57:46.238191 (delta: 0.11057)         elapsed: 14.977435 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Install helm client] *****************************************************
2019-04-03T06:57:46.347561 (delta: 0.109265)         elapsed: 15.086805 ******* 
 [WARNING]: Consider using the get_url or uri module rather than running curl.
If you need to use command because get_url or uri is insufficient you can add
warn=False to this command task or set command_warnings=False in ansible.cfg to
get rid of this message.
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash", "delta": "0:00:12.794125", "end": "2019-04-03 06:57:59.526504", "rc": 0, "start": "2019-04-03 06:57:46.732379", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0\r100  7028  100  7028    0     0   1199      0  0:00:05  0:00:05 --:--:--  2099", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0", "100  7028  100  7028    0     0   1199      0  0:00:05  0:00:05 --:--:--  2099"], "stdout": "Downloading https://kubernetes-helm.storage.googleapis.com/helm-v2.13.1-linux-amd64.tar.gz\nPreparing to install helm and tiller into /usr/local/bin\nhelm installed into /usr/local/bin/helm\ntiller installed into /usr/local/bin/tiller\nRun 'helm init' to configure helm.", "stdout_lines": ["Downloading https://kubernetes-helm.storage.googleapis.com/helm-v2.13.1-linux-amd64.tar.gz", "Preparing to install helm and tiller into /usr/local/bin", "helm installed into /usr/local/bin/helm", "tiller installed into /usr/local/bin/tiller", "Run 'helm init' to configure helm."]}

TASK [Setting up tiller.] ******************************************************
2019-04-03T06:57:59.667505 (delta: 13.319841)         elapsed: 28.406749 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "helm init", "delta": "0:00:03.276322", "end": "2019-04-03 06:58:03.321993", "rc": 0, "start": "2019-04-03 06:58:00.045671", "stderr": "", "stderr_lines": [], "stdout": "Creating /root/.helm \nCreating /root/.helm/repository \nCreating /root/.helm/repository/cache \nCreating /root/.helm/repository/local \nCreating /root/.helm/plugins \nCreating /root/.helm/starters \nCreating /root/.helm/cache/archive \nCreating /root/.helm/repository/repositories.yaml \nAdding stable repo with URL: https://kubernetes-charts.storage.googleapis.com \nAdding local repo with URL: http://127.0.0.1:8879/charts \n$HELM_HOME has been configured at /root/.helm.\nWarning: Tiller is already installed in the cluster.\n(Use --client-only to suppress this message, or --upgrade to upgrade Tiller to the current version.)\nHappy Helming!", "stdout_lines": ["Creating /root/.helm ", "Creating /root/.helm/repository ", "Creating /root/.helm/repository/cache ", "Creating /root/.helm/repository/local ", "Creating /root/.helm/plugins ", "Creating /root/.helm/starters ", "Creating /root/.helm/cache/archive ", "Creating /root/.helm/repository/repositories.yaml ", "Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com ", "Adding local repo with URL: http://127.0.0.1:8879/charts ", "$HELM_HOME has been configured at /root/.helm.", "Warning: Tiller is already installed in the cluster.", "(Use --client-only to suppress this message, or --upgrade to upgrade Tiller to the current version.)", "Happy Helming!"]}

TASK [Checking if the tiller pod is created.] **********************************
2019-04-03T06:58:03.431558 (delta: 3.763948)         elapsed: 32.170802 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "helm version", "delta": "0:00:01.399030", "end": "2019-04-03 06:58:05.101223", "rc": 0, "start": "2019-04-03 06:58:03.702193", "stderr": "", "stderr_lines": [], "stdout": "Client: &version.Version{SemVer:\"v2.13.1\", GitCommit:\"618447cbf203d147601b4b9bd7f8c37a5d39fbb4\", GitTreeState:\"clean\"}\nServer: &version.Version{SemVer:\"v2.13.1\", GitCommit:\"618447cbf203d147601b4b9bd7f8c37a5d39fbb4\", GitTreeState:\"clean\"}", "stdout_lines": ["Client: &version.Version{SemVer:\"v2.13.1\", GitCommit:\"618447cbf203d147601b4b9bd7f8c37a5d39fbb4\", GitTreeState:\"clean\"}", "Server: &version.Version{SemVer:\"v2.13.1\", GitCommit:\"618447cbf203d147601b4b9bd7f8c37a5d39fbb4\", GitTreeState:\"clean\"}"]}

TASK [Checking if the tiller service account already exists.] ******************
2019-04-03T06:58:05.225180 (delta: 1.793535)         elapsed: 33.964424 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get sa -n kube-system | grep tiller", "delta": "0:00:01.265827", "end": "2019-04-03 06:58:06.857087", "rc": 0, "start": "2019-04-03 06:58:05.591260", "stderr": "", "stderr_lines": [], "stdout": "tiller                               2         2h", "stdout_lines": ["tiller                               2         2h"]}

TASK [Checking if the tiller cluster role binding already exists.] *************
2019-04-03T06:58:06.964386 (delta: 1.739099)         elapsed: 35.70363 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get clusterrolebinding | grep tiller", "delta": "0:00:01.266220", "end": "2019-04-03 06:58:08.595594", "rc": 0, "start": "2019-04-03 06:58:07.329374", "stderr": "", "stderr_lines": [], "stdout": "tiller                                                                     /cluster-admin                                                                                                                                                 kube-system/tiller                                                                 ", "stdout_lines": ["tiller                                                                     /cluster-admin                                                                                                                                                 kube-system/tiller                                                                 "]}

TASK [Installing openebs using stable charts.] *********************************
2019-04-03T06:58:08.721563 (delta: 1.75707)         elapsed: 37.460807 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "helm install stable/openebs --namespace openebs", "delta": "0:00:05.171577", "end": "2019-04-03 06:58:14.270712", "rc": 0, "start": "2019-04-03 06:58:09.099135", "stderr": "", "stderr_lines": [], "stdout": "NAME:   icy-gerbil\nLAST DEPLOYED: Wed Apr  3 06:58:13 2019\nNAMESPACE: openebs\nSTATUS: DEPLOYED\n\nRESOURCES:\n==> v1/ClusterRole\nNAME                AGE\nicy-gerbil-openebs  1s\n\n==> v1/ClusterRoleBinding\nNAME                AGE\nicy-gerbil-openebs  1s\n\n==> v1/ConfigMap\nNAME                           DATA  AGE\nicy-gerbil-openebs-ndm-config  1     1s\n\n==> v1/Deployment\nNAME                                  READY  UP-TO-DATE  AVAILABLE  AGE\nicy-gerbil-openebs-apiserver          0/1    0           0          1s\nicy-gerbil-openebs-provisioner        0/1    0           0          1s\nicy-gerbil-openebs-snapshot-operator  0/1    0           0          1s\n\n==> v1/Pod(related)\nNAME                                                   READY  STATUS             RESTARTS  AGE\nicy-gerbil-openebs-apiserver-6cf645978f-278vr          0/1    Pending            0         0s\nicy-gerbil-openebs-ndm-5q7bv                           0/1    Pending            0         0s\nicy-gerbil-openebs-ndm-k7g6d                           0/1    ContainerCreating  0         1s\nicy-gerbil-openebs-ndm-zcvjj                           0/1    Pending            0         0s\nicy-gerbil-openebs-provisioner-687d99f9c4-ckztb        0/1    Pending            0         0s\nicy-gerbil-openebs-snapshot-operator-6778bb98f8-w62hz  0/2    Pending            0         0s\n\n==> v1/Service\nNAME                           TYPE       CLUSTER-IP    EXTERNAL-IP  PORT(S)   AGE\nicy-gerbil-openebs-apiservice  ClusterIP  172.24.42.35  <none>       5656/TCP  1s\n\n==> v1/ServiceAccount\nNAME                SECRETS  AGE\nicy-gerbil-openebs  2        1s\n\n==> v1beta1/DaemonSet\nNAME                    DESIRED  CURRENT  READY  UP-TO-DATE  AVAILABLE  NODE SELECTOR  AGE\nicy-gerbil-openebs-ndm  0        0        0      0           0          <none>         1s\n\n\nNOTES:\nThe OpenEBS has been installed. Check its status by running:\n$ kubectl get pods -n openebs\n\nFor dynamically creating OpenEBS Volumes, you can either create a new StorageClass or\nuse one of the default storage classes provided by OpenEBS.\n\nUse `kubectl get sc` to see the list of installed OpenEBS StorageClasses. A sample\nPVC spec using `openebs-jiva-default` StorageClass is given below:\"\n\n---\nkind: PersistentVolumeClaim\napiVersion: v1\nmetadata:\n  name: demo-vol-claim\nspec:\n  storageClassName: openebs-jiva-default\n  accessModes:\n    - ReadWriteOnce\n  resources:\n    requests:\n      storage: 5G\n---\n\nFor more information, please visit http://docs.openebs.io/.\n\nPlease note that, OpenEBS uses iSCSI for connecting applications with the\nOpenEBS Volumes and your nodes should have the iSCSI initiator installed.", "stdout_lines": ["NAME:   icy-gerbil", "LAST DEPLOYED: Wed Apr  3 06:58:13 2019", "NAMESPACE: openebs", "STATUS: DEPLOYED", "", "RESOURCES:", "==> v1/ClusterRole", "NAME                AGE", "icy-gerbil-openebs  1s", "", "==> v1/ClusterRoleBinding", "NAME                AGE", "icy-gerbil-openebs  1s", "", "==> v1/ConfigMap", "NAME                           DATA  AGE", "icy-gerbil-openebs-ndm-config  1     1s", "", "==> v1/Deployment", "NAME                                  READY  UP-TO-DATE  AVAILABLE  AGE", "icy-gerbil-openebs-apiserver          0/1    0           0          1s", "icy-gerbil-openebs-provisioner        0/1    0           0          1s", "icy-gerbil-openebs-snapshot-operator  0/1    0           0          1s", "", "==> v1/Pod(related)", "NAME                                                   READY  STATUS             RESTARTS  AGE", "icy-gerbil-openebs-apiserver-6cf645978f-278vr          0/1    Pending            0         0s", "icy-gerbil-openebs-ndm-5q7bv                           0/1    Pending            0         0s", "icy-gerbil-openebs-ndm-k7g6d                           0/1    ContainerCreating  0         1s", "icy-gerbil-openebs-ndm-zcvjj                           0/1    Pending            0         0s", "icy-gerbil-openebs-provisioner-687d99f9c4-ckztb        0/1    Pending            0         0s", "icy-gerbil-openebs-snapshot-operator-6778bb98f8-w62hz  0/2    Pending            0         0s", "", "==> v1/Service", "NAME                           TYPE       CLUSTER-IP    EXTERNAL-IP  PORT(S)   AGE", "icy-gerbil-openebs-apiservice  ClusterIP  172.24.42.35  <none>       5656/TCP  1s", "", "==> v1/ServiceAccount", "NAME                SECRETS  AGE", "icy-gerbil-openebs  2        1s", "", "==> v1beta1/DaemonSet", "NAME                    DESIRED  CURRENT  READY  UP-TO-DATE  AVAILABLE  NODE SELECTOR  AGE", "icy-gerbil-openebs-ndm  0        0        0      0           0          <none>         1s", "", "", "NOTES:", "The OpenEBS has been installed. Check its status by running:", "$ kubectl get pods -n openebs", "", "For dynamically creating OpenEBS Volumes, you can either create a new StorageClass or", "use one of the default storage classes provided by OpenEBS.", "", "Use `kubectl get sc` to see the list of installed OpenEBS StorageClasses. A sample", "PVC spec using `openebs-jiva-default` StorageClass is given below:\"", "", "---", "kind: PersistentVolumeClaim", "apiVersion: v1", "metadata:", "  name: demo-vol-claim", "spec:", "  storageClassName: openebs-jiva-default", "  accessModes:", "    - ReadWriteOnce", "  resources:", "    requests:", "      storage: 5G", "---", "", "For more information, please visit http://docs.openebs.io/.", "", "Please note that, OpenEBS uses iSCSI for connecting applications with the", "OpenEBS Volumes and your nodes should have the iSCSI initiator installed."]}

TASK [Checking if the openebs-provisioner is up.] ******************************
2019-04-03T06:58:14.403368 (delta: 5.681701)         elapsed: 43.142612 ******* 
FAILED - RETRYING: Checking if the openebs-provisioner is up. (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n \"openebs\" -l component=provisioner -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.176863", "end": "2019-04-03 06:58:47.610198", "rc": 0, "start": "2019-04-03 06:58:46.433335", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking if the openebs-apiserver is up.] ********************************
2019-04-03T06:58:47.725217 (delta: 33.321743)         elapsed: 76.464461 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n \"openebs\" -l component=apiserver -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.263039", "end": "2019-04-03 06:58:49.368238", "rc": 0, "start": "2019-04-03 06:58:48.105199", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking if the snapshot-operator is up.] ********************************
2019-04-03T06:58:49.445071 (delta: 1.719749)         elapsed: 78.184315 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l component=snapshot-operator -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.238162", "end": "2019-04-03 06:58:51.010964", "rc": 0, "start": "2019-04-03 06:58:49.772802", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set_fact] ****************************************************************
2019-04-03T06:58:51.128981 (delta: 1.68384)         elapsed: 79.868225 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-04-03T06:58:51.290757 (delta: 0.16167)         elapsed: 80.030001 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-04-03T06:58:51.458572 (delta: 0.167679)         elapsed: 80.197816 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-04-03T06:58:51.515642 (delta: 0.057014)         elapsed: 80.254886 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-04-03T06:58:51.566533 (delta: 0.050831)         elapsed: 80.305777 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-04-03T06:58:51.640610 (delta: 0.074015)         elapsed: 80.379854 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "964688e8d0a8123d8185b241b1b2650a93114cdb", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "5944eb82a511c07940304578509b112e", "mode": "0644", "owner": "root", "size": 418, "src": "/root/.ansible/tmp/ansible-tmp-1554274731.73-74164965734458/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-04-03T06:58:54.175442 (delta: 2.534764)         elapsed: 82.914686 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.127088", "end": "2019-04-03 06:58:55.609501", "rc": 0, "start": "2019-04-03 06:58:54.482413", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: deploy-openebs-helm \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: deploy-openebs-helm ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-04-03T06:58:55.667511 (delta: 1.492002)         elapsed: 84.406755 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.518268", "end": "2019-04-03 06:58:57.497402", "failed_when_result": false, "rc": 0, "start": "2019-04-03 06:58:55.979134", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/deploy-openebs-helm configured", "stdout_lines": ["litmusresult.litmus.io/deploy-openebs-helm configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=20   changed=15   unreachable=0    failed=0   

2019-04-03T06:58:57.544552 (delta: 1.876985)         elapsed: 86.283796 ******* 
=============================================================================== 
 
```
```
[root@master-1552853078 openebs_helm]# helm ls --all
NAME         	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
early-vulture	1       	Wed Apr  3 11:23:10 2019	DEPLOYED	openebs-0.8.3	0.8.1      	openebs  
```