### PR TITLE
Creating pod security policy and clusterrole before deploying openebs

### DIFF
--- a/providers/openebs/installers/operator/master/ansible/openebs_psp.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_psp.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-psp
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - privileged
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: openebs-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openebs-psp
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: openebs
+

--- a/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
+++ b/providers/openebs/installers/operator/master/ansible/openebs_setup.yaml
@@ -40,6 +40,18 @@
           register: lr_status
           failed_when: "lr_status.rc != 0"
 
+ # Creating pod security policy in the test cluster.
+ # Creating clusterrole with the pod security policy resources
+ # The service account used to create resources is specified in clusterrrolebinding.
+ # The namespace where openebs will be deployed is specified in the clusterrolebinding.
+ 
+        - name: Creating pod security policy, cluster role and clusterrolebinding
+          shell: kubectl apply -f "{{ psp_spec }}"
+          args:
+            executable: /bin/bash
+          register: psp_status
+          failed_when: "psp_status.rc != 0"
+
         - name: Downloading openebs-operator.yaml
           get_url:
             url: "{{ openebs_operator_link }}"

--- a/providers/openebs/installers/operator/master/ansible/vars.yaml
+++ b/providers/openebs/installers/operator/master/ansible/vars.yaml
@@ -10,3 +10,4 @@ selector_name: openebs-ndm
 sparse_pool_label: 'app=cstor-pool'
 installation_test_name: openebsinstaller
 cleanup_test_name: openebscleanup
+psp_spec: openebs_psp.yaml 


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- Creating pod security policy before installing openebs.
- Associated the PSP created to a ClusterRole.
- Associated the Privileged ClusterRole to OpenEBS Service Account.
- After this task, triggering openebs installation.

**Special notes for your reviewer**:

```
PLAYBOOK: openebs_setup.yaml ***************************************************
1 plays in ./operator/master/ansible/openebs_setup.yaml

PLAY [localhost] ***************************************************************
2019-04-11T12:43:08.583981 (delta: 0.070186)         elapsed: 0.070186 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
task path: /operator/master/ansible/openebs_setup.yaml:4
2019-04-11T12:43:08.605650 (delta: 0.021519)         elapsed: 0.091855 ******** 
ok: [127.0.0.1]
META: ran handlers

TASK [Record test instance/run ID] *********************************************
task path: /operator/master/ansible/openebs_setup.yaml:14
2019-04-11T12:43:18.270621 (delta: 9.66495)         elapsed: 9.756826 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /operator/master/ansible/openebs_setup.yaml:17
2019-04-11T12:43:18.352990 (delta: 0.082294)         elapsed: 9.839195 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect Start of Installation] **********
task path: /operator/master/ansible/openebs_setup.yaml:22
2019-04-11T12:43:18.415045 (delta: 0.061958)         elapsed: 9.90125 ********* 
changed: [127.0.0.1] => {"changed": true, "checksum": "5ecda94797aa6d989ef03225f169572090e95130", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "0f04da1cef5f4da047dade7df612c46e", "mode": "0644", "owner": "root", "size": 417, "src": "/root/.ansible/tmp/ansible-tmp-1554986598.49-50129816620381/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /operator/master/ansible/openebs_setup.yaml:33
2019-04-11T12:43:19.401265 (delta: 0.986174)         elapsed: 10.88747 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.076888", "end": "2019-04-11 12:43:21.051110", "rc": 0, "start": "2019-04-11 12:43:19.974222", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebsinstaller \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebsinstaller ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
task path: /operator/master/ansible/openebs_setup.yaml:36
2019-04-11T12:43:21.118010 (delta: 1.716647)         elapsed: 12.604215 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.614844", "end": "2019-04-11 12:43:22.933016", "failed_when_result": false, "rc": 0, "start": "2019-04-11 12:43:21.318172", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebsinstaller configured", "stdout_lines": ["litmusresult.litmus.io/openebsinstaller configured"]}

TASK [Creating pod security policy, cluster role and clusterrolebinding] *******
task path: /operator/master/ansible/openebs_setup.yaml:48
2019-04-11T12:43:22.997441 (delta: 1.879382)         elapsed: 14.483646 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f \"openebs_psp.yaml\"", "delta": "0:00:01.253827", "end": "2019-04-11 12:43:24.433087", "failed_when_result": false, "rc": 0, "start": "2019-04-11 12:43:23.179260", "stderr": "", "stderr_lines": [], "stdout": "podsecuritypolicy.extensions/privileged unchanged\nclusterrole.rbac.authorization.k8s.io/openebs-psp unchanged\nclusterrolebinding.rbac.authorization.k8s.io/openebs-binding unchanged", "stdout_lines": ["podsecuritypolicy.extensions/privileged unchanged", "clusterrole.rbac.authorization.k8s.io/openebs-psp unchanged", "clusterrolebinding.rbac.authorization.k8s.io/openebs-binding unchanged"]}

TASK [Downloading openebs-operator.yaml] ***************************************
task path: /operator/master/ansible/openebs_setup.yaml:55
2019-04-11T12:43:24.559548 (delta: 1.562056)         elapsed: 16.045753 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "90144d7a89eb54c696a3e1a44f71a3607f9a021f", "dest": "/operator/master/ansible/openebs-operator.yaml", "gid": 0, "group": "root", "md5sum": "cd9d60ff8f15a0e30ad8fa56c091361d", "mode": "0644", "msg": "OK (21753 bytes)", "owner": "root", "size": 21753, "src": "/root/.ansible/tmp/ansible-tmp-1554986604.69-229074344930829/tmpgwgKWY", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml"}

TASK [Downloading openebs-storageclasses.yaml] *********************************
task path: /operator/master/ansible/openebs_setup.yaml:65
2019-04-11T12:43:30.963394 (delta: 6.403713)         elapsed: 22.449599 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "a8aa0d7e36752b07b7061449384b341a34ad4c45", "dest": "/operator/master/ansible/storageclass.yaml", "gid": 0, "group": "root", "md5sum": "325c4aac8f18d22423932a4ad93137af", "mode": "0644", "msg": "OK (661 bytes)", "owner": "root", "size": 661, "src": "/root/.ansible/tmp/ansible-tmp-1554986611.08-84413357782876/tmpt0DpHj", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml"}

TASK [Change the openebs analytics value of openebs resources in operator YAML] ***
task path: /operator/master/ansible/openebs_setup.yaml:75
2019-04-11T12:43:32.551208 (delta: 1.587725)         elapsed: 24.037413 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Change the Node Disk manager Image] **************************************
task path: /operator/master/ansible/openebs_setup.yaml:82
2019-04-11T12:43:33.152918 (delta: 0.601611)         elapsed: 24.639123 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the openebs analytics value of openebs resources in operator YAML] ***
task path: /operator/master/ansible/openebs_setup.yaml:89
2019-04-11T12:43:33.226744 (delta: 0.073751)         elapsed: 24.712949 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "2 replacements made"}

TASK [Applying openebs operator] ***********************************************
task path: /operator/master/ansible/openebs_setup.yaml:96
2019-04-11T12:43:33.616084 (delta: 0.389276)         elapsed: 25.102289 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf apply -f openebs-operator.yaml", "delta": "0:00:02.497841", "end": "2019-04-11 12:43:36.481268", "rc": 0, "start": "2019-04-11 12:43:33.983427", "stderr": "Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply", "stderr_lines": ["Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply"], "stdout": "namespace/openebs configured\nserviceaccount/openebs-maya-operator created\nclusterrole.rbac.authorization.k8s.io/openebs-maya-operator configured\nclusterrolebinding.rbac.authorization.k8s.io/openebs-maya-operator configured\ndeployment.apps/maya-apiserver created\nservice/maya-apiserver-service created\ndeployment.apps/openebs-provisioner created\ndeployment.apps/openebs-snapshot-operator created\nconfigmap/openebs-ndm-config created\ndaemonset.extensions/openebs-ndm created\nsecret/admission-server-certs created\nservice/admission-server-svc created\ndeployment.apps/openebs-admission-server created\nvalidatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook-cfg configured", "stdout_lines": ["namespace/openebs configured", "serviceaccount/openebs-maya-operator created", "clusterrole.rbac.authorization.k8s.io/openebs-maya-operator configured", "clusterrolebinding.rbac.authorization.k8s.io/openebs-maya-operator configured", "deployment.apps/maya-apiserver created", "service/maya-apiserver-service created", "deployment.apps/openebs-provisioner created", "deployment.apps/openebs-snapshot-operator created", "configmap/openebs-ndm-config created", "daemonset.extensions/openebs-ndm created", "secret/admission-server-certs created", "service/admission-server-svc created", "deployment.apps/openebs-admission-server created", "validatingwebhookconfiguration.admissionregistration.k8s.io/validation-webhook-cfg configured"]}

TASK [Applying storageclasses] *************************************************
task path: /operator/master/ansible/openebs_setup.yaml:101
2019-04-11T12:43:36.546774 (delta: 2.930589)         elapsed: 28.032979 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl --kubeconfig /root/admin.conf apply -f storageclass.yaml", "delta": "0:00:01.642072", "end": "2019-04-11 12:43:38.406449", "rc": 0, "start": "2019-04-11 12:43:36.764377", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io/openebs-standard created\nstorageclass.storage.k8s.io/openebs-standalone created\nstorageclass.storage.k8s.io/openebs-mongodb created", "stdout_lines": ["storageclass.storage.k8s.io/openebs-standard created", "storageclass.storage.k8s.io/openebs-standalone created", "storageclass.storage.k8s.io/openebs-mongodb created"]}

TASK [Updating maya api server image] ******************************************
task path: /operator/master/ansible/openebs_setup.yaml:106
2019-04-11T12:43:38.871605 (delta: 2.324774)         elapsed: 30.35781 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva controller image] **********************************
task path: /operator/master/ansible/openebs_setup.yaml:112
2019-04-11T12:43:38.940236 (delta: 0.068575)         elapsed: 30.426441 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva replica image] *************************************
task path: /operator/master/ansible/openebs_setup.yaml:118
2019-04-11T12:43:39.032430 (delta: 0.092142)         elapsed: 30.518635 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs jiva replica count] *************************************
task path: /operator/master/ansible/openebs_setup.yaml:124
2019-04-11T12:43:39.113332 (delta: 0.080833)         elapsed: 30.599537 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor target image] *************************************
task path: /operator/master/ansible/openebs_setup.yaml:130
2019-04-11T12:43:39.183182 (delta: 0.0698)         elapsed: 30.669387 ********* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool image] ***************************************
task path: /operator/master/ansible/openebs_setup.yaml:136
2019-04-11T12:43:39.249628 (delta: 0.066393)         elapsed: 30.735833 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool management image] ****************************
task path: /operator/master/ansible/openebs_setup.yaml:142
2019-04-11T12:43:39.315609 (delta: 0.065927)         elapsed: 30.801814 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor volume management image] **************************
task path: /operator/master/ansible/openebs_setup.yaml:148
2019-04-11T12:43:39.382701 (delta: 0.067042)         elapsed: 30.868906 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor volume monitor image] *****************************
task path: /operator/master/ansible/openebs_setup.yaml:154
2019-04-11T12:43:39.447699 (delta: 0.064947)         elapsed: 30.933904 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Updating openebs cstor pool exporter image] ******************************
task path: /operator/master/ansible/openebs_setup.yaml:160
2019-04-11T12:43:39.525952 (delta: 0.078201)         elapsed: 31.012157 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Restarting all pods in openebs namespace] ********************************
task path: /operator/master/ansible/openebs_setup.yaml:166
2019-04-11T12:43:39.597436 (delta: 0.071417)         elapsed: 31.083641 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete po --all -n openebs", "delta": "0:00:12.391464", "end": "2019-04-11 12:43:52.256121", "rc": 0, "start": "2019-04-11 12:43:39.864657", "stderr": "", "stderr_lines": [], "stdout": "pod \"maya-apiserver-759cc884c6-6qsbt\" deleted\npod \"openebs-admission-server-7d9b74886c-bncqm\" deleted\npod \"openebs-grafana-84c66d78dc-dftbh\" deleted\npod \"openebs-ndm-8tlbn\" deleted\npod \"openebs-ndm-jc5lp\" deleted\npod \"openebs-ndm-l54vq\" deleted\npod \"openebs-provisioner-857bd57589-nfwwx\" deleted\npod \"openebs-snapshot-operator-75b9866978-7pwj4\" deleted", "stdout_lines": ["pod \"maya-apiserver-759cc884c6-6qsbt\" deleted", "pod \"openebs-admission-server-7d9b74886c-bncqm\" deleted", "pod \"openebs-grafana-84c66d78dc-dftbh\" deleted", "pod \"openebs-ndm-8tlbn\" deleted", "pod \"openebs-ndm-jc5lp\" deleted", "pod \"openebs-ndm-l54vq\" deleted", "pod \"openebs-provisioner-857bd57589-nfwwx\" deleted", "pod \"openebs-snapshot-operator-75b9866978-7pwj4\" deleted"]}

TASK [Verify that rolling update of maya-apiserver is completed] ***************
task path: /operator/master/ansible/openebs_setup.yaml:171
2019-04-11T12:43:52.367920 (delta: 12.770424)         elapsed: 43.854125 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods --no-headers -n openebs -l name=maya-apiserver | wc -l", "delta": "0:00:01.492881", "end": "2019-04-11 12:43:54.271148", "rc": 0, "start": "2019-04-11 12:43:52.778267", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [Checking Maya-API-Server container status] *******************************
task path: /operator/master/ansible/openebs_setup.yaml:182
2019-04-11T12:43:54.343423 (delta: 1.975403)         elapsed: 45.829628 ******* 
FAILED - RETRYING: Checking Maya-API-Server container status (120 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (119 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (118 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (117 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (116 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (115 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (114 retries left).
FAILED - RETRYING: Checking Maya-API-Server container status (113 retries left).
changed: [127.0.0.1] => {"attempts": 9, "changed": true, "cmd": "kubectl get pods --no-headers -n openebs -l name=maya-apiserver -o jsonpath='{.items[?(@.status.containerStatuses[*].name==\"maya-apiserver\")].status.containerStatuses[*].ready}'", "delta": "0:00:01.257319", "end": "2019-04-11 12:44:47.959020", "rc": 0, "start": "2019-04-11 12:44:46.701701", "stderr": "", "stderr_lines": [], "stdout": "true", "stdout_lines": ["true"]}

TASK [Checking OpenEBS-provisioner is running] *********************************
task path: /operator/master/ansible/openebs_setup.yaml:191
2019-04-11T12:44:48.050953 (delta: 53.707457)         elapsed: 99.537158 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-provisioner\")].status.phase}'", "delta": "0:00:01.402196", "end": "2019-04-11 12:44:49.837804", "rc": 0, "start": "2019-04-11 12:44:48.435608", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get maya-apiserver pod name] *********************************************
task path: /operator/master/ansible/openebs_setup.yaml:205
2019-04-11T12:44:49.966739 (delta: 1.915688)         elapsed: 101.452944 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods -n openebs --no-headers --selector=name=maya-apiserver -o custom-columns=:metadata.name", "delta": "0:00:01.336815", "end": "2019-04-11 12:44:51.696897", "rc": 0, "start": "2019-04-11 12:44:50.360082", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-759cc884c6-qspdh", "stdout_lines": ["maya-apiserver-759cc884c6-qspdh"]}

TASK [Create fact for pod name] ************************************************
task path: /operator/master/ansible/openebs_setup.yaml:214
2019-04-11T12:44:51.794098 (delta: 1.827261)         elapsed: 103.280303 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"pod_name": "maya-apiserver-759cc884c6-qspdh"}, "changed": false}

TASK [Checking OpenEBS-Snapshot-Operator is running] ***************************
task path: /operator/master/ansible/openebs_setup.yaml:218
2019-04-11T12:44:51.973161 (delta: 0.178981)         elapsed: 103.459366 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-snapshot-operator\")].status.phase}'", "delta": "0:00:01.365543", "end": "2019-04-11 12:44:53.714236", "rc": 0, "start": "2019-04-11 12:44:52.348693", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Confirm that maya-cli is available in the maya-apiserver pod] ************
task path: /operator/master/ansible/openebs_setup.yaml:225
2019-04-11T12:44:53.785633 (delta: 1.812367)         elapsed: 105.271838 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec maya-apiserver-759cc884c6-qspdh -c maya-apiserver -n openebs -- mayactl version", "delta": "0:00:01.366574", "end": "2019-04-11 12:44:55.343862", "failed_when_result": false, "rc": 0, "start": "2019-04-11 12:44:53.977288", "stderr": "", "stderr_lines": [], "stdout": "Version: 0.9.0-unreleased\nGit commit: 466673c85f7b0f332a94a3181648f5ebef9e8a76\nGO Version: go1.11.2\nGO ARCH: amd64\nGO OS: linux\nm-apiserver url:  http://172.23.5.3:5656\nm-apiserver status:  running", "stdout_lines": ["Version: 0.9.0-unreleased", "Git commit: 466673c85f7b0f332a94a3181648f5ebef9e8a76", "GO Version: go1.11.2", "GO ARCH: amd64", "GO OS: linux", "m-apiserver url:  http://172.23.5.3:5656", "m-apiserver status:  running"]}

TASK [Getting the number of nodes] *********************************************
task path: /operator/master/ansible/openebs_setup.yaml:233
2019-04-11T12:44:55.478242 (delta: 1.692532)         elapsed: 106.964447 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get node --no-headers | grep -v \"master\" | wc -l", "delta": "0:00:01.351653", "end": "2019-04-11 12:44:57.087534", "rc": 0, "start": "2019-04-11 12:44:55.735881", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Confirm if node-disk-manager is running in all the nodes] ****************
task path: /operator/master/ansible/openebs_setup.yaml:239
2019-04-11T12:44:57.219024 (delta: 1.74067)         elapsed: 108.705229 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs --selector=name=openebs-ndm | grep Running | wc -l", "delta": "0:00:01.314025", "end": "2019-04-11 12:44:58.933652", "rc": 0, "start": "2019-04-11 12:44:57.619627", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Getting the number of nodes] *********************************************
task path: /operator/master/ansible/openebs_setup.yaml:265
2019-04-11T12:44:59.062448 (delta: 1.843324)         elapsed: 110.548653 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm if node-disk-manager is running in all the nodes] ****************
task path: /operator/master/ansible/openebs_setup.yaml:271
2019-04-11T12:44:59.135768 (delta: 0.073215)         elapsed: 110.621973 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Confirm CAS Templates are deployed] **************************************
task path: /operator/master/ansible/openebs_setup.yaml:296
2019-04-11T12:44:59.220229 (delta: 0.084403)         elapsed: 110.706434 ****** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get castemplate -n openebs", "delta": "0:00:02.341937", "end": "2019-04-11 12:45:01.830905", "rc": 0, "start": "2019-04-11 12:44:59.488968", "stderr": "", "stderr_lines": [], "stdout": "NAME                                  CREATED AT\ncas-volume-stats-default-0.8.1        22d\ncas-volume-stats-default-0.8.2        6d\ncas-volume-stats-default-0.9.0        6d\ncstor-pool-create-default-0.8.1       22d\ncstor-pool-create-default-0.8.2       6d\ncstor-pool-create-default-0.9.0       6d\ncstor-pool-delete-default-0.8.1       22d\ncstor-pool-delete-default-0.8.2       6d\ncstor-snapshot-create-default-0.8.1   22d\ncstor-snapshot-create-default-0.8.2   6d\ncstor-snapshot-create-default-0.9.0   6d\ncstor-snapshot-delete-default-0.8.1   22d\ncstor-snapshot-delete-default-0.8.2   6d\ncstor-snapshot-delete-default-0.9.0   6d\ncstor-volume-create-default-0.8.1     22d\ncstor-volume-create-default-0.8.2     6d\ncstor-volume-create-default-0.9.0     6d\ncstor-volume-delete-default-0.8.1     22d\ncstor-volume-delete-default-0.8.2     6d\ncstor-volume-delete-default-0.9.0     6d\ncstor-volume-list-default-0.8.1       22d\ncstor-volume-list-default-0.8.2       6d\ncstor-volume-list-default-0.9.0       6d\ncstor-volume-read-default-0.8.1       22d\ncstor-volume-read-default-0.8.2       6d\ncstor-volume-read-default-0.9.0       6d\njiva-snapshot-create-default-0.8.1    22d\njiva-snapshot-create-default-0.8.2    6d\njiva-snapshot-create-default-0.9.0    6d\njiva-volume-create-default-0.8.1      22d\njiva-volume-create-default-0.8.2      6d\njiva-volume-create-default-0.9.0      6d\njiva-volume-delete-default-0.6.0      22d\njiva-volume-delete-default-0.8.1      22d\njiva-volume-delete-default-0.8.2      6d\njiva-volume-delete-default-0.9.0      6d\njiva-volume-list-default-0.6.0        22d\njiva-volume-list-default-0.8.1        22d\njiva-volume-list-default-0.8.2        6d\njiva-volume-list-default-0.9.0        6d\njiva-volume-read-default-0.6.0        22d\njiva-volume-read-default-0.8.1        22d\njiva-volume-read-default-0.8.2        6d\njiva-volume-read-default-0.9.0        6d\nstorage-pool-list-default-0.8.1       22d\nstorage-pool-list-default-0.8.2       6d\nstorage-pool-list-default-0.9.0       6d\nstorage-pool-read-default-0.8.1       22d\nstorage-pool-read-default-0.8.2       6d\nstorage-pool-read-default-0.9.0       6d", "stdout_lines": ["NAME                                  CREATED AT", "cas-volume-stats-default-0.8.1        22d", "cas-volume-stats-default-0.8.2        6d", "cas-volume-stats-default-0.9.0        6d", "cstor-pool-create-default-0.8.1       22d", "cstor-pool-create-default-0.8.2       6d", "cstor-pool-create-default-0.9.0       6d", "cstor-pool-delete-default-0.8.1       22d", "cstor-pool-delete-default-0.8.2       6d", "cstor-snapshot-create-default-0.8.1   22d", "cstor-snapshot-create-default-0.8.2   6d", "cstor-snapshot-create-default-0.9.0   6d", "cstor-snapshot-delete-default-0.8.1   22d", "cstor-snapshot-delete-default-0.8.2   6d", "cstor-snapshot-delete-default-0.9.0   6d", "cstor-volume-create-default-0.8.1     22d", "cstor-volume-create-default-0.8.2     6d", "cstor-volume-create-default-0.9.0     6d", "cstor-volume-delete-default-0.8.1     22d", "cstor-volume-delete-default-0.8.2     6d", "cstor-volume-delete-default-0.9.0     6d", "cstor-volume-list-default-0.8.1       22d", "cstor-volume-list-default-0.8.2       6d", "cstor-volume-list-default-0.9.0       6d", "cstor-volume-read-default-0.8.1       22d", "cstor-volume-read-default-0.8.2       6d", "cstor-volume-read-default-0.9.0       6d", "jiva-snapshot-create-default-0.8.1    22d", "jiva-snapshot-create-default-0.8.2    6d", "jiva-snapshot-create-default-0.9.0    6d", "jiva-volume-create-default-0.8.1      22d", "jiva-volume-create-default-0.8.2      6d", "jiva-volume-create-default-0.9.0      6d", "jiva-volume-delete-default-0.6.0      22d", "jiva-volume-delete-default-0.8.1      22d", "jiva-volume-delete-default-0.8.2      6d", "jiva-volume-delete-default-0.9.0      6d", "jiva-volume-list-default-0.6.0        22d", "jiva-volume-list-default-0.8.1        22d", "jiva-volume-list-default-0.8.2        6d", "jiva-volume-list-default-0.9.0        6d", "jiva-volume-read-default-0.6.0        22d", "jiva-volume-read-default-0.8.1        22d", "jiva-volume-read-default-0.8.2        6d", "jiva-volume-read-default-0.9.0        6d", "storage-pool-list-default-0.8.1       22d", "storage-pool-list-default-0.8.2       6d", "storage-pool-list-default-0.9.0       6d", "storage-pool-read-default-0.8.1       22d", "storage-pool-read-default-0.8.2       6d", "storage-pool-read-default-0.9.0       6d"]}

TASK [set_fact] ****************************************************************
task path: /operator/master/ansible/openebs_setup.yaml:305
2019-04-11T12:45:01.973596 (delta: 2.753301)         elapsed: 113.459801 ****** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Generate the litmus result CR to reflect End of Installation] ************
task path: /operator/master/ansible/openebs_setup.yaml:313
2019-04-11T12:45:02.150539 (delta: 0.176837)         elapsed: 113.636744 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "42e0ea578ffa4a1a9cda422fa345344dcc5667c9", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "c579bb9e9e52957afe03dfa862f9b3e2", "mode": "0644", "owner": "root", "size": 415, "src": "/root/.ansible/tmp/ansible-tmp-1554986702.26-139703768015736/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /operator/master/ansible/openebs_setup.yaml:324
2019-04-11T12:45:04.966543 (delta: 2.815858)         elapsed: 116.452748 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.189241", "end": "2019-04-11 12:45:06.483633", "rc": 0, "start": "2019-04-11 12:45:05.294392", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: openebsinstaller \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: openebsinstaller ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
task path: /operator/master/ansible/openebs_setup.yaml:327
2019-04-11T12:45:06.539131 (delta: 1.572516)         elapsed: 118.025336 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.654573", "end": "2019-04-11 12:45:08.379298", "failed_when_result": false, "rc": 0, "start": "2019-04-11 12:45:06.724725", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/openebsinstaller configured", "stdout_lines": ["litmusresult.litmus.io/openebsinstaller configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=26   changed=23   unreachable=0    failed=0   

2019-04-11T12:45:08.467474 (delta: 1.928287)         elapsed: 119.953679 ****** 
```