### PR TITLE
Replaced runAsUser with fsGroup in spec and reduced the volume capacity from 25G to 8G

### DIFF
--- a/apps/elasticsearch/deployers/es-statefulset.yaml
+++ b/apps/elasticsearch/deployers/es-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
           privileged: true # sysctl command needs root permission to change kernel config
       containers:
       - image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.3.2
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: elasticsearch-logging
         securityContext:
           runAsUser: 1000   # elasticsearch container runs with elasticsearch user (1000:1000)

--- a/apps/elasticsearch/deployers/es-statefulset.yaml
+++ b/apps/elasticsearch/deployers/es-statefulset.yaml
@@ -35,7 +35,7 @@ spec:
         role: elasticsearch
     spec:
       securityContext:
-        fsGroup: 1000
+         fsGroup: 1000
       serviceAccountName: elasticsearch-logging
       # Elasticsearch requires vm.max_map_count to be at least 262144.
       # If your OS already sets up this number to a higher value, feel free

--- a/apps/elasticsearch/deployers/es-statefulset.yaml
+++ b/apps/elasticsearch/deployers/es-statefulset.yaml
@@ -35,7 +35,7 @@ spec:
         role: elasticsearch
     spec:
       securityContext:
-         runAsUser: 1000
+        fsGroup: 1000
       serviceAccountName: elasticsearch-logging
       # Elasticsearch requires vm.max_map_count to be at least 262144.
       # If your OS already sets up this number to a higher value, feel free

--- a/apps/elasticsearch/deployers/run_litmus_test.yml
+++ b/apps/elasticsearch/deployers/run_litmus_test.yml
@@ -17,7 +17,7 @@ spec:
       containers:
 
       - name: ansibletest
-        image: openebs/ansible-runner:ci
+        image: sushmash/ansible-runner:ci
         imagePullPolicy: Always
 
         env:

--- a/apps/elasticsearch/deployers/run_litmus_test.yml
+++ b/apps/elasticsearch/deployers/run_litmus_test.yml
@@ -17,7 +17,7 @@ spec:
       containers:
 
       - name: ansibletest
-        image: sushmash/ansible-runner:ci
+        image: openebs/ansible-runner:ci
         imagePullPolicy: Always
 
         env:

--- a/apps/elasticsearch/deployers/run_litmus_test.yml
+++ b/apps/elasticsearch/deployers/run_litmus_test.yml
@@ -17,7 +17,7 @@ spec:
       containers:
 
       - name: ansibletest
-        image: openebs/ansible-runner:ci
+        image: sushmash/ansible-runner:ci
         imagePullPolicy: Always
 
         env:
@@ -53,7 +53,7 @@ spec:
 
           # define a variable CAPACITY to accept the size given by user
           - name: CAPACITY
-            value: 25G
+            value: 8G
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./elasticsearch/deployers/test.yml -i /etc/ansible/hosts -v; exit 0"]


### PR DESCRIPTION
* In specification of es-statefulset.yml replaced runAsUser:1000 with fsGroup:1000 .
* Sometimes the pod may get restarted again and again and application pod thus goes to CrashLoopBackOff.
* Replacing solves the issue.
* More volume capacity may sometimes lead to some issues in openShift cluster , so reducing the capacity to 8G may not lead to such issues. 