### PR TITLE
Replaced static storage capacity value with a environment variable in…

### DIFF
--- a/apps/prometheus/deployers/prometheus.yml
+++ b/apps/prometheus/deployers/prometheus.yml
@@ -51,7 +51,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5G
+      storage: volume-capacity
 ---
 apiVersion: v1
 kind: Service

--- a/apps/prometheus/deployers/run_litmus_test.yml
+++ b/apps/prometheus/deployers/run_litmus_test.yml
@@ -25,8 +25,8 @@ spec:
             value: default
 
           - name: PROVIDER_STORAGE_CLASS
-            # Supported values: openebs-standard, local-storage
-            value: cstor-memcheck
+            # use any openebs supported storage class
+            value: openebs-cstor-sparse
 
           - name: APP_PVC
             value: 'prometheus-claim'
@@ -42,6 +42,9 @@ spec:
             # Use 'deprovision' for app-clean up
           - name: ACTION
             value: provision 
+          
+          - name: VOLUME_CAPACITY
+            value: "25G"
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./prometheus/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]

--- a/apps/prometheus/deployers/test.yml
+++ b/apps/prometheus/deployers/test.yml
@@ -21,6 +21,12 @@
          ## Actual test
          ## Creating namespaces and making the application for deployment
             - include_tasks: /common/utils/pre_create_app_deploy.yml
+            
+            - name: Replace the storage capacity placeholder
+              replace:
+                path: "{{ application_deployment }}"
+                regexp: volume-capacity
+                replace: "{{ lookup('env','VOLUME_CAPACITY') }}"
 
          ## Deploying the application
             - include_tasks: /common/utils/deploy_single_app.yml

--- a/apps/prometheus/deployers/test_vars.yml
+++ b/apps/prometheus/deployers/test_vars.yml
@@ -1,4 +1,4 @@
-# Test-specific parametres
+# Test-specific parameters
 operator_ns: openebs
 application_deployment: prometheus.yml
 app_ns: "{{ lookup('env','APP_NAMESPACE') }}"


### PR DESCRIPTION
* This PR contains some added functionality to existing files in order to set the size of the volume
* This PR fixes some issues regarding deployment of prometheus. It obtains volume capacity from user 
 as env and executes the same.
* Also removed the typo in the vars file.

Below are the prometheus litmus book logs for your reference:
```
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
 [WARNING]: Found variable using reserved name: action

PLAY [localhost] ***************************************************************
2019-04-05T09:05:13.429532 (delta: 0.061537)         elapsed: 0.061537 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-04-05T09:05:13.443148 (delta: 0.01356)         elapsed: 0.075153 ********* 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-04-05T09:05:22.343792 (delta: 8.900624)         elapsed: 8.975797 ******** 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-04-05T09:05:22.415920 (delta: 0.072085)         elapsed: 9.047925 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-04-05T09:05:22.474908 (delta: 0.05894)         elapsed: 9.106913 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-04-05T09:05:22.532346 (delta: 0.057388)         elapsed: 9.164351 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-04-05T09:05:22.623154 (delta: 0.090759)         elapsed: 9.255159 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "8d34e98f66235fb9c3570a618810bfbb97f90cca", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "279779df6782cc15347dd36901dad868", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1554455122.68-131404384150298/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-04-05T09:05:23.438159 (delta: 0.814957)         elapsed: 10.070164 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.056114", "end": "2019-04-05 09:05:24.891966", "rc": 0, "start": "2019-04-05 09:05:23.835852", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: prometheus-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: prometheus-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-04-05T09:05:24.943973 (delta: 1.505726)         elapsed: 11.575978 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.408154", "end": "2019-04-05 09:05:26.540439", "failed_when_result": false, "rc": 0, "start": "2019-04-05 09:05:25.132285", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/prometheus-deployment configured", "stdout_lines": ["litmusresult.litmus.io/prometheus-deployment configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-04-05T09:05:26.604676 (delta: 1.660655)         elapsed: 13.236681 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-04-05T09:05:26.654529 (delta: 0.049798)         elapsed: 13.286534 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-04-05T09:05:26.701140 (delta: 0.046548)         elapsed: 13.333145 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-04-05T09:05:26.757501 (delta: 0.056305)         elapsed: 13.389506 ******* 
included: /common/utils/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
2019-04-05T09:05:26.870341 (delta: 0.112789)         elapsed: 13.502346 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse", "delta": "0:00:01.052835", "end": "2019-04-05 09:05:28.136283", "rc": 0, "start": "2019-04-05 09:05:27.083448", "stderr": "", "stderr_lines": [], "stdout": "NAME                   PROVISIONER                    AGE\nopenebs-cstor-sparse   openebs.io/provisioner-iscsi   7d", "stdout_lines": ["NAME                   PROVISIONER                    AGE", "openebs-cstor-sparse   openebs.io/provisioner-iscsi   7d"]}

TASK [Replace the pvc placeholder with provider] *******************************
2019-04-05T09:05:28.192258 (delta: 1.321864)         elapsed: 14.824263 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
2019-04-05T09:05:28.636078 (delta: 0.443763)         elapsed: 15.268083 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-04-05T09:05:28.888430 (delta: 0.2523)         elapsed: 15.520435 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application label values from env] *******************************
2019-04-05T09:05:28.952879 (delta: 0.064392)         elapsed: 15.584884 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "prometheus"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-04-05T09:05:29.045817 (delta: 0.092888)         elapsed: 15.677822 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "5 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
2019-04-05T09:05:29.300803 (delta: 0.25492)         elapsed: 15.932808 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-04-05T09:05:29.365918 (delta: 0.065063)         elapsed: 15.997923 ******* 
included: /common/utils/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-04-05T09:05:29.464103 (delta: 0.098135)         elapsed: 16.096108 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.042164", "end": "2019-04-05 09:05:30.757729", "rc": 0, "start": "2019-04-05 09:05:29.715565", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-ns\ndefault\ne2e\ngitlab-runner\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console", "stdout_lines": ["app-busybox-ns", "default", "e2e", "gitlab-runner", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console"]}

TASK [Create test specific namespace.] *****************************************
2019-04-05T09:05:30.811675 (delta: 1.347516)         elapsed: 17.44368 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-prometheus", "delta": "0:00:01.042620", "end": "2019-04-05 09:05:32.072479", "rc": 0, "start": "2019-04-05 09:05:31.029859", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-prometheus created", "stdout_lines": ["namespace/app-prometheus created"]}

TASK [include_tasks] ***********************************************************
2019-04-05T09:05:32.124351 (delta: 1.312626)         elapsed: 18.756356 ******* 
included: /common/utils/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-04-05T09:05:32.216799 (delta: 0.092397)         elapsed: 18.848804 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-prometheus -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.165153", "end": "2019-04-05 09:05:33.587731", "rc": 0, "start": "2019-04-05 09:05:32.422578", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Replace the storage capacity placeholder] ********************************
2019-04-05T09:05:33.648603 (delta: 1.431755)         elapsed: 20.280608 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-04-05T09:05:33.898463 (delta: 0.249808)         elapsed: 20.530468 ******* 
included: /common/utils/deploy_single_app.yml for 127.0.0.1

TASK [Deploying prometheus] ****************************************************
2019-04-05T09:05:34.023561 (delta: 0.125046)         elapsed: 20.655566 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f prometheus.yml -n app-prometheus", "delta": "0:00:01.508494", "end": "2019-04-05 09:05:35.737727", "rc": 0, "start": "2019-04-05 09:05:34.229233", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/prometheus created\npersistentvolumeclaim/prometheus-claim created\nservice/prometheus created", "stdout_lines": ["deployment.apps/prometheus created", "persistentvolumeclaim/prometheus-claim created", "service/prometheus created"]}

TASK [include_tasks] ***********************************************************
2019-04-05T09:05:35.795460 (delta: 1.77183)         elapsed: 22.427465 ******** 
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
2019-04-05T09:05:35.905775 (delta: 0.110248)         elapsed: 22.53778 ******** 
FAILED - RETRYING: Get the container status of application. (150 retries left).
FAILED - RETRYING: Get the container status of application. (149 retries left).
FAILED - RETRYING: Get the container status of application. (148 retries left).
FAILED - RETRYING: Get the container status of application. (147 retries left).
FAILED - RETRYING: Get the container status of application. (146 retries left).
FAILED - RETRYING: Get the container status of application. (145 retries left).
FAILED - RETRYING: Get the container status of application. (144 retries left).
FAILED - RETRYING: Get the container status of application. (143 retries left).
FAILED - RETRYING: Get the container status of application. (142 retries left).
FAILED - RETRYING: Get the container status of application. (141 retries left).
FAILED - RETRYING: Get the container status of application. (140 retries left).
FAILED - RETRYING: Get the container status of application. (139 retries left).
FAILED - RETRYING: Get the container status of application. (138 retries left).
FAILED - RETRYING: Get the container status of application. (137 retries left).
FAILED - RETRYING: Get the container status of application. (136 retries left).
FAILED - RETRYING: Get the container status of application. (135 retries left).
FAILED - RETRYING: Get the container status of application. (134 retries left).
FAILED - RETRYING: Get the container status of application. (133 retries left).
FAILED - RETRYING: Get the container status of application. (132 retries left).
FAILED - RETRYING: Get the container status of application. (131 retries left).
FAILED - RETRYING: Get the container status of application. (130 retries left).
changed: [127.0.0.1] => {"attempts": 22, "changed": true, "cmd": "kubectl get pod -n app-prometheus -l name=\"prometheus\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.141921", "end": "2019-04-05 09:06:47.718000", "rc": 0, "start": "2019-04-05 09:06:46.576079", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-04-05T09:06:46Z]]", "stdout_lines": ["map[running:map[startedAt:2019-04-05T09:06:46Z]]"]}

TASK [Checking prometheus pod is in running state] *****************************
2019-04-05T09:06:47.782662 (delta: 71.876828)         elapsed: 94.414667 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-prometheus -o jsonpath='{.items[?(@.metadata.labels.name==\"prometheus\")].status.phase}'", "delta": "0:00:01.070148", "end": "2019-04-05 09:06:49.055310", "rc": 0, "start": "2019-04-05 09:06:47.985162", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
2019-04-05T09:06:49.127314 (delta: 1.344588)         elapsed: 95.759319 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-04-05T09:06:49.201595 (delta: 0.074209)         elapsed: 95.8336 ********* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Deprovisioning the Application] ******************************************
2019-04-05T09:06:49.303516 (delta: 0.101859)         elapsed: 95.935521 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-04-05T09:06:49.371150 (delta: 0.067576)         elapsed: 96.003155 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-04-05T09:06:49.444915 (delta: 0.073704)         elapsed: 96.07692 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-04-05T09:06:49.536065 (delta: 0.091089)         elapsed: 96.16807 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-04-05T09:06:49.586690 (delta: 0.050565)         elapsed: 96.218695 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-04-05T09:06:49.635467 (delta: 0.04872)         elapsed: 96.267472 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-04-05T09:06:49.685186 (delta: 0.049662)         elapsed: 96.317191 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "ed42cf3bf2b6454e836fc742f64dd77c7bcf4861", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "915c620161e6dace4ecd5d2ec94d5e8d", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1554455209.74-205950209083409/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-04-05T09:06:51.994830 (delta: 2.309588)         elapsed: 98.626835 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.030014", "end": "2019-04-05 09:06:53.225376", "rc": 0, "start": "2019-04-05 09:06:52.195362", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: prometheus-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: prometheus-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-04-05T09:06:53.285701 (delta: 1.290799)         elapsed: 99.917706 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.240308", "end": "2019-04-05 09:06:55.716012", "failed_when_result": false, "rc": 0, "start": "2019-04-05 09:06:53.475704", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/prometheus-deployment configured", "stdout_lines": ["litmusresult.litmus.io/prometheus-deployment configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=28   changed=17   unreachable=0    failed=0   

2019-04-05T09:06:55.772949 (delta: 2.487192)         elapsed: 102.404954 ****** 
=============================================================================== 
```
