### PR TITLE
[Refactor] Included deprovision task in memcheck-test

### DIFF
--- a/apps/custom/tests/memcheck/run_litmus_test.yml
+++ b/apps/custom/tests/memcheck/run_litmus_test.yml
@@ -32,26 +32,4 @@ spec:
 
         command: ["/bin/bash"]
         args: ["-c", "ansible-playbook ./custom/tests/memcheck/test.yml -i /etc/ansible/hosts -v; exit 0"]
-        volumeMounts:
-          - name: logs
-            mountPath: /var/log/ansible
-        tty: true
-      - name: logger
-        image: openebs/logger
-        command: ["/bin/bash"]
-        args: ["-c", "./logger.sh -d 10 -r maya,openebs,pvc,memleak; exit 0"]
-        volumeMounts:
-          - name: kubeconfig
-            mountPath: /root/admin.conf
-            subPath: admin.conf
-          - name: logs
-            mountPath: /mnt
-        tty: true
-      volumes:
-        - name: kubeconfig
-          configMap:
-            name: kubeconfig
-        - name: logs
-          hostPath:
-            path: /mnt/memleak
-            type: ""
+

--- a/apps/custom/tests/memcheck/test.yml
+++ b/apps/custom/tests/memcheck/test.yml
@@ -75,6 +75,18 @@
            flag: "Fail"
 
      always:
+
+       - name: Deprovisioning test related resources
+         shell: |
+           kubectl delete -f {{ memleak_yml }} -n {{ app_ns }}
+
+       - name: Checking whether the application pod is removed
+         shell: kubectl get pod -n {{ app_ns }} -l name=memleak | wc -l 
+         register: pod_status
+         until: "'0' in pod_status.stdout"
+         retries: 10
+         delay: 5         
+
             ## RECORD END-OF-TEST IN LITMUS RESULT CR
        - include_tasks: /common/utils/update_litmus_result_resource.yml
          vars:


### PR DESCRIPTION
**What this PR does / why we need it**:
- Included deprovisoning task in memcheck-jiva test. 

**following is the log of ansible-test container**:
```
TASK [set_fact] ****************************************************************
2019-04-24T10:26:55.380094 (delta: 206.308258)         elapsed: 295.409565 **** 
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [Deprovisioning test related resources] ***********************************
2019-04-24T10:26:55.515045 (delta: 0.134849)         elapsed: 295.544516 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete -f memleak.yml -n memleak", "delta": "0:00:33.782076", "end": "2019-04-24 10:27:29.633426", "rc": 0, "start": "2019-04-24 10:26:55.851350", "stderr": "", "stderr_lines": [], "stdout": "pod \"memleak-test\" deleted\npersistentvolumeclaim \"demo-vol1-claim\" deleted", "stdout_lines": ["pod \"memleak-test\" deleted", "persistentvolumeclaim \"demo-vol1-claim\" deleted"]}

TASK [Checking whether the application pod is removed] *************************
2019-04-24T10:27:29.702443 (delta: 34.187309)         elapsed: 329.731914 ***** 
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n memleak -l name=memleak | wc -l", "delta": "0:00:01.571893", "end": "2019-04-24 10:27:31.541066", "rc": 0, "start": "2019-04-24 10:27:29.969173", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "0", "stdout_lines": ["0"]}

TASK [include_tasks] ***********************************************************
2019-04-24T10:27:31.648187 (delta: 1.945662)         elapsed: 331.677658 ****** 
included: /common/utils/update_litmus_result_resource.yml for 127.0.0.1

TASK [Generate the litmus result CR to reflect SOT (Start of Test)] ************
2019-04-24T10:27:31.779320 (delta: 0.131028)         elapsed: 331.808791 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
2019-04-24T10:27:31.852019 (delta: 0.072613)         elapsed: 331.88149 ******* 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the litmus result CR] **********************************************
2019-04-24T10:27:31.915760 (delta: 0.063675)         elapsed: 331.945231 ****** 
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the litmus result CR to reflect EOT (End of Test)] **************
2019-04-24T10:27:31.987612 (delta: 0.071787)         elapsed: 332.017083 ****** 
changed: [127.0.0.1] => {"changed": true, "checksum": "4895c4d619d6c95588107fcd6486ddd7c776648b", "dest": "./litmus-result.yaml", "gid": 0, "group": "root", "md5sum": "6580cd853fcf54b161be7f7d32f18140", "mode": "0644", "owner": "root", "size": 411, "src": "/root/.ansible/tmp/ansible-tmp-1556101652.06-99745598934864/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
2019-04-24T10:27:35.178827 (delta: 3.191134)         elapsed: 335.208298 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "cat litmus-result.yaml", "delta": "0:00:01.274155", "end": "2019-04-24 10:27:36.674482", "rc": 0, "start": "2019-04-24 10:27:35.400327", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: litmus.io/v1alpha1\nkind: LitmusResult\nmetadata:\n\n  # name of the litmus testcase\n  name: memleak-test \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: litmus.io/v1alpha1", "kind: LitmusResult", "metadata:", "", "  # name of the litmus testcase", "  name: memleak-test ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the litmus result CR] **********************************************
2019-04-24T10:27:36.751903 (delta: 1.572995)         elapsed: 336.781374 ****** 
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f litmus-result.yaml", "delta": "0:00:01.948418", "end": "2019-04-24 10:27:38.919551", "failed_when_result": false, "rc": 0, "start": "2019-04-24 10:27:36.971133", "stderr": "", "stderr_lines": [], "stdout": "litmusresult.litmus.io/memleak-test configured", "stdout_lines": ["litmusresult.litmus.io/memleak-test configured"]}
```
