### PR TITLE
Added prometheus provisioning litmus test script

### DIFF
--- a/apps/prometheus/deployers/prometheus.yml
+++ b/apps/prometheus/deployers/prometheus.yml
@@ -1,50 +1,161 @@
+# Create Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-prometheus-operator
 ---
-apiVersion: apps/v1beta1
+# Define Role that allows operations on K8s pods/deployments
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: app-prometheus-operator
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes", "nodes/proxy"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["namespaces", "services", "pods", "deployments", "events", "endpoints", "configmaps", "jobs"]
+  verbs: ["*"]
+---
+# Bind the Service Account with the Role Privileges.
+# TODO: Check if default account also needs to be there
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: app-prometheus-operator
+subjects:
+- kind: ServiceAccount
+  name: app-prometheus-operator
+  namespace: cr-namespace
+- kind: User
+  name: system:serviceaccount:default:default
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: app-prometheus-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openebs-prometheus-tunables
+data:
+  storage-retention: 24h
+---
+# Define the openebs prometheus jobs
+kind: ConfigMap
+metadata:
+  name: openebs-prometheus-config
+apiVersion: v1
+data:
+  prometheus.yml: |-
+    global:
+      external_labels:
+        slave: slave1
+      scrape_interval: 5s
+      evaluation_interval: 5s
+    scrape_configs:
+    - job_name: 'prometheus'
+      scheme: http
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_name]
+        regex: openebs-prometheus-server
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+---
+# prometheus-deployment
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: prometheus
-  labels:
-    lkey: lvalue
-    openebs.io/target-affinity: prometheus
+  name: openebs-prometheus
 spec:
   replicas: 1
-  selector: 
-    matchLabels:
-      lkey: lvalue
-  template: 
+  template:
     metadata:
-      labels: 
+      labels:
         lkey: lvalue
-        openebs.io/target-affinity: prometheus
+        targetkey: lvalue 
     spec:
+      serviceAccountName: app-prometheus-operator
       containers:
-        - resources:
-            limits:
-              cpu: 0.5
-          name: prometheus
-          image: prom/prometheus
-          imagePullPolicy: IfNotPresent 
-          #args:
-          env:
-            - name: MYSQL_ROOT_PASSWORD
-              value: k8sDem0
+        - name: prometheus
+          image: prom/prometheus:v2.3.0
+          args:
+            - "--config.file=/etc/prometheus/conf/prometheus.yml"
+            # Metrics are stored in an emptyDir volume which
+            # exists as long as the Pod is running on that Node.
+            # The data in an emptyDir volume is safe across container crashes.
+            - "--storage.tsdb.path=/prometheus"
+            # How long to retain samples in the local storage.
+            - "--storage.tsdb.retention=$(STORAGE_RETENTION)"
+          securityContext:
+            runAsUser: 0
           ports:
-            - containerPort: 9000
-              name: prometheus
+            - containerPort: 9090
+          env:
+            # environment vars are stored in prometheus-env configmap. 
+            - name: STORAGE_RETENTION
+              valueFrom:
+                configMapKeyRef:
+                  name: openebs-prometheus-tunables
+                  key: storage-retention
+          resources:
+            requests:
+              # A memory request of 250M means it will try to ensure minimum
+              # 250MB RAM .
+              memory: "128M"
+              # A cpu request of 128m means it will try to ensure minimum
+              # .125 CPU; where 1 CPU means :
+              # 1 *Hyperthread* on a bare-metal Intel processor with Hyperthreading
+              cpu: "128m"
+            limits:
+              memory: "700M"
+              cpu: "500m"
+          
           volumeMounts:
-            - mountPath: /etc/prometheus/conf
-              name: data-vol
+            # prometheus config file stored in the given mountpath
+            - name: prometheus-server-volume
+              mountPath: /etc/prometheus/conf
+            # metrics collected by prometheus will be stored at the given mountpath.
+            - name: prometheus-storage-volume
+              mountPath: /prometheus
       volumes:
-        - name: data-vol
+        # Prometheus Config file will be stored in this volume 
+        - name: prometheus-server-volume
+          configMap:
+            name: openebs-prometheus-config
+        # All the time series stored in this volume in form of .db file.
+        - name: prometheus-storage-volume
           persistentVolumeClaim:
             claimName: testclaim
+           
+---
+# prometheus-service
+apiVersion: v1
+kind: Service
+metadata:
+  name: openebs-prometheus-service
+spec:
+  selector: 
+    lkey: lvalue
+  type: NodePort
+  ports:
+    - port: 80 # this Service's port (cluster-internal IP clusterIP)
+      targetPort: 9090 # pods expose this port
+      nodePort: 32514
+      # Note that this Service will be visible as both NodeIP:nodePort and clusterIp:Port
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: testclaim
   labels: 
-    openebs.io/target-affinity: prometheus  
+    lkey: lvalue 
+    targetkey: lvalue 
 spec:
   storageClassName: testclass
   accessModes:
@@ -52,16 +163,3 @@ spec:
   resources:
     requests:
       storage: volume-capacity
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: prometheus
-  labels:
-    lkey: lvalue
-spec:
-  ports:
-    - port: 9090
-      targetPort: 9090
-  selector:
-      lkey: lvalue

--- a/apps/prometheus/deployers/run_litmus_test.yml
+++ b/apps/prometheus/deployers/run_litmus_test.yml
@@ -46,6 +46,9 @@ spec:
           - name: VOLUME_CAPACITY
             value: "25G"
 
+          - name: AFFINITY_LABEL
+            value: openebs.io/target-affinity
+
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./prometheus/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]
 

--- a/apps/prometheus/deployers/test.yml
+++ b/apps/prometheus/deployers/test.yml
@@ -28,6 +28,18 @@
                 regexp: volume-capacity
                 replace: "{{ lookup('env','VOLUME_CAPACITY') }}"
 
+            - name: Replace ClusterRoleBinding's namespace placeholder
+              replace:
+                path: "{{ application_deployment }}"
+                regexp: cr-namespace
+                replace: "{{ lookup('env','APP_NAMESPACE') }}"
+           
+            - name: Replace target affinity label placeholder
+              replace:
+                path: "{{ application_deployment }}"
+                regexp: "targetkey: lvalue"
+                replace: "{{ lookup('env','AFFINITY_LABEL') }}: {{ app_lvalue }}"
+
          ## Deploying the application
             - include_tasks: /common/utils/deploy_single_app.yml
               vars:


### PR DESCRIPTION
Added a prometheus deployment litmus test script.
This script:
 - creates service account,cluster role,cluster role binding,configmap,prometheus deployment , 
   prometheus service, and persistent volume claim

Below is the litmus job log for reference:

```
PLAY [localhost] ***************************************************************
2019-04-22T12:07:23.696509 (delta: 0.062586)         elapsed: 0.062586 ******** 
=============================================================================== 

TASK [Gathering Facts] *********************************************************
2019-04-22T12:07:23.712275 (delta: 0.015709)         elapsed: 0.078352 ******** 
ok: [127.0.0.1]

TASK [include_tasks] ***********************************************************
2019-04-22T12:07:32.293189 (delta: 8.580887)         elapsed: 8.659266 ******** 
included: /common/utils/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
2019-04-22T12:07:32.367932 (delta: 0.074697)         elapsed: 8.734009 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
2019-04-22T12:07:32.431228 (delta: 0.063241)         elapsed: 8.797305 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-04-22T12:07:32.496448 (delta: 0.065163)         elapsed: 8.862525 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-04-22T12:07:32.590236 (delta: 0.093718)         elapsed: 8.956313 ******** 
changed: [127.0.0.1] => {"changed": true, "checksum": "8d34e98f66235fb9c3570a618810bfbb97f90cca", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "279779df6782cc15347dd36901dad868", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1555934852.65-12976786522783/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-04-22T12:07:33.401025 (delta: 0.810739)         elapsed: 9.767102 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.069813", "end": "2019-04-22 12:07:34.990588", "rc": 0, "start": "2019-04-22 12:07:33.920775", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: prometheus-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: prometheus-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the litmus result CR] **********************************************
2019-04-22T12:07:35.044350 (delta: 1.64327)         elapsed: 11.410427 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.672885", "end": "2019-04-22 12:07:36.954637", "failed_when_result": false, "rc": 0, "start": "2019-04-22 12:07:35.281752", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/prometheus-deployment configured", "stdout_lines": ["litmusresult.litmus.io/prometheus-deployment configured"]}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-04-22T12:07:37.114884 (delta: 2.070477)         elapsed: 13.480961 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-04-22T12:07:37.245087 (delta: 0.130073)         elapsed: 13.611164 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-04-22T12:07:37.364428 (delta: 0.119206)         elapsed: 13.730505 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-04-22T12:07:37.459926 (delta: 0.095347)         elapsed: 13.826003 ******* 
included: /common/utils/pre_create_app_deploy.yml for 127.0.0.1

TASK [Check whether the provider storageclass is applied] **********************
2019-04-22T12:07:37.588093 (delta: 0.12811)         elapsed: 13.95417 ********* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get sc openebs-cstor-sparse", "delta": "0:00:01.253700", "end": "2019-04-22 12:07:39.127318", "rc": 0, "start": "2019-04-22 12:07:37.873618", "stderr": "", "stderr_lines": [], "stdout": "NAME                   PROVISIONER                    AGE\nopenebs-cstor-sparse   openebs.io/provisioner-iscsi   6d", "stdout_lines": ["NAME                   PROVISIONER                    AGE", "openebs-cstor-sparse   openebs.io/provisioner-iscsi   6d"]}

TASK [Replace the pvc placeholder with provider] *******************************
2019-04-22T12:07:39.187850 (delta: 1.599687)         elapsed: 15.553927 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace the storageclass placeholder with provider] **********************
2019-04-22T12:07:39.774255 (delta: 0.586352)         elapsed: 16.140332 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-04-22T12:07:40.140450 (delta: 0.36613)         elapsed: 16.506527 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the application label values from env] *******************************
2019-04-22T12:07:40.232521 (delta: 0.091998)         elapsed: 16.598598 ******* 
ok: [127.0.0.1] => {"ansible_facts": {"app_lkey": "name", "app_lvalue": "prometheus"}, "changed": false}

TASK [Replace the application label placeholder in deployment spec] ************
2019-04-22T12:07:40.414831 (delta: 0.182221)         elapsed: 16.780908 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "3 replacements made"}

TASK [Enable/Disable I/O based liveness probe] *********************************
2019-04-22T12:07:40.845470 (delta: 0.430558)         elapsed: 17.211547 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-04-22T12:07:40.918727 (delta: 0.073062)         elapsed: 17.284804 ******* 
included: /common/utils/create_ns.yml for 127.0.0.1

TASK [Obtain list of existing namespaces] **************************************
2019-04-22T12:07:41.037250 (delta: 0.118469)         elapsed: 17.403327 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ns --no-headers -o custom-columns=:metadata.name", "delta": "0:00:01.395349", "end": "2019-04-22 12:07:42.744805", "rc": 0, "start": "2019-04-22 12:07:41.349456", "stderr": "", "stderr_lines": [], "stdout": "default\nkube-public\nkube-service-catalog\nkube-system\nlitmus\nmanagement-infra\nopenebs\nopenshift\nopenshift-ansible-service-broker\nopenshift-infra\nopenshift-logging\nopenshift-node\nopenshift-sdn\nopenshift-template-service-broker\nopenshift-web-console\nrunner", "stdout_lines": ["default", "kube-public", "kube-service-catalog", "kube-system", "litmus", "management-infra", "openebs", "openshift", "openshift-ansible-service-broker", "openshift-infra", "openshift-logging", "openshift-node", "openshift-sdn", "openshift-template-service-broker", "openshift-web-console", "runner"]}

TASK [Create test specific namespace.] *****************************************
2019-04-22T12:07:42.843296 (delta: 1.805979)         elapsed: 19.209373 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl create ns app-prometheus", "delta": "0:00:01.386799", "end": "2019-04-22 12:07:44.620344", "rc": 0, "start": "2019-04-22 12:07:43.233545", "stderr": "", "stderr_lines": [], "stdout": "namespace/app-prometheus created", "stdout_lines": ["namespace/app-prometheus created"]}

TASK [include_tasks] ***********************************************************
2019-04-22T12:07:44.731324 (delta: 1.887921)         elapsed: 21.097401 ******* 
included: /common/utils/status_testns.yml for 127.0.0.1

TASK [Checking the status  of test specific namespace.] ************************
2019-04-22T12:07:44.876319 (delta: 0.144895)         elapsed: 21.242396 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ns app-prometheus -o custom-columns=:status.phase --no-headers", "delta": "0:00:01.307481", "end": "2019-04-22 12:07:46.418222", "rc": 0, "start": "2019-04-22 12:07:45.110741", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Replace the storage capaciy placeholder] *********************************
2019-04-22T12:07:46.537987 (delta: 1.661612)         elapsed: 22.904064 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Replace ClusterRoleBinding namespace placeholder] ************************
2019-04-22T12:07:46.909281 (delta: 0.371196)         elapsed: 23.275358 ******* 
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [include_tasks] ***********************************************************
2019-04-22T12:07:47.180859 (delta: 0.271523)         elapsed: 23.546936 ******* 
included: /common/utils/deploy_single_app.yml for 127.0.0.1

TASK [Deploying prometheus] ****************************************************
2019-04-22T12:07:47.347204 (delta: 0.166287)         elapsed: 23.713281 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f prometheus.yml -n app-prometheus", "delta": "0:00:01.660607", "end": "2019-04-22 12:07:49.311619", "rc": 0, "start": "2019-04-22 12:07:47.651012", "stderr": "", "stderr_lines": [], "stdout": "serviceaccount/app-prometheus-operator created\nclusterrole.rbac.authorization.k8s.io/app-prometheus-operator unchanged\nclusterrolebinding.rbac.authorization.k8s.io/app-prometheus-operator unchanged\nconfigmap/openebs-prometheus-tunables created\nconfigmap/openebs-prometheus-config created\ndeployment.extensions/openebs-prometheus created\nservice/openebs-prometheus-service created\npersistentvolumeclaim/prometheus-claim created", "stdout_lines": ["serviceaccount/app-prometheus-operator created", "clusterrole.rbac.authorization.k8s.io/app-prometheus-operator unchanged", "clusterrolebinding.rbac.authorization.k8s.io/app-prometheus-operator unchanged", "configmap/openebs-prometheus-tunables created", "configmap/openebs-prometheus-config created", "deployment.extensions/openebs-prometheus created", "service/openebs-prometheus-service created", "persistentvolumeclaim/prometheus-claim created"]}

TASK [include_tasks] ***********************************************************
2019-04-22T12:07:49.413089 (delta: 2.065796)         elapsed: 25.779166 ******* 
included: /common/utils/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
2019-04-22T12:07:49.608608 (delta: 0.195439)         elapsed: 25.974685 ******* 
FAILED - RETRYING: Get the container status of application. (150 retries left).
changed: [127.0.0.1] => {"attempts": 2, "changed": true, "cmd": "kubectl get pod -n app-prometheus -l name=\"prometheus\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:01.207412", "end": "2019-04-22 12:07:54.571143", "rc": 0, "start": "2019-04-22 12:07:53.363731", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2019-04-22T12:07:51Z]]", "stdout_lines": ["map[running:map[startedAt:2019-04-22T12:07:51Z]]"]}

TASK [Checking prometheus pod is in running state] *****************************
2019-04-22T12:07:54.656307 (delta: 5.047512)         elapsed: 31.022384 ******* 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-prometheus -o jsonpath='{.items[?(@.metadata.labels.name==\"prometheus\")].status.phase}'", "delta": "0:00:01.128564", "end": "2019-04-22 12:07:56.052504", "rc": 0, "start": "2019-04-22 12:07:54.923940", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [include_tasks] ***********************************************************
2019-04-22T12:07:56.186149 (delta: 1.52977)         elapsed: 32.552226 ******** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-04-22T12:07:56.335123 (delta: 0.14886)         elapsed: 32.7012 ********** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Deprovisioning the Application] ******************************************
2019-04-22T12:07:56.494406 (delta: 0.159175)         elapsed: 32.860483 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
2019-04-22T12:07:56.559418 (delta: 0.064953)         elapsed: 32.925495 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
2019-04-22T12:07:56.668464 (delta: 0.10899)         elapsed: 33.034541 ******** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-04-22T12:07:56.834321 (delta: 0.165728)         elapsed: 33.200398 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-04-22T12:07:56.894166 (delta: 0.059789)         elapsed: 33.260243 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-04-22T12:07:56.950911 (delta: 0.056691)         elapsed: 33.316988 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-04-22T12:07:57.057871 (delta: 0.106862)         elapsed: 33.423948 ******* 
changed: [127.0.0.1] => {"changed": true, "checksum": "ed42cf3bf2b6454e836fc742f64dd77c7bcf4861", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "915c620161e6dace4ecd5d2ec94d5e8d", "mode": "0644", "owner": "root", "size": 420, "src": "/root/.ansible/tmp/ansible-tmp-1555934877.18-176017569410534/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-04-22T12:07:59.633206 (delta: 2.575244)         elapsed: 35.999283 ******* 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.070333", "end": "2019-04-22 12:08:01.055076", "rc": 0, "start": "2019-04-22 12:07:59.984743", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: prometheus-deployment \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: prometheus-deployment ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-04-22T12:08:01.113822 (delta: 1.48052)         elapsed: 37.479899 ******** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.674728", "end": "2019-04-22 12:08:03.063991", "failed_when_result": false, "rc": 0, "start": "2019-04-22 12:08:01.389263", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/prometheus-deployment configured", "stdout_lines": ["litmusresult.litmus.io/prometheus-deployment configured"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=29   changed=18   unreachable=0    failed=0   

2019-04-22T12:08:03.150588 (delta: 2.036712)         elapsed: 39.516665 ******* 
=============================================================================== 




```
