### PR TITLE
Created a external liveness for busybox

### DIFF
--- a/apps/busybox/liveness/busybox_liveness.yml
+++ b/apps/busybox/liveness/busybox_liveness.yml
@@ -1,0 +1,82 @@
+---
+# Source: openebs/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: app-namespace
+  labels:
+    name: app-namespace
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-namespace
+  namespace: app-namespace
+  labels:
+    name: app-namespace
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: app-namespace
+  labels:
+    name: app-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: app-namespace
+subjects:
+- kind: ServiceAccount
+  name: app-namespace
+  namespace: app-namespace
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: busybox-liveness-
+  namespace: app-namespace
+spec:
+  template:
+    metadata:
+      name: busybox-liveness
+      namespace: app-namespace
+      labels:
+        liveness: busybox-liveness
+
+        # label used for mass-liveness check upon infra-chaos
+        infra-aid: liveness
+
+    spec:
+      serviceAccountName: app-namespace
+      restartPolicy: Never
+ 
+      containers:
+      - name: busybox-liveness  
+        image: openebs/busybox-liveness-client
+        imagePullPolicy: Always
+
+        env:
+
+          - name: LIVENESS_TIMEOUT_SECONDS
+            value: "liveness-timeout-seconds"
+
+          # number of retries when livenss-fails 
+          - name: LIVENESS_RETRY_COUNT
+            value: "liveness-retry-count"
+
+            # Namespace in which busybox is running
+          - name: NAMESPACE
+            value: app-namespace 
+
+          - name: POD_NAME
+            value: pod-name   
+
+        command: ["/bin/bash"]
+        args: ["-c", "./liveness.sh; exit 0"]

--- a/apps/busybox/liveness/run_litmus_test.yml
+++ b/apps/busybox/liveness/run_litmus_test.yml
@@ -2,16 +2,16 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: busybox-liveness-
+  generateName: litmus-busybox-liveness-
   namespace: litmus
 spec:
   activeDeadlineSeconds: 5400
   template:
     metadata:
-      name: busybox-liveness
+      name: litmus-busybox-liveness
       namespace: litmus
       labels:
-        liveness: busybox-liveness
+        liveness: litmus-busybox-liveness
 
         # label used for mass-liveness check upon infra-chaos
         infra-aid: liveness
@@ -33,16 +33,6 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
 
-        command: ["/bin/bash"]
-        args: ["-c", "ansible-playbook ./busybox/liveness/test.yml -i /etc/ansible/hosts -v; exit 0"]
-
-      - name: busybox-liveness  
-        image: ranjnshashank855/busybox-liveness-client
-        imagePullPolicy: Always
-
-        env:
-
-           
           - name: LIVENESS_TIMEOUT_SECONDS
             value: "10"
 
@@ -54,8 +44,12 @@ spec:
           - name: NAMESPACE
             value: app-busybox-ns 
 
-          - name: POD_NAME
-            value: busybox-0 
+          - name: APPLICATION_LABEL
+            value: 'app=busybox-sts'
 
         command: ["/bin/bash"]
-        args: ["-c", "./liveness.sh; exit 0"]
+        args: ["-c", "ansible-playbook ./busybox/liveness/test.yml -i /etc/ansible/hosts -v; exit 0"]
+
+           
+         
+

--- a/apps/busybox/liveness/test.yml
+++ b/apps/busybox/liveness/test.yml
@@ -24,19 +24,41 @@
           vars:
             status: 'SOT'
 
-        - name: Checking whether liveness container is running
-          shell: >
-            kubectl get pod {{ test_pod }} -n litmus 
-            -o jsonpath='{.status.containerStatuses[?(@.name=="busybox-liveness")].state}'
-          register: container_status
-          until: "'running' in container_status.stdout"
-          delay: 60
-          retries: 10
+        - name: Getting the application pod name
+          shell: kubectl get po -n {{ namespace }} -l {{ app_label }} -o jsonpath={.items[0].metadata.name}
+          register: pod_name
 
-        - name: Verifying whether liveness check is started successfully  
-          shell: kubectl logs {{ test_pod }} -n litmus -c busybox-liveness 
-          register: output
-          until: "liveness_log in output.stdout"
+        - name: Replacing the placeholder for pod-name
+          replace:
+            path: "{{ busybox_liveness }}"
+            regexp: "pod-name"
+            replace: "{{ pod_name.stdout }}"   
+
+        - name: Replacing the placeholder for namespace
+          replace:
+            path: "{{ busybox_liveness }}"
+            regexp: "app-namespace"
+            replace: "{{ namespace }}"   
+
+        - name: Replacing the placeholder for liveness-retry-count
+          replace:
+            path: "{{ busybox_liveness }}"
+            regexp: "liveness-retry-count"
+            replace: "{{ liveness_retry }}"   
+
+        - name: Replacing the placeholder for liveness-timeout
+          replace:
+            path: "{{ busybox_liveness }}"
+            regexp: "liveness-timeout-seconds"
+            replace: "{{ liveness_timeout }}"   
+
+        - name: Creating busybox-liveness job
+          shell: kubectl create -f {{ busybox_liveness }} 
+
+        - name: Verifying whether liveness pod is started successfully  
+          shell: kubectl get pod -n {{ namespace }} -l liveness=busybox-liveness -o jsonpath={.items[0].status.phase} 
+          register: pod_status
+          until: "'Running' in pod_status.stdout"
           delay: 60 
           retries: 20
 
@@ -54,12 +76,3 @@
           vars:
             status: 'EOT'
         
-        ## if flag=fail, task exits immediately; if flag=pass, runs indefinitely until liveness check ends.
-        - name: Run until liveness container is terminated
-          shell: |
-            cmd="kubectl get pod {{ test_pod }} -n litmus -o jsonpath='{.status.containerStatuses[?(@.name==\"busybox-liveness\")].state}'"
-            while true; do state=$(eval $cmd); rc=$?; if [[ $rc -eq 0 && ! $state =~ 'terminated' ]]; then sleep 1; else exit; fi; done
-          args:
-            executable: /bin/bash
-          register: output
-          when: flag == "Pass"

--- a/apps/busybox/liveness/vars.yml
+++ b/apps/busybox/liveness/vars.yml
@@ -1,3 +1,7 @@
 test_name: busybox-liveness
-test_pod: "{{ lookup('env','MY_POD_NAME') }}"
+namespace: "{{ lookup('env','NAMESPACE') }}"
+app_label: "{{ lookup('env','APPLICATION_LABEL') }}"
+busybox_liveness: busybox_liveness.yml
+liveness_retry: "{{ lookup('env','LIVENESS_RETRY_COUNT') }}"
+liveness_timeout: "{{ lookup('env','LIVENESS_TIMEOUT_SECONDS') }}"
 liveness_log: "liveness-running"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Creates a separate liveness job for busybox in application specific namespace.
 
**Following is the ansible log**:
```

PLAY [localhost] ***************************************************************
2019-04-09T09:41:27.076566 (delta: 0.062682)         elapsed: 0.062682 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-04-09T09:41:27.090948 (delta: 0.014325)         elapsed: 0.077064 ******** 
ok: [127.0.0.1]

TASK [Record test instance/run ID] *********************************************
2019-04-09T09:41:36.526562 (delta: 9.435593)         elapsed: 9.512678 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-04-09T09:41:36.619611 (delta: 0.093006)         elapsed: 9.605727 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-04-09T09:41:36.734416 (delta: 0.11473)         elapsed: 9.720532 ********* 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-04-09T09:41:36.945645 (delta: 0.211115)         elapsed: 9.931761 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "42145c7f2a9614dea70a5b418c60011cf39c45c4", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "bb5fa585c59969956fa1ec5a096acd24", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1554802897.01-176523122264808/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-04-09T09:41:37.830083 (delta: 0.884379)         elapsed: 10.816199 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.109588", "end": "2019-04-09 09:41:39.351783", "rc": 0, "start": "2019-04-09 09:41:38.242195", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: busybox-liveness \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: busybox-liveness ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-04-09T09:41:39.422079 (delta: 1.591919)         elapsed: 12.408195 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:02.066300", "end": "2019-04-09 09:41:41.784068", "failed_when_result": false, "rc": 0, "start": "2019-04-09 09:41:39.717768", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/busybox-liveness unchanged", "stdout_lines": ["litmusresult.litmus.io/busybox-liveness unchanged"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-04-09T09:41:41.936512 (delta: 2.514331)         elapsed: 14.922628 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-04-09T09:41:42.057820 (delta: 0.121199)         elapsed: 15.043936 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-04-09T09:41:42.176557 (delta: 0.118624)         elapsed: 15.162673 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Getting the application pod name] ****************************************
2019-04-09T09:41:42.232473 (delta: 0.055856)         elapsed: 15.218589 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get po -n app-busybox-ns -l app=busybox-sts -o jsonpath={.items[0].metadata.name}", "delta": "0:00:01.313362", "end": "2019-04-09 09:41:43.806115", "rc": 0, "start": "2019-04-09 09:41:42.492753", "stderr": "", "stderr_lines": [], "stdout": "app-busybox-754f6499df-ckmp2", "stdout_lines": ["app-busybox-754f6499df-ckmp2"]}

TASK [Replacing the placeholder for pod-name] **********************************
2019-04-09T09:41:43.869614 (delta: 1.637079)         elapsed: 16.85573 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the placeholder for namespace] *********************************
2019-04-09T09:41:44.339400 (delta: 0.469722)         elapsed: 17.325516 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "14 replacements made"}

TASK [Replacing the placeholder for liveness-retry-count] **********************
2019-04-09T09:41:44.714264 (delta: 0.374792)         elapsed: 17.70038 ******** 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replacing the placeholder for liveness-timeout] **************************
2019-04-09T09:41:45.007357 (delta: 0.293032)         elapsed: 17.993473 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Creating busybox-liveness job] *******************************************
2019-04-09T09:41:45.337972 (delta: 0.330553)         elapsed: 18.324088 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create -f busybox_liveness.yml", "delta": "0:00:01.590783", "end": "2019-04-09 09:41:47.139225", "rc": 0, "start": "2019-04-09 09:41:45.548442", "stderr": "", "stderr_lines": [], "stdout": "clusterrole.rbac.authorization.k8s.io/app-busybox-ns created\nserviceaccount/app-busybox-ns created\nclusterrolebinding.rbac.authorization.k8s.io/app-busybox-ns created\njob.batch/busybox-liveness-df5fn created", "stdout_lines": ["clusterrole.rbac.authorization.k8s.io/app-busybox-ns created", "serviceaccount/app-busybox-ns created", "clusterrolebinding.rbac.authorization.k8s.io/app-busybox-ns created", "job.batch/busybox-liveness-df5fn created"]}

TASK [Verifying whether liveness pod is started successfully] ******************
2019-04-09T09:41:47.192634 (delta: 1.854568)         elapsed: 20.17875 ******** 
FAILED - RETRYING: Verifying whether liveness pod is started successfully (20 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n app-busybox-ns -l liveness=busybox-liveness -o jsonpath={.items[0].status.phase}", "delta": "0:00:01.314217", "end": "2019-04-09 09:42:50.333616", "rc": 0, "start": "2019-04-09 09:42:49.019399", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [set_fact] ****************************************************************
2019-04-09T09:42:50.457298 (delta: 63.26461)         elapsed: 83.443414 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
2019-04-09T09:42:50.621338 (delta: 0.163944)         elapsed: 83.607454 ******* 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-04-09T09:42:50.798806 (delta: 0.177368)         elapsed: 83.784922 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-04-09T09:42:50.849249 (delta: 0.050383)         elapsed: 83.835365 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-04-09T09:42:50.898367 (delta: 0.049063)         elapsed: 83.884483 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-04-09T09:42:50.953875 (delta: 0.055446)         elapsed: 83.939991 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "be4eaa0d097868df2568b19bb3912ca5e0172866", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "a6e427d28894bb8af4d1d513f7e47d9c", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1554802971.02-60141427431432/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-04-09T09:42:53.382592 (delta: 2.428654)         elapsed: 86.368708 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:00.935500", "end": "2019-04-09 09:42:54.565503", "rc": 0, "start": "2019-04-09 09:42:53.630003", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: busybox-liveness \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: busybox-liveness ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-04-09T09:42:54.619167 (delta: 1.236521)         elapsed: 87.605283 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.423086", "end": "2019-04-09 09:42:56.278564", "failed_when_result": false, "rc": 0, "start": "2019-04-09 09:42:54.855478", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/busybox-liveness configured", "stdout_lines": ["litmusresult.litmus.io/busybox-liveness configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=17   changed=13   unreachable=0    failed=0
```
