### PR TITLE
changed imagePullPolicy from Always to IfNotPresent

### DIFF
--- a/apps/elasticsearch/deployers/es-statefulset.yaml
+++ b/apps/elasticsearch/deployers/es-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
           privileged: true # sysctl command needs root permission to change kernel config
       containers:
       - image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: elasticsearch-logging
         securityContext:
           runAsUser: 1000   # elasticsearch container runs with elasticsearch user (1000:1000)


### PR DESCRIPTION
* The file is changed that tells don't pull the image if the docker image of the elasticsearch is already present.
