### PR TITLE
feat(yaml):Test clone creation with different capacity.

### DIFF
--- a/funclib/kubectl/k8s_snapshot_clone/create_clone.yml
+++ b/funclib/kubectl/k8s_snapshot_clone/create_clone.yml
@@ -19,22 +19,52 @@
 #        - snapshot_name - Name of snapshot
 #        - storage_class  - storageclass to create clone
 
-- name: Update the clone creation template with the values provided.
-  template:
-     src: /funclib/kubectl/k8s_snapshot_clone/snapshot-claim.j2
-     dest: snapshot-claim.yml
-
-- name: Creating PVC from the snapshot
-  shell: kubectl apply -f snapshot-claim.yml
+- name: Checking the volume capacity
+  shell: kubectl get pvc {{ pvc_name }}  -n {{ app_ns }} --no-headers -o custom-columns=:status.capacity.storage
   args:
     executable: /bin/bash
+  register: quota
 
-- name: Checking if the pvc is created successfully
-  shell: kubectl get pvc -n {{ app_ns }} | grep {{ clone_claim_name }}
-  args:
-    executable: /bin/bash
-  register: pvc_out
-  until: "'Bound' in pvc_out.stdout"
-  delay: 60
-  retries: 10
+- name: Set capacity value into a variable
+  set_fact:
+    size: "{{ quota.stdout }}"
+
+- block:
+
+    - name: Update the clone creation template with the values provided.
+      template:
+        src: /funclib/kubectl/k8s_snapshot_clone/snapshot-claim.j2
+        dest: snapshot-claim.yml
+
+    - name: Creating PVC from the snapshot
+      shell: kubectl apply -f snapshot-claim.yml
+      args:
+        executable: /bin/bash
+
+    - name: Checking if the pvc is created successfully
+      shell: kubectl get pvc -n {{ app_ns }} | grep {{ clone_claim_name }}
+      args:
+        executable: /bin/bash
+      register: pvc_out
+      until: "'Bound' in pvc_out.stdout"
+      delay: 60
+      retries: 10
+  when: "size == capacity"
+
+- block:
+
+    - name: Update the clone creation template with the values provided.
+      template:
+        src: /funclib/kubectl/k8s_snapshot_clone/snapshot-claim.j2
+        dest: snapshot-claim.yml
+
+    - name: Creating PVC from the snapshot
+      shell: kubectl apply -f snapshot-claim.yml
+      args:
+        executable: /bin/bash
+      register: clone_status
+      failed_when: clone_status.rc == 0
+  
+  when: "size != capacity"
+
 


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

**What this PR does / why we need it**:
- This util can create clone based on snapshot name, namespace and the capacity provided.
- If the capacity of cloned volume is not equal to the actual capacity of PVC, the clone creation fails.
- It succeeds only if the given cloned volume's capacity is equal to PVC's capacity.