### PR TITLE
feat[litmus]: LitmusBook for clone in snapshot rebuild scenarios

### DIFF
--- a/experiments/functional/clone-snapshot-rebuild/busybox.j2
+++ b/experiments/functional/clone-snapshot-rebuild/busybox.j2
@@ -1,0 +1,26 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ clone_app }}
+  labels:
+    name: {{ clone_app }}
+spec:
+  template:
+    metadata:
+      labels:
+        name: {{ clone_app }}
+    spec:
+      containers:
+      - name: {{ clone_app }}
+        imagePullPolicy: IfNotPresent
+        image: busybox
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do sleep 10;done"]
+        env:
+        volumeMounts:
+        - name: {{ clone_app }}
+          mountPath: /busybox
+      volumes:
+      - name: {{ clone_app }}
+        persistentVolumeClaim:
+          claimName: {{ clone_claim_name }}

--- a/experiments/functional/clone-snapshot-rebuild/chaosutil.j2
+++ b/experiments/functional/clone-snapshot-rebuild/chaosutil.j2
@@ -1,0 +1,11 @@
+{% if clone_action is defined and clone_action == 'during-rebuild' %}
+  funcutil: kubectl/k8s_snapshot_clone/clone_during_rebuild.yml
+{% endif %}
+{% if clone_action is defined and clone_action == 'pre-rebuild' %}
+  funcutil: kubectl/k8s_snapshot_clone/clone_pre_rebuild.yml
+{% endif %}
+{% if clone_action is defined and clone_action == 'post-rebuild' %}
+  funcutil: kubectl/k8s_snapshot_clone/clone_post_rebuild.yml  
+{% endif %}
+
+

--- a/experiments/functional/clone-snapshot-rebuild/run_litmus_test.yml
+++ b/experiments/functional/clone-snapshot-rebuild/run_litmus_test.yml
@@ -1,0 +1,58 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: litmus-k8s-snap-rebuild-clone-
+  namespace: litmus
+spec:
+  template:
+    metadata:
+      name: litmus
+      labels:
+        app: k8s-snap-rebuild-clone
+
+    spec:
+      serviceAccountName: litmus
+      restartPolicy: Never
+      containers:
+      - name: ansibletest
+        image: openebs/ansible-runner:ci
+        imagePullPolicy: Always
+
+        env:
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_LABEL
+            value: app=busybox-sts
+
+            # Application pvc
+          - name: APP_PVC
+            value: openebs-busybox
+
+            # Application namespace
+          - name: APP_NAMESPACE
+            value: app-busybox-ns
+
+          - name: PROVIDER_STORAGE_CLASS
+            value: openebs-snapshot-promoter
+
+          - name: SNAPSHOT_NAME
+            value: busybox-snap
+
+          - name: CLONE_VOL_CLAIM
+            value: post-rebuild-clone-claim
+
+          - name: CLONE_APP_NAME
+            value: busybox-clone
+
+            # clone action 
+          - name: CLONE_ACTION
+            # Supported values: post-rebuild,pre-rebuild,during-rebuild
+            value: "post-rebuild"
+
+          - name: CAPACITY
+            value: 5G            
+
+        command: ["/bin/bash"]
+        args: ["-c", "ansible-playbook ./experiments/functional/clone-snapshot-rebuild/test.yml -i /etc/ansible/hosts -vv; exit 0"]

--- a/experiments/functional/clone-snapshot-rebuild/test.yml
+++ b/experiments/functional/clone-snapshot-rebuild/test.yml
@@ -1,0 +1,286 @@
+---
+#Description: Creation of volume snapshot and clone in rebuild scenario.
+#Author: sathyaseelan
+
+########################################################################################
+#Steps:                                                                                #
+#1) Creating LitmusResult CR for updating test result.                                 #
+#2) Checking if the application is running in k8s cluster.                             #
+#3) Obtain the cstor sparse pool replica details using corresponding utility           #
+#4) Dumping data into the application                                                  #
+#5) Select one of the replicas.                                                        #
+#6) Introduce packet drop in the selected replica.                                     #
+#7) Create snapshot using corresponding funclib utility.                               #
+#8) Verify snapshot creation.                                                           #
+#9) Perform the clone  scenarios using corresponding utility                           #
+#      I) clone snapshot after successful rebuild.                                     #
+#      II) clone snapshot before rebuild begins.                                       #
+#      III) clone snapshot while rebuild is in progress.                               #
+#10) Ensure if the clone is created successfully.                                      #
+#11) Verify the snapshot rebuild is successful.                                        #
+#12) Verify if the storage replicas are synchronised.                                  #
+#13) Create new application pod using the cloned volume.                               #
+#14) Verify the data in the new volume and compare it with the original one.           #
+#15) Update the LitmusResult CR.                                                       #
+########################################################################################
+
+- hosts: localhost
+  connection: local
+
+  vars_files:
+    - test_vars.yml
+
+  tasks:
+    - block:
+
+          ## Generating the testname.
+        - include_tasks: /common/utils/create_testname.yml
+
+           ## RECORD START-OF-TEST IN LITMUS RESULT CR
+        - include_tasks: "/common/utils/update_litmus_result_resource.yml"
+          vars:
+            status: 'SOT'
+
+        - name: Apply the litmus result CR
+          command: kubectl apply -f litmus-result.yaml
+          register: lr_status
+          failed_when: "lr_status.rc != 0"
+
+        - name: Check whether the snapshot specific storage class is created.
+          command: kubectl get sc {{ lookup('env','PROVIDER_STORAGE_CLASS') }}
+          register: result
+
+        - name: Checking if the application is running.
+          shell: >
+            kubectl get pods -n {{ namespace }} --no-headers 
+            -l {{ application_label }} -o custom-columns=:status.phase
+          args:
+            executable: /bin/bash
+          register: result
+          until: "'Running' in result.stdout"
+          delay: 30
+          retries: 15
+
+        - name: Identify the chaos util to be invoked
+          template:
+            src: chaosutil.j2
+            dest: chaosutil.yml
+
+        - include_vars:
+            file: chaosutil.yml
+
+        - name: Record the chaos util path
+          set_fact:
+            chaos_util_path: "/funclib/{{ funcutil }}"
+
+          ## Obtain cstor replica pods
+        - include_tasks: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml
+          vars:
+            app_ns: "{{ namespace }}"
+            pvc_name: "{{ app_pvc }}"
+            app_label: "{{ application_label }}"
+            ns: "{{ operator_ns }}"
+
+        - name: Display details
+          debug:
+            msg:
+              - "cstor_replicas: {{ cstor_replicas_pod }}"
+              - "Pv_name: {{ pv.stdout }}"
+
+        - name: Obtaining the application pod name.
+          shell: >
+            kubectl get pods -n {{ namespace }} -l {{ application_label }} 
+            --no-headers -o custom-columns=:metadata.name
+          args:
+            executable: /bin/bash
+          register: app_pod
+
+        - name: Recording application pod name in a variable.
+          set_fact:
+            app_pod_name: "{{ app_pod.stdout}}"
+
+        - name: Run dd on the application
+          shell: >
+            kubectl exec -it {{ app_pod_name }} -n {{ namespace }} 
+            -- sh -c "cd /busybox; dd if=/dev/urandom of=file1 bs=4k count=50000"
+          args:
+            executable: /bin/bash
+
+        - name: Perform filesystem sync on busybox pod before creating snapshot.
+          shell: >
+            kubectl exec {{ app_pod_name }} -n {{ namespace }} -- sh -c "sync;sync;sync"
+          args:
+            executable: /bin/bash
+
+        - name: check the md5sum of the file
+          shell: kubectl exec -it {{ app_pod_name }} -n {{ namespace }} -- sh -c "cd /busybox; md5sum file1"
+          args:
+            executable: /bin/bash
+          register: app_check
+
+           ##Select any cstor replica pod to inject packet loss
+        - set_fact:
+            replica_pod: "{{ cstor_replicas_pod | list | first }}"
+
+           ## Inducing the packet drop on the above pool pod.
+        - include_tasks: "/chaoslib/openebs/inject_packet_loss_tc.yml"
+          vars:
+            status: "induce"
+            target_pod: "{{ replica_pod }}"
+            operator_namespace: "{{ operator_ns }}"
+
+           ## If there are no IOs happening on the volume, replica won't get disconnected
+        - name: Check if the targeted replica is disconnected.
+          shell: >
+            kubectl exec -it {{ cstor_target.stdout }} -n {{ operator_ns }} --container  cstor-istgt
+            -- istgtcontrol -q replica |json_pp | jq '.volumeStatus[0].replicaStatus[].Mode' | grep Healthy | wc -l
+          register: connected_replica
+          until: "(connected_replica.stdout|int) == ((healthy_pods.stdout|int) - 1)"
+          delay: 15
+          retries: 30
+
+        - name: Creating snapshot.
+          include_tasks: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml
+          vars:
+            app_ns: "{{ namespace }}"
+            pvc_name: "{{ app_pvc }}"
+
+        - name: Checking the snapshot status
+          include_tasks: /funclib/kubectl/k8s_snapshot_clone/snapshot_status.yml
+          vars:
+            app_ns: "{{ namespace }}"
+            snap_name: "{{ snapshot_name }}"
+            pvc_name: "{{ app_pvc }}"
+            action: 'Success'
+
+        - debug:
+            msg: "snapid_name: {{ snapid_name }}"
+
+        - name: Checking if the snapshot is not created in the degraded replica.
+          shell: >
+            kubectl exec -ti {{ replica_pod }} -n {{ operator_ns }} 
+            --container cstor-pool -- zfs list -t snapshot
+          args:
+            executable: /bin/bash
+          register: list_snap
+          failed_when: "snapid_name in list_snap.stdout"
+
+          # Perform the clone rebuild scenario from chos_util. 
+
+        - name: Perform the clone scenario using utils
+          include: "{{ chaos_util_path }}"
+          app_name: "{{ namespace }}"
+          target_ns: "{{ operator_ns }}"
+          tgt_rep_pod: "{{ replica_pod }}"
+          vol_capacity: "{{ volume_capacity }}"
+ 
+        - block:
+            - name: Check if the snapshot is being rebuilt.
+              shell: >
+                kubectl exec -it {{ replica_pod }} -n {{ operator_ns }} 
+                --container cstor-pool -- zfs list -t snapshot
+              args:
+                executable: /bin/bash
+              register: list_snap
+              until: "snapid_name in list_snap.stdout"
+              delay: 30
+              retries: 20
+    
+            - name: Check if the snapshot rebuild is successful.
+              shell: >
+                kubectl exec -ti {{ replica_pod }} -n {{ operator_ns }} -c cstor-pool
+                -- zfs stats |json_pp| grep "rebuildStatus" |awk -F ':' '{print $2}' | tr -d '"' | tr -d ','
+              args:
+                executable: /bin/bash
+              register: snap_result
+              until: "'DONE' in snap_result.stdout"
+              delay: 20
+              retries: 100
+
+          when: clone_action != 'post-rebuild'
+
+        - name: Obtaining new PV name from the pvc.
+          shell: >
+            kubectl get pvc {{ clone_claim_name }} -n {{ namespace }} 
+            -o custom-columns=:spec.volumeName --no-headers
+          args:
+            executable: /bin/bash
+          register: snap_pv
+
+        - name: check if the sync is completed in all the replicas.
+          shell: > 
+            kubectl exec -it {{ item }} -n {{ operator_ns }} 
+            --container cstor-pool -- zfs list | grep {{ snap_pv.stdout }}
+          args:
+            executable: /bin/bash
+          register: result
+          with_items:
+            - "{{ cstor_replicas_pod }}"
+          until: "snap_pv.stdout in result.stdout"
+          delay: 60
+          retries: 20
+
+        - name: Form a name for the clone application.
+          set_fact:
+            clone_app: "{{ cloned_app }}-{{ clone_action }}"
+
+        - name: Update the busybox deployment spec with the clone pvc.
+          template:
+            src: busybox.j2
+            dest: busybox.yml
+
+        - name: Deploy the application using snapped volume.
+          shell: kubectl apply -f busybox.yml -n {{ namespace }}
+          args:
+            executable: /bin/bash
+
+        - name: Check if the new application pod is started.
+          shell: kubectl get pods -n {{ namespace }} -l name={{ clone_app }}
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "'Running' in app_status.stdout"
+          delay: 60
+          retries: 10
+
+        - name: Obtaining the application pod name.
+          shell: >
+            kubectl get pods -n {{ namespace }} -l name={{ clone_app }} 
+            --no-headers -o custom-columns=:metadata.name
+          args:
+            executable: /bin/bash
+          register: new_pod_name
+
+        - name: check the md5sum of the file in cloned application.
+          shell: kubectl exec -it {{ new_pod_name.stdout }} -n {{ namespace }} -- sh -c "cd /busybox; md5sum file1"
+          args:
+            executable: /bin/bash
+          register: new_app_check
+          failed_when: new_app_check.stdout != app_check.stdout
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+        - set_fact:
+            flag: "Fail"
+
+      always:
+            ## RECORD END-OF-TEST IN LITMUS RESULT CR
+        - name: Generate the litmus result CR to reflect EOT (End of Test)
+          template:
+            src: /litmus-result.j2
+            dest: litmus-result.yaml
+          vars:
+            test: "{{ test_name }}"
+            app: "busybox"
+            chaostype: ""
+            phase: completed
+            verdict: "{{ flag }}"
+
+        - name: Apply the litmus result CR
+          shell: kubectl apply -f litmus-result.yaml
+          args:
+            executable: /bin/bash
+          register: lr_status
+          failed_when: "lr_status.rc != 0"

--- a/experiments/functional/clone-snapshot-rebuild/test_vars.yml
+++ b/experiments/functional/clone-snapshot-rebuild/test_vars.yml
@@ -1,0 +1,22 @@
+---
+test_name: k8s-snapshot-rebuild-clone
+
+application_label: "{{ lookup('env','APP_LABEL') }}"
+
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+app_pvc: "{{ lookup('env','APP_PVC') }}"
+
+snapshot_name: "{{ lookup('env','SNAPSHOT_NAME') }}"
+
+clone_claim_name: "{{ lookup('env','CLONE_VOL_CLAIM') }}"
+
+cloned_app: "{{ lookup('env','CLONE_APP_NAME') }}"
+
+operator_ns: openebs
+
+storage_class: "{{ lookup('env','PROVIDER_STORAGE_CLASS') }}"
+
+clone_action: "{{ lookup('env','CLONE_ACTION') }}"
+
+volume_capacity: "{{ lookup('env','CAPACITY') }}"

--- a/funclib/kubectl/k8s_snapshot_clone/clone_during_rebuild.yml
+++ b/funclib/kubectl/k8s_snapshot_clone/clone_during_rebuild.yml
@@ -27,3 +27,4 @@
           include_tasks: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml
           vars:
             app_ns: "{{ app_name }}"
+            capacity: "{{ vol_capacity }}"

--- a/funclib/kubectl/k8s_snapshot_clone/clone_post_rebuild.yml
+++ b/funclib/kubectl/k8s_snapshot_clone/clone_post_rebuild.yml
@@ -31,3 +31,4 @@
           include_tasks: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml
           vars:
             app_ns: "{{ app_name }}"
+            capacity: "{{ vol_capacity }}"

--- a/funclib/kubectl/k8s_snapshot_clone/clone_pre_rebuild.yml
+++ b/funclib/kubectl/k8s_snapshot_clone/clone_pre_rebuild.yml
@@ -3,6 +3,7 @@
           include_tasks: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml
           vars:
             app_ns: "{{ app_name }}"
+            capacity: "{{ vol_capacity }}"
 
           ## Removing the packet drop rule by including the relevant util..
         - include_tasks: "/chaoslib/openebs/inject_packet_loss_tc.yml"


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Litmusbook for taking clone in various snapshot rebuild scenarios.

```
ansible-playbook 2.7.8
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.15rc1 (default, Nov 12 2018, 14:31:15) [GCC 7.3.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
[DEPRECATION WARNING]: Specifying include variables at the top-level of the 
task is deprecated. Please see: 
https://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-
encouraging-reuse   for currently supported syntax regarding included files and
 variables. This feature will be removed in version 2.12. Deprecation warnings 
can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAYBOOK: test.yml *************************************************************
1 plays in ./experiments/functional/clone-snapshot-rebuild/test.yml

PLAY [localhost] ***************************************************************
2019-04-09T08:03:26.799099 (delta: 0.061995)         elapsed: 0.061995 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:27
2019-04-09T08:03:26.816058 (delta: 0.016881)         elapsed: 0.078954 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:37
2019-04-09T08:03:36.585878 (delta: 9.769786)         elapsed: 9.848774 ******** 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /common/utils/create_testname.yml:3
2019-04-09T08:03:36.742667 (delta: 0.15673)         elapsed: 10.005563 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /common/utils/create_testname.yml:7
2019-04-09T08:03:36.858525 (delta: 0.115745)         elapsed: 10.121421 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:40
2019-04-09T08:03:36.989468 (delta: 0.130836)         elapsed: 10.252364 ******* 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
task path: /common/utils/update_litmus_result_resource.yml:3
2019-04-09T08:03:37.178757 (delta: 0.189185)         elapsed: 10.441653 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "8ba546e006fe6715f5815bb9988c2a5ad5c2fb6f", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "2cce1039eb49bdab57c8b30f30a17dac", "mode": "0644", "owner": "root", "size": 427, "src": "/root/.ansible/tmp/ansible-tmp-1554797017.24-251983598587933/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:14
2019-04-09T08:03:38.001403 (delta: 0.822586)         elapsed: 11.264299 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.137685", "end": "2019-04-09 08:03:39.559293", "rc": 0, "start": "2019-04-09 08:03:38.421608", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: k8s-snapshot-rebuild-clone \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: k8s-snapshot-rebuild-clone ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:17
2019-04-09T08:03:39.617272 (delta: 1.615806)         elapsed: 12.880168 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.721399", "end": "2019-04-09 08:03:42.594829", "failed_when_result": false, "rc": 0, "start": "2019-04-09 08:03:39.873430", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/k8s-snapshot-rebuild-clone configured", "stdout_lines": ["litmusresult.litmus.io/k8s-snapshot-rebuild-clone configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /common/utils/update_litmus_result_resource.yml:27
2019-04-09T08:03:42.718312 (delta: 3.100982)         elapsed: 15.981208 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /common/utils/update_litmus_result_resource.yml:38
2019-04-09T08:03:42.823991 (delta: 0.105578)         elapsed: 16.086887 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /common/utils/update_litmus_result_resource.yml:41
2019-04-09T08:03:42.931097 (delta: 0.106967)         elapsed: 16.193993 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:44
2019-04-09T08:03:43.039283 (delta: 0.108086)         elapsed: 16.302179 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "apply", "-f", "litmus-result.yaml"], "delta": "0:00:01.415356", "end": "2019-04-09 08:03:44.837247", "failed_when_result": false, "rc": 0, "start": "2019-04-09 08:03:43.421891", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/k8s-snapshot-rebuild-clone unchanged", "stdout_lines": ["litmusresult.litmus.io/k8s-snapshot-rebuild-clone unchanged"]}

TASK [Check whether the snapshot specific storage class is created.] ***********
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:49
2019-04-09T08:03:44.899489 (delta: 1.8601)         elapsed: 18.162385 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": ["kubectl", "get", "sc", "openebs-snapshot-promoter"], "delta": "0:00:01.164439", "end": "2019-04-09 08:03:46.295217", "rc": 0, "start": "2019-04-09 08:03:45.130778", "stderr": "", "stderr_lines": [], "stdout": "NAME                        PROVISIONER                                                AGE\nopenebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   10d", "stdout_lines": ["NAME                        PROVISIONER                                                AGE", "openebs-snapshot-promoter   volumesnapshot.external-storage.k8s.io/snapshot-promoter   10d"]}

TASK [Checking if the application is running.] *********************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:53
2019-04-09T08:03:46.405877 (delta: 1.506318)         elapsed: 19.668773 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns --no-headers -l app=busybox-sts -o custom-columns=:status.phase", "delta": "0:00:01.141602", "end": "2019-04-09 08:03:47.808144", "rc": 0, "start": "2019-04-09 08:03:46.666542", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:64
2019-04-09T08:03:47.874566 (delta: 1.468588)         elapsed: 21.137462 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "67a60ddeacfef709d3cf684f9a407fbd3c23a6a0", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "6db6d5160e7a308e0e1d7cb7e030848a", "mode": "0644", "owner": "root", "size": 66, "src": "/root/.ansible/tmp/ansible-tmp-1554797027.93-242935343103849/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:69
2019-04-09T08:03:48.407243 (delta: 0.532614)         elapsed: 21.670139 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"funcutil": "kubectl/k8s_snapshot_clone/clone_post_rebuild.yml"}, "ansible_included_var_files": ["/experiments/functional/clone-snapshot-rebuild/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:72
2019-04-09T08:03:48.554872 (delta: 0.147538)         elapsed: 21.817768 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/funclib/kubectl/k8s_snapshot_clone/clone_post_rebuild.yml"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:77
2019-04-09T08:03:48.641170 (delta: 0.086244)         elapsed: 21.904066 ******* 
included: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml for 127.0.0.1

TASK [Display details] *********************************************************
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:2
2019-04-09T08:03:48.794810 (delta: 0.15358)         elapsed: 22.057706 ******** 
ok: [127.0.0.1] => {
    "msg": [
        "app_ns: app-busybox-ns", 
        "pvc_name: openebs-busybox", 
        "app_label: app=busybox-sts", 
        "ns: openebs"
    ]
}

TASK [Checking if the application is up and running.] **************************
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:11
2019-04-09T08:03:48.903974 (delta: 0.109098)         elapsed: 22.16687 ******** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o custom-columns=:status.phase", "delta": "0:00:01.093931", "end": "2019-04-09 08:03:50.215127", "rc": 0, "start": "2019-04-09 08:03:49.121196", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Derive PV name from PVC] *************************************************
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:20
2019-04-09T08:03:50.343319 (delta: 1.439256)         elapsed: 23.606215 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc openebs-busybox -n app-busybox-ns --no-headers -o custom-columns=:spec.volumeName", "delta": "0:00:01.187212", "end": "2019-04-09 08:03:51.885762", "rc": 0, "start": "2019-04-09 08:03:50.698550", "stderr": "", "stderr_lines": [], "stdout": "pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9", "stdout_lines": ["pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9"]}

TASK [Derive the cstor target using pv.] ***************************************
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:28
2019-04-09T08:03:51.963005 (delta: 1.619589)         elapsed: 25.225901 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs -l openebs.io/persistent-volume=pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9 -o custom-columns=:metadata.name --no-headers", "delta": "0:00:01.323963", "end": "2019-04-09 08:03:53.557513", "rc": 0, "start": "2019-04-09 08:03:52.233550", "stderr": "", "stderr_lines": [], "stdout": "pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9-target-56cf657db4nvhkg", "stdout_lines": ["pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9-target-56cf657db4nvhkg"]}

TASK [Obtaining the consistency factor of cstor target.] ***********************
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:35
2019-04-09T08:03:53.626162 (delta: 1.663045)         elapsed: 26.889058 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9-target-56cf657db4nvhkg -n openebs --container cstor-istgt -- cat /usr/local/etc/istgt/istgt.conf | grep -A8 \"pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9\" | grep ConsistencyFactor| cut -d ' ' -f 4", "delta": "0:00:01.559549", "end": "2019-04-09 08:03:55.507764", "rc": 0, "start": "2019-04-09 08:03:53.948215", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "2", "stdout_lines": ["2"]}

TASK [Create an empty list of replica pods.] ***********************************
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:43
2019-04-09T08:03:55.619514 (delta: 1.993292)         elapsed: 28.88241 ******** 
ok: [127.0.0.1] => {"ansible_facts": {"cstor_replicas_pod": []}, "changed": false}

TASK [Obtaining the pool deployments from cvr] *********************************
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:47
2019-04-09T08:03:55.794490 (delta: 0.174873)         elapsed: 29.057386 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9 --no-headers -o=jsonpath='{range .items[*]}{.metadata.labels.cstorpool\\.openebs\\.io\\/name}{\"\\n\"}{end}'", "delta": "0:00:01.099462", "end": "2019-04-09 08:03:57.118363", "rc": 0, "start": "2019-04-09 08:03:56.018901", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-2ho0\ncstor-sparse-pool-4igp\ncstor-sparse-pool-xh8q", "stdout_lines": ["cstor-sparse-pool-2ho0", "cstor-sparse-pool-4igp", "cstor-sparse-pool-xh8q"]}

TASK [Find the replication factor by getting count of pool deployment Create an empty list of replica pods.] ***
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:56
2019-04-09T08:03:57.178170 (delta: 1.383614)         elapsed: 30.441066 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replication_factor": "3"}, "changed": false}

TASK [Obtaining the replicasets corresponding to pool deployements.] ***********
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:60
2019-04-09T08:03:57.285472 (delta: 0.107235)         elapsed: 30.548368 ******* 
changed: [127.0.0.1] => (item=cstor-sparse-pool-2ho0) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-2ho0\")].metadata.name}'", "delta": "0:00:01.083042", "end": "2019-04-09 08:03:58.740291", "item": "cstor-sparse-pool-2ho0", "rc": 0, "start": "2019-04-09 08:03:57.657249", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-2ho0-7b695f86c6", "stdout_lines": ["cstor-sparse-pool-2ho0-7b695f86c6"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-4igp) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-4igp\")].metadata.name}'", "delta": "0:00:01.124159", "end": "2019-04-09 08:04:00.151854", "item": "cstor-sparse-pool-4igp", "rc": 0, "start": "2019-04-09 08:03:59.027695", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-4igp-7c5cff8cd7", "stdout_lines": ["cstor-sparse-pool-4igp-7c5cff8cd7"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-xh8q) => {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-xh8q\")].metadata.name}'", "delta": "0:00:01.379308", "end": "2019-04-09 08:04:01.817535", "item": "cstor-sparse-pool-xh8q", "rc": 0, "start": "2019-04-09 08:04:00.438227", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-xh8q-5f5cfb469", "stdout_lines": ["cstor-sparse-pool-xh8q-5f5cfb469"]}

TASK [Obtaining the pool pods] *************************************************
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:68
2019-04-09T08:04:01.887589 (delta: 4.602025)         elapsed: 35.150485 ******* 
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-2ho0-7b695f86c6', '_ansible_item_result': True, u'delta': u'0:00:01.083042', 'stdout_lines': [u'cstor-sparse-pool-2ho0-7b695f86c6'], '_ansible_item_label': u'cstor-sparse-pool-2ho0', u'end': u'2019-04-09 08:03:58.740291', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-2ho0")].metadata.name}\'', 'item': u'cstor-sparse-pool-2ho0', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-2ho0")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-04-09 08:03:57.657249', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-2ho0-7b695f86c6\")].metadata.name}'", "delta": "0:00:01.265279", "end": "2019-04-09 08:04:03.434534", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-2ho0\")].metadata.name}'", "delta": "0:00:01.083042", "end": "2019-04-09 08:03:58.740291", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-2ho0\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-2ho0", "rc": 0, "start": "2019-04-09 08:03:57.657249", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-2ho0-7b695f86c6", "stdout_lines": ["cstor-sparse-pool-2ho0-7b695f86c6"]}, "rc": 0, "start": "2019-04-09 08:04:02.169255", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-2ho0-7b695f86c6-k92vq", "stdout_lines": ["cstor-sparse-pool-2ho0-7b695f86c6-k92vq"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-4igp-7c5cff8cd7', '_ansible_item_result': True, u'delta': u'0:00:01.124159', 'stdout_lines': [u'cstor-sparse-pool-4igp-7c5cff8cd7'], '_ansible_item_label': u'cstor-sparse-pool-4igp', u'end': u'2019-04-09 08:04:00.151854', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-4igp")].metadata.name}\'', 'item': u'cstor-sparse-pool-4igp', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-4igp")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-04-09 08:03:59.027695', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-4igp-7c5cff8cd7\")].metadata.name}'", "delta": "0:00:01.190871", "end": "2019-04-09 08:04:04.947391", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-4igp\")].metadata.name}'", "delta": "0:00:01.124159", "end": "2019-04-09 08:04:00.151854", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-4igp\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-4igp", "rc": 0, "start": "2019-04-09 08:03:59.027695", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-4igp-7c5cff8cd7", "stdout_lines": ["cstor-sparse-pool-4igp-7c5cff8cd7"]}, "rc": 0, "start": "2019-04-09 08:04:03.756520", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx", "stdout_lines": ["cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx"]}
changed: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-xh8q-5f5cfb469', '_ansible_item_result': True, u'delta': u'0:00:01.379308', 'stdout_lines': [u'cstor-sparse-pool-xh8q-5f5cfb469'], '_ansible_item_label': u'cstor-sparse-pool-xh8q', u'end': u'2019-04-09 08:04:01.817535', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-xh8q")].metadata.name}\'', 'item': u'cstor-sparse-pool-xh8q', u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-xh8q")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-04-09 08:04:00.438227', '_ansible_ignore_errors': None}) => {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-xh8q-5f5cfb469\")].metadata.name}'", "delta": "0:00:01.388900", "end": "2019-04-09 08:04:06.580823", "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-xh8q\")].metadata.name}'", "delta": "0:00:01.379308", "end": "2019-04-09 08:04:01.817535", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-xh8q\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-xh8q", "rc": 0, "start": "2019-04-09 08:04:00.438227", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-xh8q-5f5cfb469", "stdout_lines": ["cstor-sparse-pool-xh8q-5f5cfb469"]}, "rc": 0, "start": "2019-04-09 08:04:05.191923", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-xh8q-5f5cfb469-gq62t", "stdout_lines": ["cstor-sparse-pool-xh8q-5f5cfb469-gq62t"]}

TASK [Build a list of replica pods.] *******************************************
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:76
2019-04-09T08:04:06.656992 (delta: 4.769328)         elapsed: 39.919888 ******* 
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-2ho0-7b695f86c6-k92vq', '_ansible_item_result': True, u'delta': u'0:00:01.265279', 'stdout_lines': [u'cstor-sparse-pool-2ho0-7b695f86c6-k92vq'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-2ho0-7b695f86c6', '_ansible_item_result': True, u'delta': u'0:00:01.083042', 'stdout_lines': [u'cstor-sparse-pool-2ho0-7b695f86c6'], '_ansible_item_label': u'cstor-sparse-pool-2ho0', u'end': u'2019-04-09 08:03:58.740291', '_ansible_no_log': False, u'start': u'2019-04-09 08:03:57.657249', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-2ho0")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-2ho0', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-2ho0")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-04-09 08:04:03.434534', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-2ho0-7b695f86c6")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-2ho0-7b695f86c6', '_ansible_item_result': True, u'delta': u'0:00:01.083042', 'stdout_lines': [u'cstor-sparse-pool-2ho0-7b695f86c6'], '_ansible_item_label': u'cstor-sparse-pool-2ho0', u'end': u'2019-04-09 08:03:58.740291', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-2ho0")].metadata.name}\'', u'start': u'2019-04-09 08:03:57.657249', 'item': u'cstor-sparse-pool-2ho0', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-2ho0")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-2ho0-7b695f86c6")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-04-09 08:04:02.169255', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-sparse-pool-2ho0-7b695f86c6-k92vq"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-2ho0-7b695f86c6\")].metadata.name}'", "delta": "0:00:01.265279", "end": "2019-04-09 08:04:03.434534", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-2ho0-7b695f86c6\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-2ho0\")].metadata.name}'", "delta": "0:00:01.083042", "end": "2019-04-09 08:03:58.740291", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-2ho0\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-2ho0", "rc": 0, "start": "2019-04-09 08:03:57.657249", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-2ho0-7b695f86c6", "stdout_lines": ["cstor-sparse-pool-2ho0-7b695f86c6"]}, "rc": 0, "start": "2019-04-09 08:04:02.169255", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-2ho0-7b695f86c6-k92vq", "stdout_lines": ["cstor-sparse-pool-2ho0-7b695f86c6-k92vq"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx', '_ansible_item_result': True, u'delta': u'0:00:01.190871', 'stdout_lines': [u'cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-4igp-7c5cff8cd7', '_ansible_item_result': True, u'delta': u'0:00:01.124159', 'stdout_lines': [u'cstor-sparse-pool-4igp-7c5cff8cd7'], '_ansible_item_label': u'cstor-sparse-pool-4igp', u'end': u'2019-04-09 08:04:00.151854', '_ansible_no_log': False, u'start': u'2019-04-09 08:03:59.027695', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-4igp")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-4igp', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-4igp")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-04-09 08:04:04.947391', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-4igp-7c5cff8cd7")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-4igp-7c5cff8cd7', '_ansible_item_result': True, u'delta': u'0:00:01.124159', 'stdout_lines': [u'cstor-sparse-pool-4igp-7c5cff8cd7'], '_ansible_item_label': u'cstor-sparse-pool-4igp', u'end': u'2019-04-09 08:04:00.151854', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-4igp")].metadata.name}\'', u'start': u'2019-04-09 08:03:59.027695', 'item': u'cstor-sparse-pool-4igp', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-4igp")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-4igp-7c5cff8cd7")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-04-09 08:04:03.756520', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-sparse-pool-2ho0-7b695f86c6-k92vq", "cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-4igp-7c5cff8cd7\")].metadata.name}'", "delta": "0:00:01.190871", "end": "2019-04-09 08:04:04.947391", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-4igp-7c5cff8cd7\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-4igp\")].metadata.name}'", "delta": "0:00:01.124159", "end": "2019-04-09 08:04:00.151854", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-4igp\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-4igp", "rc": 0, "start": "2019-04-09 08:03:59.027695", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-4igp-7c5cff8cd7", "stdout_lines": ["cstor-sparse-pool-4igp-7c5cff8cd7"]}, "rc": 0, "start": "2019-04-09 08:04:03.756520", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx", "stdout_lines": ["cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx"]}}
ok: [127.0.0.1] => (item={'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stdout': u'cstor-sparse-pool-xh8q-5f5cfb469-gq62t', '_ansible_item_result': True, u'delta': u'0:00:01.388900', 'stdout_lines': [u'cstor-sparse-pool-xh8q-5f5cfb469-gq62t'], '_ansible_item_label': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-xh8q-5f5cfb469', '_ansible_item_result': True, u'delta': u'0:00:01.379308', 'stdout_lines': [u'cstor-sparse-pool-xh8q-5f5cfb469'], '_ansible_item_label': u'cstor-sparse-pool-xh8q', u'end': u'2019-04-09 08:04:01.817535', '_ansible_no_log': False, u'start': u'2019-04-09 08:04:00.438227', u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-xh8q")].metadata.name}\'', 'failed': False, 'item': u'cstor-sparse-pool-xh8q', u'rc': 0, u'invocation': {u'module_args': {u'creates': None, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-xh8q")].metadata.name}\'', u'removes': None, u'argv': None, u'warn': True, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'end': u'2019-04-09 08:04:06.580823', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-xh8q-5f5cfb469")].metadata.name}\'', 'item': {'_ansible_parsed': True, 'stderr_lines': [], u'changed': True, u'stderr': u'', u'stdout': u'cstor-sparse-pool-xh8q-5f5cfb469', '_ansible_item_result': True, u'delta': u'0:00:01.379308', 'stdout_lines': [u'cstor-sparse-pool-xh8q-5f5cfb469'], '_ansible_item_label': u'cstor-sparse-pool-xh8q', u'end': u'2019-04-09 08:04:01.817535', '_ansible_no_log': False, 'failed': False, u'cmd': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-xh8q")].metadata.name}\'', u'start': u'2019-04-09 08:04:00.438227', 'item': u'cstor-sparse-pool-xh8q', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-xh8q")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, '_ansible_ignore_errors': None}, u'stderr': u'', u'rc': 0, u'invocation': {u'module_args': {u'warn': True, u'executable': None, u'_uses_shell': True, u'_raw_params': u'kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath=\'{.items[?(@.metadata.ownerReferences[0].name=="cstor-sparse-pool-xh8q-5f5cfb469")].metadata.name}\'', u'removes': None, u'argv': None, u'creates': None, u'chdir': None, u'stdin': None}}, u'start': u'2019-04-09 08:04:05.191923', '_ansible_ignore_errors': None}) => {"ansible_facts": {"cstor_replicas_pod": ["cstor-sparse-pool-2ho0-7b695f86c6-k92vq", "cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx", "cstor-sparse-pool-xh8q-5f5cfb469-gq62t"]}, "changed": false, "item": {"changed": true, "cmd": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-xh8q-5f5cfb469\")].metadata.name}'", "delta": "0:00:01.388900", "end": "2019-04-09 08:04:06.580823", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get pod --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-xh8q-5f5cfb469\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": {"changed": true, "cmd": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-xh8q\")].metadata.name}'", "delta": "0:00:01.379308", "end": "2019-04-09 08:04:01.817535", "failed": false, "invocation": {"module_args": {"_raw_params": "kubectl get rs --selector=app=cstor-pool -n openebs --no-headers -o=jsonpath='{.items[?(@.metadata.ownerReferences[0].name==\"cstor-sparse-pool-xh8q\")].metadata.name}'", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "warn": true}}, "item": "cstor-sparse-pool-xh8q", "rc": 0, "start": "2019-04-09 08:04:00.438227", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-xh8q-5f5cfb469", "stdout_lines": ["cstor-sparse-pool-xh8q-5f5cfb469"]}, "rc": 0, "start": "2019-04-09 08:04:05.191923", "stderr": "", "stderr_lines": [], "stdout": "cstor-sparse-pool-xh8q-5f5cfb469-gq62t", "stdout_lines": ["cstor-sparse-pool-xh8q-5f5cfb469-gq62t"]}}

TASK [Making sure number of healthy pods is equal to replication factor] *******
task path: /funclib/kubectl/k8s_snapshot_clone/snap_rebuild_prerequisites.yml:81
2019-04-09T08:04:06.848917 (delta: 0.191824)         elapsed: 40.111813 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9-target-56cf657db4nvhkg -n openebs --container cstor-istgt -- istgtcontrol -q replica |json_pp | jq '.volumeStatus[0].replicaStatus[].Mode' | grep Healthy | wc -l", "delta": "0:00:01.815549", "end": "2019-04-09 08:04:08.937307", "rc": 0, "start": "2019-04-09 08:04:07.121758", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "3", "stdout_lines": ["3"]}

TASK [Display details] *********************************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:84
2019-04-09T08:04:09.071480 (delta: 2.222503)         elapsed: 42.334376 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "cstor_replicas: [u'cstor-sparse-pool-2ho0-7b695f86c6-k92vq', u'cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx', u'cstor-sparse-pool-xh8q-5f5cfb469-gq62t']", 
        "Pv_name: pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9"
    ]
}

TASK [Obtaining the application pod name.] *************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:90
2019-04-09T08:04:09.202187 (delta: 0.130605)         elapsed: 42.465083 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l app=busybox-sts --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.355955", "end": "2019-04-09 08:04:10.791179", "rc": 0, "start": "2019-04-09 08:04:09.435224", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-754f6499df-ckmp2", "stdout_lines": ["app-busybox-754f6499df-ckmp2"]}

TASK [Recording application pod name in a variable.] ***************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:98
2019-04-09T08:04:10.892885 (delta: 1.690629)         elapsed: 44.155781 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_pod_name": "app-busybox-754f6499df-ckmp2"}, "changed": false}

TASK [Run dd on the application] ***********************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:102
2019-04-09T08:04:11.057840 (delta: 0.164861)         elapsed: 44.320736 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it app-busybox-754f6499df-ckmp2 -n app-busybox-ns -- sh -c \"cd /busybox; dd if=/dev/urandom of=file1 bs=4k count=50000\"", "delta": "0:00:03.315825", "end": "2019-04-09 08:04:14.585636", "rc": 0, "start": "2019-04-09 08:04:11.269811", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\n50000+0 records in\n50000+0 records out\n204800000 bytes (195.3MB) copied, 1.944186 seconds, 100.5MB/s", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "50000+0 records in", "50000+0 records out", "204800000 bytes (195.3MB) copied, 1.944186 seconds, 100.5MB/s"], "stdout": "", "stdout_lines": []}

TASK [Perform filesystem sync on busybox pod before creating snapshot.] ********
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:109
2019-04-09T08:04:14.722688 (delta: 3.664791)         elapsed: 47.985584 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec app-busybox-754f6499df-ckmp2 -n app-busybox-ns -- sh -c \"sync;sync;sync\"", "delta": "0:00:34.569285", "end": "2019-04-09 08:04:49.553916", "rc": 0, "start": "2019-04-09 08:04:14.984631", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [check the md5sum of the file] ********************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:115
2019-04-09T08:04:49.690265 (delta: 34.96747)         elapsed: 82.953161 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it app-busybox-754f6499df-ckmp2 -n app-busybox-ns -- sh -c \"cd /busybox; md5sum file1\"", "delta": "0:00:03.156975", "end": "2019-04-09 08:04:53.129871", "rc": 0, "start": "2019-04-09 08:04:49.972896", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "d78b8dd4cce34546843b9e614bdf97cb  file1", "stdout_lines": ["d78b8dd4cce34546843b9e614bdf97cb  file1"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:122
2019-04-09T08:04:53.200032 (delta: 3.509664)         elapsed: 86.462928 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"replica_pod": "cstor-sparse-pool-2ho0-7b695f86c6-k92vq"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:126
2019-04-09T08:04:53.330870 (delta: 0.130765)         elapsed: 86.593766 ******* 
included: /chaoslib/openebs/inject_packet_loss_tc.yml for 127.0.0.1

TASK [Checking whether tc is already installed] ********************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:9
2019-04-09T08:04:53.479853 (delta: 0.148902)         elapsed: 86.742749 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-2ho0-7b695f86c6-k92vq -n openebs --container cstor-pool -- bash -c \"which tc\"", "delta": "0:00:01.626126", "end": "2019-04-09 08:04:55.453846", "rc": 0, "start": "2019-04-09 08:04:53.827720", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "/sbin/tc", "stdout_lines": ["/sbin/tc"]}

TASK [Install tc command on targeted replica pod] ******************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:15
2019-04-09T08:04:55.543645 (delta: 2.063717)         elapsed: 88.806541 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Inject packet loss on targeted replica] **********************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:22
2019-04-09T08:04:55.660185 (delta: 0.11647)         elapsed: 88.923081 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-2ho0-7b695f86c6-k92vq -n openebs --container cstor-pool -- bash -c \"tc qdisc add dev eth0 root netem loss 100.00\"", "delta": "0:00:01.810206", "end": "2019-04-09 08:04:57.886816", "rc": 0, "start": "2019-04-09 08:04:56.076610", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Remove packet loss rule from targeted replica pod] ***********************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:32
2019-04-09T08:04:58.006166 (delta: 2.345877)         elapsed: 91.269062 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the targeted replica is disconnected.] **************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:133
2019-04-09T08:04:58.142289 (delta: 0.136024)         elapsed: 91.405185 ******* 
FAILED - RETRYING: Check if the targeted replica is disconnected. (30 retries left).
FAILED - RETRYING: Check if the targeted replica is disconnected. (29 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl exec -it pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9-target-56cf657db4nvhkg -n openebs --container cstor-istgt -- istgtcontrol -q replica |json_pp | jq '.volumeStatus[0].replicaStatus[].Mode' | grep Healthy | wc -l", "delta": "0:00:01.717081", "end": "2019-04-09 08:05:33.665571", "rc": 0, "start": "2019-04-09 08:05:31.948490", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "2", "stdout_lines": ["2"]}

TASK [Creating snapshot.] ******************************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:142
2019-04-09T08:05:33.787612 (delta: 35.645215)         elapsed: 127.050508 ***** 
included: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml for 127.0.0.1

TASK [Display details] *********************************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:14
2019-04-09T08:05:33.956668 (delta: 0.16896)         elapsed: 127.219564 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "app_ns: app-busybox-ns", 
        "pvc_name: openebs-busybox", 
        "snapshot_name: busybox-snap"
    ]
}

TASK [Update the snapshot template with the values provided.] ******************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:21
2019-04-09T08:05:34.058665 (delta: 0.101937)         elapsed: 127.321561 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "5064ebb769a9daf1bbb106bbd1bc4761e11fa1e3", "dest": "./snapshot.yml", "gid": 0, "group": "root", "md5sum": "c9cc09a50af34727d3ac06e3b60a7d6e", "mode": "0644", "owner": "root", "size": 186, "src": "/root/.ansible/tmp/ansible-tmp-1554797134.11-58897820538512/source", "state": "file", "uid": 0}

TASK [Creating the volume snapshot] ********************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_snapshot.yml:26
2019-04-09T08:05:34.496565 (delta: 0.43784)         elapsed: 127.759461 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl apply -f snapshot.yml", "delta": "0:00:02.503643", "end": "2019-04-09 08:05:37.240300", "rc": 0, "start": "2019-04-09 08:05:34.736657", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshot.volumesnapshot.external-storage.k8s.io/busybox-snap created", "stdout_lines": ["volumesnapshot.volumesnapshot.external-storage.k8s.io/busybox-snap created"]}

TASK [Checking the snapshot status] ********************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:148
2019-04-09T08:05:37.370813 (delta: 2.87419)         elapsed: 130.633709 ******* 
included: /funclib/kubectl/k8s_snapshot_clone/snapshot_status.yml for 127.0.0.1

TASK [Display details] *********************************************************
task path: /funclib/kubectl/k8s_snapshot_clone/snapshot_status.yml:2
2019-04-09T08:05:37.509821 (delta: 0.13891)         elapsed: 130.772717 ******* 
ok: [127.0.0.1] => {
    "msg": [
        "app_ns: app-busybox-ns", 
        "snap_name: busybox-snap", 
        "pvc_name: openebs-busybox"
    ]
}

TASK [Check if the snapshot is created successfully] ***************************
task path: /funclib/kubectl/k8s_snapshot_clone/snapshot_status.yml:10
2019-04-09T08:05:37.605243 (delta: 0.095366)         elapsed: 130.868139 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl describe volumesnapshot busybox-snap -n app-busybox-ns | grep Message", "delta": "0:00:01.278089", "end": "2019-04-09 08:05:39.129129", "rc": 0, "start": "2019-04-09 08:05:37.851040", "stderr": "", "stderr_lines": [], "stdout": "    Message:               Snapshot created successfully", "stdout_lines": ["    Message:               Snapshot created successfully"]}

TASK [Obtain the snapshot data name] *******************************************
task path: /funclib/kubectl/k8s_snapshot_clone/snapshot_status.yml:19
2019-04-09T08:05:39.221489 (delta: 1.616188)         elapsed: 132.484385 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get volumesnapshot busybox-snap -n app-busybox-ns -o jsonpath='{.spec.snapshotDataName}'", "delta": "0:00:02.167000", "end": "2019-04-09 08:05:41.756398", "failed_when_result": false, "rc": 0, "start": "2019-04-09 08:05:39.589398", "stderr": "", "stderr_lines": [], "stdout": "k8s-volume-snapshot-4249f09f-5a9e-11e9-b945-0a58ac17047c", "stdout_lines": ["k8s-volume-snapshot-4249f09f-5a9e-11e9-b945-0a58ac17047c"]}

TASK [Get the snapshot id from volumesnapshotdata] *****************************
task path: /funclib/kubectl/k8s_snapshot_clone/snapshot_status.yml:26
2019-04-09T08:05:41.889044 (delta: 2.667476)         elapsed: 135.15194 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get volumesnapshotdata k8s-volume-snapshot-4249f09f-5a9e-11e9-b945-0a58ac17047c -o jsonpath='{.spec.openebsVolume.snapshotId}'", "delta": "0:00:01.337760", "end": "2019-04-09 08:05:43.495315", "rc": 0, "start": "2019-04-09 08:05:42.157555", "stderr": "", "stderr_lines": [], "stdout": "pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9_busybox-snap_1554797136422892269", "stdout_lines": ["pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9_busybox-snap_1554797136422892269"]}

TASK [Form the snap name being rebuilt.] ***************************************
task path: /funclib/kubectl/k8s_snapshot_clone/snapshot_status.yml:32
2019-04-09T08:05:43.613983 (delta: 1.724826)         elapsed: 136.876879 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"snapid_name": "pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9@pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9_busybox-snap_1554797136422892269"}, "changed": false}

TASK [Check whether the status of snapshot] ************************************
task path: /funclib/kubectl/k8s_snapshot_clone/snapshot_status.yml:40
2019-04-09T08:05:43.798891 (delta: 0.184761)         elapsed: 137.061787 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [debug] *******************************************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:156
2019-04-09T08:05:43.850957 (delta: 0.052001)         elapsed: 137.113853 ****** 
ok: [127.0.0.1] => {
    "msg": "snapid_name: pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9@pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9_busybox-snap_1554797136422892269"
}

TASK [Checking if the snapshot is not created in the degraded replica.] ********
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:159
2019-04-09T08:05:43.940688 (delta: 0.08965)         elapsed: 137.203584 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -ti cstor-sparse-pool-2ho0-7b695f86c6-k92vq -n openebs --container cstor-pool -- zfs list -t snapshot", "delta": "0:00:01.697148", "end": "2019-04-09 08:05:45.866455", "failed_when_result": false, "rc": 0, "start": "2019-04-09 08:05:44.169307", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                            USED  AVAIL  REFER  MOUNTPOINT\ncstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-3caa957a-5a87-11e9-9b23-0050569866b9@pvc-3caa957a-5a87-11e9-9b23-0050569866b9_busybox-snap_1554787614452334657    46K      -   197M  -\ncstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-9e7e14a1-5a81-11e9-9b23-0050569866b9@pvc-9e7e14a1-5a81-11e9-9b23-0050569866b9_busybox-snap_1554785121746018772  45.5K      -   197M  -\ncstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-e29424f9-5a7c-11e9-9b23-0050569866b9@pvc-e29424f9-5a7c-11e9-9b23-0050569866b9_busybox-snap_1554784171498776700    39K      -   197M  -", "stdout_lines": ["NAME                                                                                                                                                            USED  AVAIL  REFER  MOUNTPOINT", "cstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-3caa957a-5a87-11e9-9b23-0050569866b9@pvc-3caa957a-5a87-11e9-9b23-0050569866b9_busybox-snap_1554787614452334657    46K      -   197M  -", "cstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-9e7e14a1-5a81-11e9-9b23-0050569866b9@pvc-9e7e14a1-5a81-11e9-9b23-0050569866b9_busybox-snap_1554785121746018772  45.5K      -   197M  -", "cstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-e29424f9-5a7c-11e9-9b23-0050569866b9@pvc-e29424f9-5a7c-11e9-9b23-0050569866b9_busybox-snap_1554784171498776700    39K      -   197M  -"]}

TASK [Perform the clone scenario using utils] **********************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:170
2019-04-09T08:05:45.951430 (delta: 2.010679)         elapsed: 139.214326 ****** 
included: /funclib/kubectl/k8s_snapshot_clone/clone_post_rebuild.yml for 127.0.0.1

TASK [include_tasks] ***********************************************************
task path: /funclib/kubectl/k8s_snapshot_clone/clone_post_rebuild.yml:4
2019-04-09T08:05:46.077783 (delta: 0.126295)         elapsed: 139.340679 ****** 
included: /chaoslib/openebs/inject_packet_loss_tc.yml for 127.0.0.1

TASK [Checking whether tc is already installed] ********************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:9
2019-04-09T08:05:46.171777 (delta: 0.093936)         elapsed: 139.434673 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Install tc command on targeted replica pod] ******************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:15
2019-04-09T08:05:46.236912 (delta: 0.065067)         elapsed: 139.499808 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Inject packet loss on targeted replica] **********************************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:22
2019-04-09T08:05:46.305178 (delta: 0.068201)         elapsed: 139.568074 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Remove packet loss rule from targeted replica pod] ***********************
task path: /chaoslib/openebs/inject_packet_loss_tc.yml:32
2019-04-09T08:05:46.378846 (delta: 0.073594)         elapsed: 139.641742 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-2ho0-7b695f86c6-k92vq -n openebs --container cstor-pool -- bash -c \"tc qdisc del dev eth0 root netem loss 100.00\"", "delta": "0:00:01.416435", "end": "2019-04-09 08:05:48.146719", "rc": 0, "start": "2019-04-09 08:05:46.730284", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "", "stdout_lines": []}

TASK [Check if the snapshot is being rebuilt.] *********************************
task path: /funclib/kubectl/k8s_snapshot_clone/clone_post_rebuild.yml:10
2019-04-09T08:05:48.234999 (delta: 1.856079)         elapsed: 141.497895 ****** 
FAILED - RETRYING: Check if the snapshot is being rebuilt. (20 retries left).
FAILED - RETRYING: Check if the snapshot is being rebuilt. (19 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-2ho0-7b695f86c6-k92vq -n openebs --container cstor-pool -- zfs list -t snapshot", "delta": "0:00:01.622883", "end": "2019-04-09 08:06:54.692888", "rc": 0, "start": "2019-04-09 08:06:53.070005", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "NAME                                                                                                                                                            USED  AVAIL  REFER  MOUNTPOINT\ncstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-3caa957a-5a87-11e9-9b23-0050569866b9@pvc-3caa957a-5a87-11e9-9b23-0050569866b9_busybox-snap_1554787614452334657    46K      -   197M  -\ncstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-9e7e14a1-5a81-11e9-9b23-0050569866b9@pvc-9e7e14a1-5a81-11e9-9b23-0050569866b9_busybox-snap_1554785121746018772  45.5K      -   197M  -\ncstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9@pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9_busybox-snap_1554797136422892269    33K      -   197M  -\ncstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-e29424f9-5a7c-11e9-9b23-0050569866b9@pvc-e29424f9-5a7c-11e9-9b23-0050569866b9_busybox-snap_1554784171498776700    39K      -   197M  -", "stdout_lines": ["NAME                                                                                                                                                            USED  AVAIL  REFER  MOUNTPOINT", "cstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-3caa957a-5a87-11e9-9b23-0050569866b9@pvc-3caa957a-5a87-11e9-9b23-0050569866b9_busybox-snap_1554787614452334657    46K      -   197M  -", "cstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-9e7e14a1-5a81-11e9-9b23-0050569866b9@pvc-9e7e14a1-5a81-11e9-9b23-0050569866b9_busybox-snap_1554785121746018772  45.5K      -   197M  -", "cstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9@pvc-aa9df18b-5a9d-11e9-9b23-0050569866b9_busybox-snap_1554797136422892269    33K      -   197M  -", "cstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-e29424f9-5a7c-11e9-9b23-0050569866b9@pvc-e29424f9-5a7c-11e9-9b23-0050569866b9_busybox-snap_1554784171498776700    39K      -   197M  -"]}

TASK [Check if the snapshot rebuild is successful.] ****************************
task path: /funclib/kubectl/k8s_snapshot_clone/clone_post_rebuild.yml:19
2019-04-09T08:06:54.754807 (delta: 66.519695)         elapsed: 208.017703 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl exec -ti cstor-sparse-pool-2ho0-7b695f86c6-k92vq -n openebs -c cstor-pool -- zfs stats |json_pp| grep \"rebuildStatus\" |awk -F ':' '{print $2}' | tr -d '\"' | tr -d ','", "delta": "0:00:01.695907", "end": "2019-04-09 08:06:56.706674", "rc": 0, "start": "2019-04-09 08:06:55.010767", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": " DONE\n INIT\n INIT\n INIT\n INIT\n INIT\n INIT\n INIT", "stdout_lines": [" DONE", " INIT", " INIT", " INIT", " INIT", " INIT", " INIT", " INIT"]}

TASK [Creating clone using snapshot after rebuild.] ****************************
task path: /funclib/kubectl/k8s_snapshot_clone/clone_post_rebuild.yml:30
2019-04-09T08:06:56.869378 (delta: 2.114513)         elapsed: 210.132274 ****** 
included: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml for 127.0.0.1

TASK [Update the clone creation template with the values provided.] ************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:22
2019-04-09T08:06:57.054235 (delta: 0.184751)         elapsed: 210.317131 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "62510b150b467bfa79c1d6ad83ff761c8363f09c", "dest": "./snapshot-claim.yml", "gid": 0, "group": "root", "md5sum": "a1833ef59b625008f3ef8230105794e1", "mode": "0644", "owner": "root", "size": 318, "src": "/root/.ansible/tmp/ansible-tmp-1554797217.11-190189492850902/source", "state": "file", "uid": 0}

TASK [Creating PVC from the snapshot] ******************************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:27
2019-04-09T08:06:57.493551 (delta: 0.439258)         elapsed: 210.756447 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f snapshot-claim.yml", "delta": "0:00:01.712649", "end": "2019-04-09 08:06:59.463090", "rc": 0, "start": "2019-04-09 08:06:57.750441", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim/post-rebuild-clone-claim created", "stdout_lines": ["persistentvolumeclaim/post-rebuild-clone-claim created"]}

TASK [Checking if the pvc is created successfully] *****************************
task path: /funclib/kubectl/k8s_snapshot_clone/create_clone.yml:32
2019-04-09T08:06:59.516446 (delta: 2.022833)         elapsed: 212.779342 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pvc -n app-busybox-ns | grep post-rebuild-clone-claim", "delta": "0:00:01.352338", "end": "2019-04-09 08:07:01.155736", "rc": 0, "start": "2019-04-09 08:06:59.803398", "stderr": "", "stderr_lines": [], "stdout": "post-rebuild-clone-claim   Bound    pvc-7320e345-5a9e-11e9-9b23-0050569866b9   5G         RWO            openebs-snapshot-promoter   2s", "stdout_lines": ["post-rebuild-clone-claim   Bound    pvc-7320e345-5a9e-11e9-9b23-0050569866b9   5G         RWO            openebs-snapshot-promoter   2s"]}

TASK [Check if the snapshot is being rebuilt.] *********************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:178
2019-04-09T08:07:01.237410 (delta: 1.720907)         elapsed: 214.500306 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the snapshot rebuild is successful.] ****************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:189
2019-04-09T08:07:01.318257 (delta: 0.080781)         elapsed: 214.581153 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtaining new PV name from the pvc.] *************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:202
2019-04-09T08:07:01.403816 (delta: 0.085482)         elapsed: 214.666712 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc post-rebuild-clone-claim -n app-busybox-ns -o custom-columns=:spec.volumeName --no-headers", "delta": "0:00:01.694554", "end": "2019-04-09 08:07:03.359697", "rc": 0, "start": "2019-04-09 08:07:01.665143", "stderr": "", "stderr_lines": [], "stdout": "pvc-7320e345-5a9e-11e9-9b23-0050569866b9", "stdout_lines": ["pvc-7320e345-5a9e-11e9-9b23-0050569866b9"]}

TASK [check if the sync is completed in all the replicas.] *********************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:210
2019-04-09T08:07:03.421192 (delta: 2.0173)         elapsed: 216.684088 ******** 
changed: [127.0.0.1] => (item=cstor-sparse-pool-2ho0-7b695f86c6-k92vq) => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-2ho0-7b695f86c6-k92vq -n openebs --container cstor-pool -- zfs list | grep pvc-7320e345-5a9e-11e9-9b23-0050569866b9", "delta": "0:00:01.600668", "end": "2019-04-09 08:07:05.226440", "item": "cstor-sparse-pool-2ho0-7b695f86c6-k92vq", "rc": 0, "start": "2019-04-09 08:07:03.625772", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "cstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-7320e345-5a9e-11e9-9b23-0050569866b9   512B  8.81G   197M  -", "stdout_lines": ["cstor-81787e51-59ed-11e9-9b23-0050569866b9/pvc-7320e345-5a9e-11e9-9b23-0050569866b9   512B  8.81G   197M  -"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx) => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx -n openebs --container cstor-pool -- zfs list | grep pvc-7320e345-5a9e-11e9-9b23-0050569866b9", "delta": "0:00:01.662834", "end": "2019-04-09 08:07:07.235175", "item": "cstor-sparse-pool-4igp-7c5cff8cd7-m2vxx", "rc": 0, "start": "2019-04-09 08:07:05.572341", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "cstor-81a21960-59ed-11e9-9b23-0050569866b9/pvc-7320e345-5a9e-11e9-9b23-0050569866b9                 512B  8.68G   197M  -\ncstor-81a21960-59ed-11e9-9b23-0050569866b9/pvc-7320e345-5a9e-11e9-9b23-0050569866b9_rebuild_clone     0B  8.68G   197M  -", "stdout_lines": ["cstor-81a21960-59ed-11e9-9b23-0050569866b9/pvc-7320e345-5a9e-11e9-9b23-0050569866b9                 512B  8.68G   197M  -", "cstor-81a21960-59ed-11e9-9b23-0050569866b9/pvc-7320e345-5a9e-11e9-9b23-0050569866b9_rebuild_clone     0B  8.68G   197M  -"]}
changed: [127.0.0.1] => (item=cstor-sparse-pool-xh8q-5f5cfb469-gq62t) => {"attempts": 1, "changed": true, "cmd": "kubectl exec -it cstor-sparse-pool-xh8q-5f5cfb469-gq62t -n openebs --container cstor-pool -- zfs list | grep pvc-7320e345-5a9e-11e9-9b23-0050569866b9", "delta": "0:00:01.541949", "end": "2019-04-09 08:07:09.114560", "item": "cstor-sparse-pool-xh8q-5f5cfb469-gq62t", "rc": 0, "start": "2019-04-09 08:07:07.572611", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "cstor-815954dc-59ed-11e9-9b23-0050569866b9/pvc-7320e345-5a9e-11e9-9b23-0050569866b9                 512B  8.81G   197M  -\ncstor-815954dc-59ed-11e9-9b23-0050569866b9/pvc-7320e345-5a9e-11e9-9b23-0050569866b9_rebuild_clone     0B  8.81G   197M  -", "stdout_lines": ["cstor-815954dc-59ed-11e9-9b23-0050569866b9/pvc-7320e345-5a9e-11e9-9b23-0050569866b9                 512B  8.81G   197M  -", "cstor-815954dc-59ed-11e9-9b23-0050569866b9/pvc-7320e345-5a9e-11e9-9b23-0050569866b9_rebuild_clone     0B  8.81G   197M  -"]}

TASK [Form a name for the clone application.] **********************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:223
2019-04-09T08:07:09.236305 (delta: 5.815054)         elapsed: 222.499201 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"clone_app": "busybox-clone-post-rebuild"}, "changed": false}

TASK [Update the busybox deployment spec with the clone pvc.] ******************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:227
2019-04-09T08:07:09.422945 (delta: 0.186551)         elapsed: 222.685841 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "744c6bb3e325033ccb13dfeabbd067e6aa91a22e", "dest": "./busybox.yml", "gid": 0, "group": "root", "md5sum": "9418ee9f609c19a226b009c42d87ace5", "mode": "0644", "owner": "root", "size": 674, "src": "/root/.ansible/tmp/ansible-tmp-1554797229.51-272302611972723/source", "state": "file", "uid": 0}

TASK [Deploy the application using snapped volume.] ****************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:232
2019-04-09T08:07:10.006879 (delta: 0.58379)         elapsed: 223.269775 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f busybox.yml -n app-busybox-ns", "delta": "0:00:01.520572", "end": "2019-04-09 08:07:11.772943", "rc": 0, "start": "2019-04-09 08:07:10.252371", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/busybox-clone-post-rebuild created", "stdout_lines": ["deployment.apps/busybox-clone-post-rebuild created"]}

TASK [Check if the new application pod is started.] ****************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:237
2019-04-09T08:07:11.856939 (delta: 1.85)         elapsed: 225.119835 ********** 
FAILED - RETRYING: Check if the new application pod is started. (10 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l name=busybox-clone-post-rebuild", "delta": "0:00:01.274728", "end": "2019-04-09 08:08:15.201785", "rc": 0, "start": "2019-04-09 08:08:13.927057", "stderr": "", "stderr_lines": [], "stdout": "NAME                                          READY   STATUS    RESTARTS   AGE\nbusybox-clone-post-rebuild-58cb845886-h44d4   1/1     Running   0          1m", "stdout_lines": ["NAME                                          READY   STATUS    RESTARTS   AGE", "busybox-clone-post-rebuild-58cb845886-h44d4   1/1     Running   0          1m"]}

TASK [Obtaining the application pod name.] *************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:246
2019-04-09T08:08:15.275550 (delta: 63.418505)         elapsed: 288.538446 ***** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n app-busybox-ns -l name=busybox-clone-post-rebuild --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.133534", "end": "2019-04-09 08:08:16.793062", "rc": 0, "start": "2019-04-09 08:08:15.659528", "stderr": "", "stderr_lines": [], "stdout": "busybox-clone-post-rebuild-58cb845886-h44d4", "stdout_lines": ["busybox-clone-post-rebuild-58cb845886-h44d4"]}

TASK [check the md5sum of the file in cloned application.] *********************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:254
2019-04-09T08:08:16.885007 (delta: 1.609389)         elapsed: 290.147903 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec -it busybox-clone-post-rebuild-58cb845886-h44d4 -n app-busybox-ns -- sh -c \"cd /busybox; md5sum file1\"", "delta": "0:00:07.526870", "end": "2019-04-09 08:08:24.842198", "failed_when_result": false, "rc": 0, "start": "2019-04-09 08:08:17.315328", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file"], "stdout": "d78b8dd4cce34546843b9e614bdf97cb  file1", "stdout_lines": ["d78b8dd4cce34546843b9e614bdf97cb  file1"]}

TASK [set_fact] ****************************************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:261
2019-04-09T08:08:24.941833 (delta: 8.056696)         elapsed: 298.204729 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:270
2019-04-09T08:08:25.081849 (delta: 0.139946)         elapsed: 298.344745 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "8b41592ab2e03e4299098f0397feba99ae8e956d", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "f18764fcd5985b4819e24a54c4b87ff9", "mode": "0644", "owner": "root", "size": 432, "src": "/root/.ansible/tmp/ansible-tmp-1554797305.21-227715598886011/source", "state": "file", "uid": 0}

TASK [Apply the litmus result CR] **********************************************
task path: /experiments/functional/clone-snapshot-rebuild/test.yml:281
2019-04-09T08:08:27.698459 (delta: 2.616512)         elapsed: 300.961355 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.499723", "end": "2019-04-09 08:08:29.498965", "failed_when_result": false, "rc": 0, "start": "2019-04-09 08:08:27.999242", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/k8s-snapshot-rebuild-clone configured", "stdout_lines": ["litmusresult.litmus.io/k8s-snapshot-rebuild-clone configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=68   changed=43   unreachable=0    failed=0   

2019-04-09T08:08:29.561315 (delta: 1.862784)         elapsed: 302.824211 ****** 
=============================================================================== 
```